### PR TITLE
Fix glue to handle local procedures

### DIFF
--- a/Tools/glue/msobj.c
+++ b/Tools/glue/msobj.c
@@ -1571,26 +1571,24 @@ MSObjMapExternal(const char	*file,	    /* Name of object file being read */
 {
 	printf("MSObjMapExternal\n"); fflush(stderr);
     if (targMethod == TFM_EXTERNAL) {
-	if (fdataPtr->external & MO_EXT_UNDEFINED) {
-	    /*
-	     * The thing was undefined when it was encountered in its EXTDEF
-	     * record -- bitch now, so we can tell the user where s/he screwed
-	     * up...
-	     */
-	    if (pass == 2)
-	    {
-		FloatingPointExtDef f;
+		if (fdataPtr->external & MO_EXT_UNDEFINED) {
+			/*
+			* The thing was undefined when it was encountered in its EXTDEF
+			* record -- bitch now, so we can tell the user where s/he screwed
+			* up...
+			*/
+			if (pass == 2) {
+				FloatingPointExtDef f;
 
-		f = MSObj_IsFloatingPointExtDef(fdataPtr->external &
-					       	~MO_EXT_UNDEFINED);
+				f = MSObj_IsFloatingPointExtDef(fdataPtr->external &
+									~MO_EXT_UNDEFINED);
 
-		if (f == FPED_FALSE)
-		{
-		    Pass2_RelocError(sd, fixOff, "%i undefined2",
-				 fdataPtr->external & ~MO_EXT_UNDEFINED);
-		}
-		return f;
-	    }
+				if (f == FPED_FALSE) {
+					Pass2_RelocError(sd, fixOff, "%i undefined2",
+						fdataPtr->external & ~MO_EXT_UNDEFINED);
+				}
+			return f;
+			}
 	} else {
 	    ObjSymHeader    *osh;   	/* Header of block holding external */
 	    ObjSym  	    *os;    	/* External symbol */
@@ -1607,27 +1605,24 @@ MSObjMapExternal(const char	*file,	    /* Name of object file being read */
 	    mapBlock = VMGetMapBlock(symbols);
 
 	    if (pass == 1) {
-		/*
-		 * Watcom C: we encounter this type of fixup in pass 1
-		 * when the symbol list still contains references to
-		 * names, not ObjSym records. So we need to look up
-		 * the fixup target ourselves.
-		 */
-		if (!Sym_Find(symbols, 0, fdataPtr->external, &symBlock, &symOff, TRUE)) {
-		    char* str = ST_Lock(symbols, fdataPtr->external);
-		    ID newName = ST_LookupNoLen(symbols, strings, str+1);
-		    ST_Unlock(symbols, fdataPtr->external);
-		    if (newName != NullID) {
-			if (!Sym_Find(symbols, 0, newName, &symBlock, &symOff, TRUE))
-			{
+			/*
+			* Watcom C: we encounter this type of fixup in pass 1
+			* when the symbol list still contains references to
+			* names, not ObjSym records. So we need to look up
+			* the fixup target ourselves.
+			*/
+			if (!Sym_Find(symbols, 0, fdataPtr->external, &symBlock, &symOff, TRUE)) {
+				char* str = ST_Lock(symbols, fdataPtr->external);
+				ID newName = ST_LookupNoLen(symbols, strings, str+1);
+				ST_Unlock(symbols, fdataPtr->external);
+				if (newName != NullID) {
+					if (!Sym_Find(symbols, 0, newName, &symBlock, &symOff, TRUE)) {
+						return FPED_FALSE;
+					}
+				} else {
 				return FPED_FALSE;
+				}
 			}
-		    }
-		    else
-		    {
-			return FPED_FALSE;
-		    }
-		}
 	    }
 
 	    /*

--- a/Tools/glue/msobj.h
+++ b/Tools/glue/msobj.h
@@ -155,6 +155,17 @@
  *	    - type index (0 => symbol is untyped)
  *	- checksum (byte)
  */
+
+/**
+ * Reference: http://www.fileformat.info/format/ms-obj/corion.htm
+ *
+ * Watcom uses LPUBDEF1 for NEAR modules instead of PUBDEF. The specification
+ * defines b6 and b7 as both LPUBDEF but doesn't state the difference so we'll
+ * just treat them both as real symbols for now - mcasadevall
+ */
+
+#define MO_LPUBDEF1 0xb6
+#define MO_LPUBDEF2 0xb7
 #define MO_PUBDEF   0x90
 
 /*


### PR DESCRIPTION
This was a fairly lengthy debugging process, but I fixed the glue linker and cleared up the formatting to make it much clearer on what's going on; the short version is that Watcom uses a different OBJ header to denote publicly reachable local symbols (_near) calls.

These symbols are real, and are "public" in terms of the module. I don't know the GEO file format well enough to know if this is going to be a problem as they may be exposed in ansic.geo despite being near symbols but this would have been an issue with the Borland compiler as well.