### PR TITLE
glue: do not perform fuzzy comparison of fixup symbols for wcc, and…

### DIFF
--- a/Tools/glue/msobj.c
+++ b/Tools/glue/msobj.c
@@ -1610,12 +1610,23 @@ MSObjMapExternal(const char	*file,	    /* Name of object file being read */
 		/*
 		 * Watcom C: we encounter this type of fixup in pass 1
 		 * when the symbol list still contains references to
-		 * names, not ObjSym records. So we nede to look up
+		 * names, not ObjSym records. So we need to look up
 		 * the fixup target ourselves.
 		 */
-
 		if (!Sym_Find(symbols, 0, fdataPtr->external, &symBlock, &symOff, TRUE)) {
-		    return FPED_FALSE;
+		    char* str = ST_Lock(symbols, fdataPtr->external);
+		    ID newName = ST_LookupNoLen(symbols, strings, str+1);
+		    ST_Unlock(symbols, fdataPtr->external);
+		    if (newName != NullID) {
+			if (!Sym_Find(symbols, 0, newName, &symBlock, &symOff, TRUE))
+			{
+				return FPED_FALSE;
+			}
+		    }
+		    else
+		    {
+			return FPED_FALSE;
+		    }
 		}
 	    }
 

--- a/Tools/glue/sym.c
+++ b/Tools/glue/sym.c
@@ -735,7 +735,7 @@ Sym_Enter(VMHandle  	file,    	/* Output file */
 	 * are iffy, but we allow them. When they start congregating
 	 * in the same segment, though, we get upset.
 	 */
-	//Notify(NOTIFY_ERROR, "%i multiply defined in a single segment", id);
+	Notify(NOTIFY_ERROR, "%i multiply defined in a single segment", id);
     }
     /*
      * table and block were left locked by SymLookup


### PR DESCRIPTION
…do not create name-mangled aliases to avoid clashes between ChunkHandle and chunk content in LMem heaps.

This makes columnec.geo compile and produces correct sizes for all LMem chunks. However, relocs of ChunkHandles inside the heap are still not fixed up correctly.