### PR TITLE
User.conf added to bin/target.cmd and related updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ dependencies.mk
 Makefile
 !Installed/**/dependencies.mk
 !Installed/**/Makefile
+bin/user.conf

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ dependencies.mk
 Makefile
 !Installed/**/dependencies.mk
 !Installed/**/Makefile
-bin/user.conf

--- a/README.md
+++ b/README.md
@@ -66,4 +66,14 @@ Launch the target environment in dosbox:
   - enter `quit` at the "=>" prompt to detach the debugger and launch PC/GEOS stand-alone
     - or: enter `c` to launch with the debugger running in the background (slower)
 
+
+## Customize target environment
+If you want to customize the target environment settings only for yourself, you should not change the file %LOCAL_ROOT%/bin/basbox.conf.
+- Create a file called user.conf in %ROOT_DIR%/bin.
+- Enter the new settings here. These settings overwrite those from basebox.conf. Example:
+  - [cpu]
+  - cycles=55000
+- GIT ignores this file (see .gitignore)
+
+##
 We are on https://bluewaysw.slack.com/ for more efficient collaboration. Please register at https://blog.bluewaysw.de for MyGEOS and use the Slack section and receive access to our developer community. Welcome!

--- a/README.md
+++ b/README.md
@@ -68,12 +68,11 @@ Launch the target environment in dosbox:
 
 
 ## Customize target environment
-If you want to customize the target environment settings only for yourself, you should not change the file %LOCAL_ROOT%/bin/basbox.conf.
-- Create a file called user.conf in %ROOT_DIR%/bin.
+If you want to customize the target environment settings only for yourself, you should not change the file %ROOT_DIR%/bin/basbox.conf.
+- Create a file called basebox_user.conf in %LOCAL_ROOT% folder.
 - Enter the new settings here. These settings overwrite those from basebox.conf. Example:
   - [cpu]
   - cycles=55000
-- GIT ignores this file (see .gitignore)
 
 ##
 We are on https://bluewaysw.slack.com/ for more efficient collaboration. Please register at https://blog.bluewaysw.de for MyGEOS and use the Slack section and receive access to our developer community. Welcome!

--- a/bin/basebox.conf
+++ b/bin/basebox.conf
@@ -127,7 +127,7 @@ midiconfig=
 # oplrate: Sample rate of OPL music emulation. Use 49716 for highest quality (set the mixer rate accordingly).
 #          Possible values: 44100, 49716, 48000, 32000, 22050, 16000, 11025, 8000.
 
-sbtype=sb1
+sbtype=sb16
 sbbase=220
 irq=7
 dma=1

--- a/bin/target.cmd
+++ b/bin/target.cmd
@@ -8,7 +8,7 @@ IF NOT DEFINED BASEBOX (SET BASEBOX=dosbox)
 set OLD_PATH=%cd%
 cd /D %LOCAL_ROOT%\gbuild\localpc 
 del /F %LOCAL_ROOT%\gbuild\localpc\IPX_STAT.txt
-start /B %BASEBOX% -conf %ROOT_DIR%\bin\basebox.conf -conf %ROOT_DIR%\bin\user.conf -noconsole
+start /B %BASEBOX% -conf %ROOT_DIR%\bin\basebox.conf -conf %LOCAL_ROOT%\basebox_user.conf -noconsole
 cd %OLD_PATH%
 @cls
 :waitForFile

--- a/bin/target.cmd
+++ b/bin/target.cmd
@@ -8,7 +8,7 @@ IF NOT DEFINED BASEBOX (SET BASEBOX=dosbox)
 set OLD_PATH=%cd%
 cd /D %LOCAL_ROOT%\gbuild\localpc 
 del /F %LOCAL_ROOT%\gbuild\localpc\IPX_STAT.txt
-start /B %BASEBOX% -conf %ROOT_DIR%\bin\basebox.conf -noconsole
+start /B %BASEBOX% -conf %ROOT_DIR%\bin\basebox.conf -conf %ROOT_DIR%\bin\user.conf -noconsole
 cd %OLD_PATH%
 @cls
 :waitForFile


### PR DESCRIPTION
The basic settings of the target environment in the basebox.conf are not optimal for more powerful systems. Especially the values for cycles and frameskip can often be adjusted. 
The idea is that the user (programmer) can adjust the BaseBox settings without changing the basebox.conf file. To do this, a second conf file (user.conf) is used, which is not included in the repository (see .gitignore). Settings in this file overwrite the corresponding settings in basebox.conf. There is no problem if the user.conf file does not exist.