### PR TITLE
Fixing typo causing 'wmake install' to fail for initial pmake build

### DIFF
--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -1974,7 +1974,7 @@ int getcOptrURL(dword data)  /* callback routine to get one char */
 
     MemUnlock( OptrToHandle(((OPTRFILE *)data)->text) );
 
-    return c?c:EOF;
+    return (c!=0)?c:EOF;
 }
 
 int LOCAL getcFileURL(dword data)  /* callback routine to get one char */

--- a/Tools/pmake/pmake/parse.c
+++ b/Tools/pmake/pmake/parse.c
@@ -1382,7 +1382,7 @@ Parse_DoVar (char* line0, GNode *ctxt)
 	free(cp);
     } else if (type == VAR_SHELL) {
 
-#if definded(unix) || defined(_LINUX)
+#if defined(unix) || defined(_LINUX)
 	char	result[BUFSIZ];	/* Result of command */
 	char	*args[4];   	/* Args for invoking the shell */
 	Boolean	freeCmd;    	/* TRUE if the command needs to be freed, i.e.


### PR DESCRIPTION
When trying to set up the repo on a new machine and building according to the instructions, I bumped into this error for the initial "wmake install" step to create pmake.exe.

I used the latest Watcom nightly, and ran the build under Windows 10 64-bit.