### PR TITLE
Preparations for making glue compatible with Watcom C

### DIFF
--- a/CInclude/geos.h
+++ b/CInclude/geos.h
@@ -218,7 +218,7 @@ typedef	byte ByteEnum;
 typedef	sword Boolean;
 typedef unsigned int wchar;
 
-#if defined _MSDOS && _MSC_VER
+#if (defined _MSDOS && _MSC_VER) || defined __WATCOMC__
 typedef void __based(void)* ChunkHandle;
 #else
 typedef word ChunkHandle;

--- a/Include/Win32/geos.mk
+++ b/Include/Win32/geos.mk
@@ -583,7 +583,7 @@ CCOM_MODEL	?= -ml
 # s -> no stack checking
 
 CCOMFLAGS       += -D__GEOS__ -D__WATCOM__ -Ot -d3 -w4 \
-		   	-os -ol -ol+ -hc -s \
+			-os -ol -ol+ -hc -s -ecc \
 		   	$(CCOM_MODEL) \
             $(.INCLUDES:N*/Include*:S/\//\\/g:S/^-I/-i=/g) \
 						-i="$(WATCOM)/h" \

--- a/Include/Win32/tool.mk
+++ b/Include/Win32/tool.mk
@@ -178,7 +178,7 @@ INSTALLALL	:= $(MACHINES:S/^/install/g)
 win32	: ${.TARGET:S%$%.md/$(NAME).exe%}    	    .JOIN
 ${MACHINES:S%$%.md/$(NAME).exe%g} : $(win32OBJS) $(win32LIBS) 
 	$(WLINK) $(CLINKFLAGS)  \
-			DEBUG WATCOM ALL \
+			DEBUG ALL \
 			$(.ALLSRC:M*.obj:S/^/file /g) \
 			$(.ALLSRC:M*.lib:S/^/lib /g) \
 			library kernel32 \


### PR DESCRIPTION
This set of changes does not yet include the actual glue changes to make a simple geode build successfuly, but it makes some preparations that I think are "reasonable" to improve compatibility and debuggability.  Only tested on win32 so far.