### PR TITLE
fixed C_HUNGARUMLAUT

### DIFF
--- a/Include/char.def
+++ b/Include/char.def
@@ -339,7 +339,7 @@ C_BREVE			enum Chars, 0xf9
 C_DOTACCENT		enum Chars, 0xfa
 C_RING			enum Chars, 0xfb
 C_CEDILLA		enum Chars, 0xfc
-C_HUNGARUMLAT		enum Chars, 0xfd
+C_HUNGARUMLAUT		enum Chars, 0xfd
 C_OGONEK		enum Chars, 0xfe
 C_CARON			enum Chars, 0xff
 
@@ -351,6 +351,11 @@ C_SUM		= C_U_SIGMA
 C_PRODUCT	= C_U_PI
 C_RADICAL	= C_ROOT
 C_LOZENGE	= C_DIAMONDBULLET
+
+;
+; some former spelling errors:
+;
+C_HUNGARUMLAT	= C_HUNGARUMLAUT
 
 endif
 


### PR DESCRIPTION
Quote from https://en.wikipedia.org/wiki/Double_acute_accent :
The double acute accent ... is sometimes referred to by typographers as Hungarumlaut.