### PR TITLE
Making techdocs more accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,23 @@ If you want to customize the target environment settings only for yourself, you 
   - [cpu]
   - cycles=55000
 
+
+# How to develop?
+
+PC/GEOS comes with extensive technical documentation that describes tools, programming languages and API calls from the perspective of an SDK user. This documentation can be found in the `TechDocs` folder and is available in Markdown format. Here are some entry points to the main volumes:
+
+- Introduction
+  - [Tutorial](TechDocs/Markdown/tutorial.md) - the initial chapters describing the development environment are somewhat outdated, and still refer to the original two-machine setup for debugbing, but this nevertheless gives a good idea of overall development process.
+  - [Concepts](TechDocs/Markdown/concepts.md)
+  - [Tools](TechDocs/Markdown/tools.md)
+- C development
+  - [GOC keywords and API calls](TechDocs/Markdown/routines.md)
+  - [Objects Reference](TechDocs/Markdown/objects.md)
+  - [Quick Reference](TechDocs/Markdown/quickref.md)
+- Assembly development
+  - [ESP Assembly Language](TechDocs/Markdown/esp.md)
+  - [Assembly Reference](TechDocs/Markdown/asmref.md)
+  - [Driver Development Kit](TechDocs/Markdown/ddk.md)
+
 ##
 We are on https://bluewaysw.slack.com/ for more efficient collaboration. Please register at https://blog.bluewaysw.de for MyGEOS and use the Slack section and receive access to our developer community. Welcome!

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you want to customize the target environment settings only for yourself, you 
 PC/GEOS comes with extensive technical documentation that describes tools, programming languages and API calls from the perspective of an SDK user. This documentation can be found in the `TechDocs` folder and is available in Markdown format. Here are some entry points to the main volumes:
 
 - Introduction
-  - [Tutorial](TechDocs/Markdown/tutorial.md) - the initial chapters describing the development environment are somewhat outdated, and still refer to the original two-machine setup for debugbing, but this nevertheless gives a good idea of overall development process.
+  - [Tutorial](TechDocs/Markdown/tutorial.md) - the initial chapters describing the development environment are somewhat outdated, and still refer to the original two-machine setup for debugging, but this nevertheless gives a good idea of overall development process.
   - [Concepts](TechDocs/Markdown/concepts.md)
   - [Tools](TechDocs/Markdown/tools.md)
 - C development


### PR DESCRIPTION
I have added some entry points to the techdocs from the top-level Readme, so they become more visible, and perhaps also available for web crawling, so searches for technical GEOS terms can turn up more results.