### PR TITLE
Fix #188 (updating rev file), grev tool and realated docs updated.

### DIFF
--- a/CInclude/geos.mk
+++ b/CInclude/geos.mk
@@ -85,8 +85,7 @@
 #       Name    Date            Description
 #       ----    ----            -----------
 #       ardeb   7/23/89         Initial Revision
-#	RainerB	1/22/2023	Add -s flag to grev
-#		3/5/2023	made rev file in LOCAL_ROOT working
+#	RainerB	3/20/2023	Add -s flag to grev when pmake is called in LOCAL_ROOT
 #
 # DESCRIPTION:
 #       This is a makefile to be included by all makefiles in the PC/GEOS
@@ -207,11 +206,14 @@ _GEODE  :=      $(GEODE)
 GREV            ?= grev
 GREVCMD         := $(GREV) 
 
-_REL    !=      $(GREVCMD) neweng $(REVFILE) -R -s
+# Don't pass the -s flag so that the rev files are not changed with every build.
+# This means that the automatic versioning in the ROOT_DIR is disabled.
+
+_REL    !=      $(GREVCMD) neweng $(REVFILE) -R
 # if    defined(NPM) || exists(NPM)
-_PROTO  !=      $(GREVCMD) newprotomajor $(REVFILE) -P -s 
+_PROTO  !=      $(GREVCMD) newprotomajor $(REVFILE) -P
 # elif  defined(npm) || exists(npm)
-_PROTO  !=      $(GREVCMD) newprotominor $(REVFILE) -P -s
+_PROTO  !=      $(GREVCMD) newprotominor $(REVFILE) -P
 # else
 _PROTO  !=      $(GREVCMD) getproto $(REVFILE) -P
 # endif
@@ -224,6 +226,7 @@ GREV		?= grev
 GREVFLAGS	=
 #
 # Don't use a branch option on a local .rev file
+# Pass the -s flag to automatically save the new revision number in the rev file
 
 _REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s
 _PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P

--- a/CInclude/geos.mk
+++ b/CInclude/geos.mk
@@ -205,11 +205,11 @@ _GEODE  :=      $(GEODE)
 GREV            ?= grev
 GREVCMD         := $(GREV) 
 
-_REL    !=      $(GREVCMD) neweng $(REVFILE) -R
+_REL    !=      $(GREVCMD) neweng $(REVFILE) -R -s
 # if    defined(NPM) || exists(NPM)
-_PROTO  !=      $(GREVCMD) newprotomajor $(REVFILE) -P
+_PROTO  !=      $(GREVCMD) newprotomajor $(REVFILE) -P -s 
 # elif  defined(npm) || exists(npm)
-_PROTO  !=      $(GREVCMD) newprotominor $(REVFILE) -P
+_PROTO  !=      $(GREVCMD) newprotominor $(REVFILE) -P -s
 # else
 _PROTO  !=      $(GREVCMD) getproto $(REVFILE) -P
 # endif

--- a/CInclude/geos.mk
+++ b/CInclude/geos.mk
@@ -85,6 +85,8 @@
 #       Name    Date            Description
 #       ----    ----            -----------
 #       ardeb   7/23/89         Initial Revision
+#	RainerB	1/22/2023	Add -s flag to grev
+#		3/5/2023	made rev file in LOCAL_ROOT working
 #
 # DESCRIPTION:
 #       This is a makefile to be included by all makefiles in the PC/GEOS
@@ -213,6 +215,18 @@ _PROTO  !=      $(GREVCMD) newprotominor $(REVFILE) -P -s
 # else
 _PROTO  !=      $(GREVCMD) getproto $(REVFILE) -P
 # endif
+
+#elif defined(GEODE) && exists($(CURRENT_DIR)/$(GEODE).rev)
+## the .rev file is local, use it.
+REVFILE		= $(CURRENT_DIR)/$(GEODE).rev
+_GEODE 		:= $(GEODE)
+GREV		?= grev
+GREVFLAGS	=
+#
+# Don't use a branch option on a local .rev file
+
+_REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s
+_PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P
 
 #else
 

--- a/Include/Win32/geos.mk
+++ b/Include/Win32/geos.mk
@@ -93,6 +93,8 @@
 #	Name	Date		Description
 #	----	----		-----------
 #	ardeb	7/23/89		Initial Revision
+#	RainerB	1/22/2023	Add -s flag to grev
+#		3/5/2023	made rev file in LOCAL_ROOT working
 #
 # DESCRIPTION:
 #	This is a makefile to be included by all makefiles in the PC/GEOS
@@ -340,7 +342,6 @@ INSTALL_DIR	:= $(INSTALL_DIR:H)
 #	Obtain revision control information. Results are left in
 #	$(_REL) and $(_PROTO).
 #
-# XXX: disabled until grev.c has branch stuff added to it...
 #if	defined(GEODE) && exists($(INSTALL_DIR)/$(GEODE).rev)
 REVFILE		= $(INSTALL_DIR)/$(GEODE).rev
 
@@ -359,6 +360,18 @@ GREVFLAGS	+= -B $(BRANCH)
 #endif
 
 _REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s 
+_PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P
+
+#elif defined(GEODE) && exists($(CURRENT_DIR)/$(GEODE).rev)
+## the .rev file is local, use it.
+REVFILE		= $(CURRENT_DIR)/$(GEODE).rev
+_GEODE 		:= $(GEODE)
+GREV		?= grev
+GREVFLAGS	=
+#
+# Don't use a branch option on a local .rev file
+
+_REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s
 _PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P
 
 #else

--- a/Include/Win32/geos.mk
+++ b/Include/Win32/geos.mk
@@ -358,7 +358,7 @@ GREVFLAGS	=
 GREVFLAGS	+= -B $(BRANCH)
 #endif
 
-_REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R
+_REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s 
 _PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P
 
 #else

--- a/Include/Win32/geos.mk
+++ b/Include/Win32/geos.mk
@@ -93,8 +93,8 @@
 #	Name	Date		Description
 #	----	----		-----------
 #	ardeb	7/23/89		Initial Revision
-#	RainerB	1/22/2023	Add -s flag to grev
-#		3/5/2023	made rev file in LOCAL_ROOT working
+#	RainerB	3/20/2023	Add -s flag to grev when pmake is called in LOCAL_ROOT
+#				Add -z flag to glue also for EC version
 #
 # DESCRIPTION:
 #	This is a makefile to be included by all makefiles in the PC/GEOS
@@ -359,7 +359,10 @@ GREVFLAGS	=
 GREVFLAGS	+= -B $(BRANCH)
 #endif
 
-_REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s 
+# Don't pass the -s flag so that the rev files are not changed with every build.
+# This means that the automatic versioning in the ROOT_DIR is disabled.
+
+_REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R
 _PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P
 
 #elif defined(GEODE) && exists($(CURRENT_DIR)/$(GEODE).rev)
@@ -370,6 +373,7 @@ GREV		?= grev
 GREVFLAGS	=
 #
 # Don't use a branch option on a local .rev file
+# Pass the -s flag to automatically save the new revision number in the rev file
 
 _REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s
 _PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P

--- a/Include/Win32/geos.mk
+++ b/Include/Win32/geos.mk
@@ -788,7 +788,7 @@ LINK		: .USE
 	del /F $(.TARGET:S|/|\\|g)
 #endif
 	$(LINK) \
-	  $(.TARGET:M*ec.geo:S/$(.TARGET)/-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -E/)\
+	  $(.TARGET:M*ec.geo:S/$(.TARGET)/-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -E -z/)\
 	  $(.TARGET:M*.geo:N*ec.geo:S/$(.TARGET)/-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -z/)\
 	  -F./$(PRODUCT) \
 	  $(.TARGET:M*.vm:S/$(.TARGET)/-Ov -P $(_PROTO) -R $(_REL)/)\
@@ -806,7 +806,7 @@ LINK		: .USE
 	del /F $(.TARGET:S|/|\\|g)
 #endif
 	$(LINK) \
-	  $(.TARGET:M*EC.geo:S/$(.TARGET)/-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -E/)\
+	  $(.TARGET:M*EC.geo:S/$(.TARGET)/-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -E -z/)\
 	  $(.TARGET:M*.geo:N*EC.geo:S/$(.TARGET)/-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -z/)\
 	  $(.TARGET:M*.vm:S/$(.TARGET)/-Ov -P $(_PROTO) -R $(_REL)/)\
 	  $(.TARGET:M*.com:S/$(.TARGET)/-Oc/)\

--- a/Include/sun.geos.mk
+++ b/Include/sun.geos.mk
@@ -659,9 +659,9 @@ GPFILE		= $(GEODE).gp
 SETLIBFLAG	?= lf=""
 LINK		: .USE .NOEXPORT
 	case "$(.TARGET)" in
-	    *ec.geo)	of="-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -E" ;;
+	    *ec.geo)	of="-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -E -z" ;;
 #if !empty(BRANCH:MRelease1*)
-	    *.geo)  	of="-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL)" ;;
+	    *.geo)  	of="-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -z" ;;
 #else
 	    *.geo)  	of="-Og $(.ALLSRC:M*.gp) -P $(_PROTO) -R $(_REL) -z" ;;
 #endif

--- a/Include/sun.geos.mk
+++ b/Include/sun.geos.mk
@@ -91,6 +91,8 @@
 #	Name	Date		Description
 #	----	----		-----------
 #	ardeb	7/23/89		Initial Revision
+#	RainerB	1/22/2023	Add -s flag to grev
+#		3/5/2023	made rev file in LOCAL_ROOT working
 #
 # DESCRIPTION:
 #	This is a makefile to be included by all makefiles in the PC/GEOS
@@ -332,6 +334,18 @@ _PROTO	!=	$(GREVCMD) newprotominor $(GEODE).rev -s
 #else
 _PROTO	!=	$(GREVCMD) getproto $(GEODE).rev
 #endif
+
+#elif defined(GEODE) && exists($(CURRENT_DIR)/$(GEODE).rev)
+## the .rev file is local, use it.
+REVFILE		= $(CURRENT_DIR)/$(GEODE).rev
+_GEODE 		:= $(GEODE)
+GREV		?= grev
+GREVFLAGS	=
+#
+# Don't use a branch option on a local .rev file
+
+_REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s
+_PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P
 
 #else
 

--- a/Include/sun.geos.mk
+++ b/Include/sun.geos.mk
@@ -91,8 +91,8 @@
 #	Name	Date		Description
 #	----	----		-----------
 #	ardeb	7/23/89		Initial Revision
-#	RainerB	1/22/2023	Add -s flag to grev
-#		3/5/2023	made rev file in LOCAL_ROOT working
+#	RainerB	3/20/2023	Add -s flag to grev when pmake is called in LOCAL_ROOT
+#				Add -z flag to glue also for EC version
 #
 # DESCRIPTION:
 #	This is a makefile to be included by all makefiles in the PC/GEOS
@@ -326,11 +326,14 @@ GREV		?= grev
 GREVCMD		= RFILE=$(INSTALL_DIR)/$(_GEODE).rev \
                   $(GREV) -B$(BRANCH) $(GREVTREE)
 
-_REL	!=	$(GREVCMD) neweng $(GEODE).rev -s
+# Don't pass the -s flag so that the rev files are not changed with every build.
+# This means that the automatic versioning in the ROOT_DIR is disabled.
+
+_REL	!=	$(GREVCMD) neweng $(GEODE).rev
 #if	defined(NPM) || exists(NPM)
-_PROTO	!=	$(GREVCMD) newprotomajor $(GEODE).rev -s
+_PROTO	!=	$(GREVCMD) newprotomajor $(GEODE).rev
 #elif	defined(npm) || exists(npm)
-_PROTO	!=	$(GREVCMD) newprotominor $(GEODE).rev -s
+_PROTO	!=	$(GREVCMD) newprotominor $(GEODE).rev
 #else
 _PROTO	!=	$(GREVCMD) getproto $(GEODE).rev
 #endif
@@ -343,6 +346,7 @@ GREV		?= grev
 GREVFLAGS	=
 #
 # Don't use a branch option on a local .rev file
+# Pass the -s flag to automatically save the new revision number in the rev file
 
 _REL	!=	$(GREV) neweng $(REVFILE) $(GREVFLAGS) -R -s
 _PROTO	!=	$(GREV) getproto $(REVFILE) $(GREVFLAGS) -P

--- a/Include/sun.geos.mk
+++ b/Include/sun.geos.mk
@@ -324,11 +324,11 @@ GREV		?= grev
 GREVCMD		= RFILE=$(INSTALL_DIR)/$(_GEODE).rev \
                   $(GREV) -B$(BRANCH) $(GREVTREE)
 
-_REL	!=	$(GREVCMD) neweng $(GEODE).rev
+_REL	!=	$(GREVCMD) neweng $(GEODE).rev -s
 #if	defined(NPM) || exists(NPM)
-_PROTO	!=	$(GREVCMD) newprotomajor $(GEODE).rev
+_PROTO	!=	$(GREVCMD) newprotomajor $(GEODE).rev -s
 #elif	defined(npm) || exists(npm)
-_PROTO	!=	$(GREVCMD) newprotominor $(GEODE).rev
+_PROTO	!=	$(GREVCMD) newprotominor $(GEODE).rev -s
 #else
 _PROTO	!=	$(GREVCMD) getproto $(GEODE).rev
 #endif

--- a/TechDocs/Markdown/Tools/ttools.md
+++ b/TechDocs/Markdown/Tools/ttools.md
@@ -605,47 +605,63 @@ user name, the date, and an optional comment.
 
 The grev utility takes the following arguments:
 
-**new** ***file*** **["*****comment*****"|-P|-R]** - Create a new revision record, listing comment as an initial revision for 
+**grev command** ***file*** **[-P|-R|-s] [-B branch]** **[rev] ["comment"]**
+
+- ***file*** is the name of the revision file (ending in .REV)
+- **rev** is only used for the newrev command, see below.
+- The **-P** option causes grev to give minimal output, printing only the protocol number. 
+- The **-R** option causes grev to print only the revision number. 
+- The **-s** option **MUST** be given to save changes to file. If this flag is not 
+       passed, the change will only be displayed to the screen.
+- The **-B** option causes grev to use branch rather than the trunk.
+- These options are referred to as ***[flags]*** in the list below.
+
+Possible commands are:
+
+**new** ***file*** ***[flags]*** **["comment"]**   
+Create a new revision record, listing comment as an initial revision for 
 the base (0.0.0.0 release, 0.0 protocol). This command may only be 
-executed in the geode's development directory. The -P option causes grev 
-to give minimal output, printing only the protocol number. The -R option 
-causes grev to print only the revision number. These last two options are 
-normally used by **pmake** to extract the relevant numbers.
+executed in the geode's development directory. [flags] can be given, but 
+will have no effect.
 
-**info** ***file*** - Print the current release and protocol from the revision file.
+**info** ***file*** ***[flags]***   
+Print the current release and protocol from the revision file.
 
-**getproto** ***file*** - Print only the current protocol from the revision file.
+**getproto** ***file*** ***[flags]***   
+Print only the current protocol from the revision file.
+The **-P** option works as stated above.
 
-newprotomajor file ["comment"|-P|-R]
-
-**NPM** ***file*** **["*****comment*****"|-P|-R]** - Increase the major protocol number by one, setting the minor number to 
+**newprotomajor** ***file*** ***[flags]*** **["comment"]**   
+**NPM** ***file*** ***[flags]*** **["comment"]**   
+Increase the major protocol number by one, setting the minor number to 
 zero. The comment argument is listed as the reason for the change in the 
-file. The -P and -R options work as they do for **grev new**.
+file. You must give the **-s** option to save changes to file. The **-P** option 
+works as stated above.
 
-newprotominor file ["comment"|-P|-R]
+**newprotominor** ***file*** ***[flags]*** **["comment"]**   
+**npm** ***file*** ***[flags]*** **["comment"]**   
+Increase the minor protocol number by one. The comment string is listed 
+as the reason for the change in the file. You must give the **-s** option to 
+save changes to file. The **-P** option works as stated above.
 
-**npm** ***file*** **["*****comment*****"|-P|-R]** - Increase the minor protocol number by one. The comment string is listed 
-as the reason for the change in the file. The -P and -R options work as 
-they do for **grev new**.
+**newrev** ***file*** ***[flags]*** **A.B.C ["comment"]**   
+Update release number to A.B.C.0 The comment is listed as the reason for 
+the change. You must give the **-s** option to save changes to file.
 
-**newrev** ***file number1.number2*** **["*****comment*****"|-P|-R]** - 
-Increase release number from A.B.C.D to number1.number2.0.0. The 
-comment is listed as the reason for the change. The -P and -R options 
-work as they do for grev new.
+**newchange** ***file*** ***[flags]*** **["comment"]**   
+Up release number from A.B.**C.D** to A.B.**C+1.0**. The comment is listed as 
+the reason for the change. You must give the **-s** option to save changes 
+to file. The **-R** option works as stated above.
 
-newchange file ["comment"|-P|-R]
+**neweng** ***file*** ***[flags]*** **["comment"]**   
+**ne** ***file*** ***[flags]*** **["comment"]**   
+Increase release number from A.B.C.**D** to A.B.C.**D+1**. The comment is 
+listed as the reason for the change. You must give the **-s** option to save
+changes to file. The **-R** option works as stated above.
 
-**nc** ***file*** **["*****comment*****"|-P|-R]** - 
-Up release number from A.B.C.D to A.B.C+1.0. The comment is listed as 
-the reason for the change. The -P and -R options work as they do for grev 
-new.
-
-neweng file ["comment"|-P|-R]
-
-**ne** ***file*** **["*****comment*****"|-P|-R]** - Increase release number from A.B.C.D to A.B.C.D+1. The comment is 
-listed as the reason for the change. The -P and -R options work as they 
-do for grev new.
-
+**help**   
+Print out a detailed help.
+ 
 ### 10.8 mkmf
 
 The mkmf tool exists to create a file named MAKEFILE. The **pmake** program 

--- a/TechDocs/ascii/Tools/ttools.txt
+++ b/TechDocs/ascii/Tools/ttools.txt
@@ -606,51 +606,64 @@ user name, the date, and an optional comment.
 
 The grev utility takes the following arguments:
 
-new file ["comment"|-P|-R]
-Create a new revision record, listing comment as an initial revision for 
-the base (0.0.0.0 release, 0.0 protocol). This command may only be 
-executed in the geode's development directory. The -P option causes grev 
-to give minimal output, printing only the protocol number. The -R option 
-causes grev to print only the revision number. These last two options are 
-normally used by pmake to extract the relevant numbers.
+grev command file [-P|-R|-s] [-B branch] [<rev>] ["comment"]
 
-info file	Print the current release and protocol from the revision file.
+file is the name of the revision file (ending in .REV)
+<rev> is only used for the newrev command, see below.
 
-getproto file
-Print only the current protocol from the revision file.
+The -P option causes grev to give minimal output, printing only the protocol 
+       number. 
+The -R option causes grev to print only the revision number. 
+The -s option MUST be given to save changes to file.  If this flag is not 
+       passed, the change will only be displayed to the screen.
+The -B option causes grev to use branch rather than the trunk.
+These options are referred to as [flags] in the list below.
 
-newprotomajor file ["comment"|-P|-R]
+Possible commands are:
 
-NPM file ["comment"|-P|-R]
-Increase the major protocol number by one, setting the minor number to 
-zero. The comment argument is listed as the reason for the change in the 
-file. The -P and -R options work as they do for grev new.
+new file [flags] ["comment"]
+   Create a new revision record, listing comment as an initial revision for 
+   the base (0.0.0.0 release, 0.0 protocol). This command may only be 
+   executed in the geode's development directory. [flags] can be given, but 
+   will have no effect.
 
-newprotominor file ["comment"|-P|-R]
+info file [flags]	
+   Print the current release and protocol from the revision file.
 
-npm file ["comment"|-P|-R]
-Increase the minor protocol number by one. The comment string is listed 
-as the reason for the change in the file. The -P and -R options work as 
-they do for grev new.
+getproto file [flags]
+   Print only the current protocol from the revision file.
+   The -P option works as stated above.
 
-newrev file number1.number2 ["comment"|-P|-R]
-Increase release number from A.B.C.D to number1.number2.0.0. The 
-comment is listed as the reason for the change. The -P and -R options 
-work as they do for grev new.
+newprotomajor file [flags] ["comment"]
+NPM file [flags] ["comment"]
+   Increase the major protocol number by one, setting the minor number to 
+   zero. The comment argument is listed as the reason for the change in the 
+   file. You must give the -s option to save changes to file. The -P option 
+   works as stated above.
 
-newchange file ["comment"|-P|-R]
+newprotominor  file [flags] ["comment"]
+npm file [flags] ["comment"]
+   Increase the minor protocol number by one. The comment string is listed 
+   as the reason for the change in the file. You must give the -s option to 
+   save changes to file. The -P option works as stated above.
 
-nc file ["comment"|-P|-R]
-Up release number from A.B.C.D to A.B.C+1.0. The comment is listed as 
-the reason for the change. The -P and -R options work as they do for grev 
-new.
+newrev file [flags] A.B.C ["comment"]
+   Update release number to A.B.C.0 The comment is listed as the reason for 
+   the change. You must give the -s option to save changes to file.
 
-neweng file ["comment"|-P|-R]
+newchange file [flags] ["comment"]
+   Up release number from A.B.C.D to A.B.C+1.0. The comment is listed as 
+   the reason for the change. You must give the -s option to save changes 
+   to file. The -R option works as stated above.
 
-ne file ["comment"|-P|-R]
-Increase release number from A.B.C.D to A.B.C.D+1. The comment is 
-listed as the reason for the change. The -P and -R options work as they 
-do for grev new.
+neweng file [flags] ["comment"]
+ne file [flags] ["comment"]
+   Increase release number from A.B.C.D to A.B.C.D+1. The comment is 
+   listed as the reason for the change. You must give the -s option to save
+   changes to file. The -R option works as stated above.
+   
+help
+   Print out a detailed help.
 
 	10.8	mkmf
 

--- a/TechDocs/html/Tools/Tools/TTools_7.htm
+++ b/TechDocs/html/Tools/Tools/TTools_7.htm
@@ -14,16 +14,16 @@
 
 
 <H1 CLASS="sectionTitle">
-<A HREF="index.htm">Using Tools</A>: 7 
+<A HREF="index.htm">Using Tools</A>: 7
 <A NAME="73219">
  </A>
 Grev</H1>
 <!-- This blob is a bunch of standard links: up, back, index, etc. -->
 <!-- up to top -->|&nbsp;<A HREF="../../index.htm"><IMG SRC="../../docImages/upTop.gif" ALT="Up: " BORDER="0">GEOS SDK TechDocs</A>
 <!-- up to parent -->| <A HREF="index.htm"><IMG SRC="../../docImages/up.gif" ALT="Up" BORDER="0"></A>
-<!-- down to first child --> 
-<!-- to previous --> | <A HREF="TTools_6.htm"><IMG SRC="../../docImages/prev.gif" BORDER="0" ALT="Prev: ">6 Goc</A> 
-<!-- to next --> | <A HREF="TTools_8.htm"><IMG SRC="../../docImages/next.gif" BORDER="0" ALT="Next: ">8 mkmf</A> 
+<!-- down to first child -->
+<!-- to previous --> | <A HREF="TTools_6.htm"><IMG SRC="../../docImages/prev.gif" BORDER="0" ALT="Prev: ">6 Goc</A>
+<!-- to next --> | <A HREF="TTools_8.htm"><IMG SRC="../../docImages/next.gif" BORDER="0" ALT="Next: ">8 mkmf</A>
 <HR>
 <!-- That blob was a bunch of standard links: up, back, index, etc. -->
 <P>
@@ -73,176 +73,96 @@ one line for each protocol change, denoting the protocol number, optional user n
 
 <H3>Using the grev utility:</H3>
 <P>
-In the Nokia 9000i SDK version 2 (refer to
-<A HREF = "../../Nokia9000/Versions/index.htm">versions</A>),
-the .rev file may be in the local or in the 
-&quot;Installed&quot; branch. It is suggested that developers keep a local .rev file so that they don't have to make revisions to the branch by hand. 
-<P>
 The <CODE>grev</CODE> utility uses the following syntax:</P>
 <PRE>
-     grev &lt<EM>option</EM>&gt &lt<EM>rev filename</EM>&gt [&lt<EM>comment</EM>&gt|-P|-R] -s
+     <BIG><B>grev &lt<EM>command</EM>&gt &lt<EM>rev filename</EM>&gt [-P|-R|-s] [-B branch] [&lt;rev&gt;] [&quot<EM>comment</EM>&quot]</B></BIG>
 </PRE>
+<ul>
+<li>&lt<EM>rev filename</EM>&gt is the name of the revision file (ending in .REV), referred as <b>file</b> in the list below.</li>
+<li>&lt<EM>rev</EM>&gt is only used for the <b>newrev</b> command, see below.</li><p>
+<li>The -P option causes grev to give minimal output, printing only the protocol number.</li>
+<li>The -R option causes grev to print only the revision number.</li>
+<li>The <B>-s</B> option MUST be given to save change to file. If this flag is not passed, the change will only be
+displayed to the screen.</li>
+<li>The -B option causes grev to use branch rather than the trunk.</li>
+<li>These options are referred to as <B>[flags]</B> in the list below.</li><br>
+</ul>
+Possible commands are:<p>
 
-It is necessary to pass the <STRONG>-s</STRONG> flag to save the protocol
-change. There are few circumstances where this flag is not needed.
-<P>
-
-&lt<EM>options</EM>&gt may be one of the following:
 <DL><DD>
 <DL>
-<DT>
-<STRONG>
-new </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- [&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</DT><DD>
-</STRONG>
-Create a new revision record, listing comment as an initial revision for the base (0.0.0.0 release, 0.0 protocol). This command may only be executed in the geode's development directory. The -P option causes grev to give minimal output, printing only the protocol number. The -R option causes grev to print only the revision number. These last two options are normally used by <CODE>
-pmake</CODE>
- to extract the relevant numbers.</DD>
-<DT>
-<STRONG>
-info </STRONG>
-<STRONG>
-file</STRONG>
-</DT><DD>Print the current release and protocol from the revision file.</DD>
-<DT>
-<STRONG>
-getproto</STRONG>
- <STRONG>
-file</DT><DD>
-</STRONG>
-Print only the current protocol from the revision file.</DD>
-<DT>
-<STRONG>
-newprotomajor </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- [&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</STRONG>
- </DT>
-<DT>
-<STRONG>
-NPM </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- [&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</DT><DD>
-</STRONG>
-Increase the major protocol number by one, setting the minor number to zero. The comment argument is listed as the reason for the change in the file. The -P and -R options work as they do for <CODE>
-grev new</CODE>
-.</DD>
-<DT>
-<STRONG>
-newprotominor </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- [&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</STRONG>
- </DT>
-<DT>
-<STRONG>
-npm </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- [&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</DT><DD>
-</STRONG>
-Increase the minor protocol number by one. The comment string is listed as the reason for the change in the file. The -P and -R options work as they do for <CODE>
-grev new</CODE>
-.</DD>
-<DT>
-<STRONG>
-newrev </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- </STRONG>
-<STRONG>
-number1.number2.number3 </STRONG>
-<STRONG>
-[&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</DT><DD>
-</STRONG>
-Increase release number from A.B.C.D to <EM>number1</EM>.<EM>number2</EM>.number3.0. The comment is listed as the reason for the change. The -P and -R options work as they do for <CODE>
-grev new</CODE>
-.</DD>
-<DT>
-<STRONG>
-newchange </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- [&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</STRONG>
- </DT><DD>
-Up release number from A.B.C.D to A.B.C+1.0. The comment is listed as the reason for the change. The -P and -R options work as they do for <CODE>
-grev new</CODE>
-.</DD>
-<DT>
-<STRONG>
-neweng </STRONG>
-<STRONG>
-file</STRONG>
-<STRONG>
- [&quot;</STRONG>
-<STRONG>
-comment</STRONG>
-<STRONG>
-&quot;|-P|-R]</STRONG>
- </DT><DD>
-Increase release number from A.B.C.D to A.B.C.D+1. The comment is listed as the reason for the change. The -P and -R options work as they do for <CODE>
-grev new</CODE>
-.</DD>
-</DL>
-</DL>
+<DT><strong>new file [flags] ["comment"]</strong>
+</DT>
+<DD>Create a new revision record, listing comment as an initial revision for
+   the base (0.0.0.0 release, 0.0 protocol). This command may only be
+   executed in the geode's development directory. <STRONG>[flags]</STRONG> can be given, but
+   will have no effect.
+</DD>
 
-&lt<EM>rev filename</EM>&gt is the name of the revision file (ending in .REV).
-<P>
-&lt<EM>comment</EM>&gt is an optional comment embedded in quotes.
-<P>
-<STRONG>-P</STRONG> causes <CODE>grev</CODE> to give minimal output, printing only the protocol number. This flag is normally used by <CODE>pmake</CODE> to extract to protocol number.
-<P>
-<STRONG>-R</STRONG> causes <CODE>grev</CODE> to print only the revision number. <CODE>pmake</CODE> uses this flag to extract the version number.
-<P>
-<STRONG>-s</STRONG>, as noted above, causes the change to be saved to 
-the revision file. If this flag is not passed, the change will only be 
-displayed to the screen.
+<DT><strong>info file [flags]</strong>
+</DT>
+<DD>Print the current release and protocol from the revision file.
+</DD>
+
+<DT><strong>getproto file [flags]</strong>
+</DT>
+<DD>Print only the current protocol from the revision file.
+   The <B>-P</B> option works as stated above.
+</DD>
+
+<DT><strong>newprotomajor file [flags] ["comment"]</strong>
+</DT>
+<DT><strong>NPM file [flags] ["comment"]</strong>
+</DT>
+<DD>Increase the major protocol number by one, setting the minor number to
+   zero. The comment argument is listed as the reason for the change in the
+   file. You must give the <B>-s</B> option to save changes to file. The <B>-P</B> option
+   works as stated above.
+</DD>
+
+<DT><strong>newprotominor  file [flags] ["comment"]</strong>
+</DT>
+<DT><strong>npm file [flags] ["comment"]</strong>
+</DT>
+<DD>Increase the minor protocol number by one. The comment string is listed
+   as the reason for the change in the file. You must give the <B>-s</B> option to
+   save changes to file. The <B>-P</B> option works as stated above.
+</DD>
+
+<DT><strong>newrev file [flags] <EM>A.B.C</EM> ["comment"]</strong>
+</DT>
+<DD>Update release number to A.B.C.0 The comment is listed as the reason for
+   the change. You must give the <B>-s</B> option to save changes to file.
+</DD>
+
+<DT><strong>newchange file [flags] ["comment"]</strong>
+<DD>Up release number from A.B.<B>C.D</B> to A.B.<B>C+1.0</B>. The comment is listed as
+   the reason for the change. You must give the <B>-s</B> option to save changes
+   to file. The <B>-R</B> option works as stated above.
+</DD>
+
+<DT><strong>neweng file [flags] ["comment"]</strong>
+</DT>
+<DT><strong>ne file [flags] ["comment"]</strong>
+</DT>
+<DD>Increase release number from A.B.C.<B>D</B> to A.B.C.<B>D+1</B>. The comment is
+   listed as the reason for the change. You must give the <B>-s</B> option to save
+   changes to file. The <B>-R</B> option works as stated above.
+</DD>
+
+<DT><strong>help</strong>
+</DT>
+<DD>Print out a detailed help.
+</DD>
+</DL></DD></DL>
 
 <HR>
 <!-- This blob is a bunch of standard links: up, back, index, etc. -->
 <!-- up to top -->|&nbsp;<A HREF="../../index.htm"><IMG SRC="../../docImages/upTop.gif" ALT="Up: " BORDER="0">GEOS SDK TechDocs</A>
 <!-- up to parent -->| <A HREF="index.htm"><IMG SRC="../../docImages/up.gif" ALT="Up" BORDER="0"></A>
-<!-- down to first child --> 
-<!-- to previous --> | <A HREF="TTools_6.htm"><IMG SRC="../../docImages/prev.gif" BORDER="0" ALT="Prev: ">6 Goc</A> 
-<!-- to next --> | <A HREF="TTools_8.htm"><IMG SRC="../../docImages/next.gif" BORDER="0" ALT="Next: ">8 mkmf</A> 
+<!-- down to first child -->
+<!-- to previous --> | <A HREF="TTools_6.htm"><IMG SRC="../../docImages/prev.gif" BORDER="0" ALT="Prev: ">6 Goc</A>
+<!-- to next --> | <A HREF="TTools_8.htm"><IMG SRC="../../docImages/next.gif" BORDER="0" ALT="Next: ">8 mkmf</A>
 <HR>
 <!-- That blob was a bunch of standard links: up, back, index, etc. -->
 </BODY>

--- a/Tools/goc/goc.c
+++ b/Tools/goc/goc.c
@@ -900,7 +900,7 @@ OpenOutputFile(char *outFile)
 	OPEN_AND_ASSIGN_OUTPUT_FILE(foutput,outFile);
 	if (localize){
 
-	    Localize_Init(outFile,TRUE); /*TRUE. resource names are all caps */
+	    Localize_Init(outFile,FALSE); /*FALSE. Do not capitalize resource names. */
 	}
 
 	if (foutput == NULL) {

--- a/Tools/grev/grev.c
+++ b/Tools/grev/grev.c
@@ -13,9 +13,9 @@
 *	Name	Date		Description
 *	----	----		-----------
 *	jimmy	8/19/92		Initial version
-*   jacob   9/9/96		Win32 port
-*	RainerB	01/15/2023	Usage() added, command help added
- *
+*       jacob   9/9/96		Win32 port
+*	RainerB	02/13/2023	Usage() added, command help added
+*
 *	DESCRIPTION: this file contains code for the DOS version of grev
 *
 *	$Id: grev.c,v 1.1 92/10/27 17:34:47 jimmy Exp $
@@ -65,7 +65,7 @@ Commands are:
     grev  newrev <file> <rev> [<comment>]
 	Set the revision for <file> to <rev> where rev is of the form "1.2.3".
 
-	grev help
+    grev help
 	Output detailed description.
 
 Instead of a comment a special parameter (either -P or -R) may be passed so
@@ -129,7 +129,7 @@ typedef enum {
 } SubCommand;
 
 #define EXIT(errstring) {fprintf(stderr, "grev: %s", errstring); \
-						Usage(FALSE); \
+                         Usage(FALSE); \
                          exit(1);}
 
 const char *InvalidRevisionNumber = "invalid revision number, no changes made\n";
@@ -182,27 +182,27 @@ main(int argc, char **argv)
 #if 0
 {
     int	n;
-	fp = fopen("D:\\gparam.txt", "at");		// <-- at == append text
-	if (fp == NULL) {
-	    printf("GREV Debug: GParam.txt not open");
-	    exit(1);
-	}
-	// dump current path to file
-	getcwd( buf, 256);
-	strcat(buf, ":\n");
-	fwrite(buf, strlen(buf), 1, fp);
 
-	// dump parameters to file
-	sprintf(buf,"   ");
-	for ( n=0; n<argc; n++)
-	{
-		strcat(buf,argv[n]);
-		strcat(buf, "   ");
-	}
-	strcat(buf, " *\n");
-	fwrite(buf, strlen(buf), 1, fp);
+    fp = fopen("D:\\gparam.txt", "at");		// <-- at == append text
+    if (fp == NULL) {
+	printf("GREV Debug: GParam.txt not open");
+	exit(1);
+    }
+    // dump current path to file
+    getcwd( buf, 256);
+    strcat(buf, ":\n");
+    fwrite(buf, strlen(buf), 1, fp);
 
-	fclose(fp);
+    // dump parameters to file
+    sprintf(buf,"   ");
+    for ( n=0; n<argc; n++) {
+	strcat(buf,argv[n]);
+	strcat(buf, "   ");
+    }
+    strcat(buf, " *\n");
+    fwrite(buf, strlen(buf), 1, fp);
+
+    fclose(fp);
 }
 #endif
 /*** DEBUG ENDS ****/
@@ -218,14 +218,14 @@ main(int argc, char **argv)
     }
     subcmd = argv[1];
 
-	/*
-	 * If the subcommand is 'help' or similar, output an detailed help.
-	 * In this case no rev file is required.
-	 */
-	if ( strcmp(subcmd, "help") * strcmp(subcmd, "-help") * strcmp(subcmd, "?") * strcmp(subcmd, "-?") == 0 ) {
+    /*
+     * If the subcommand is 'help' or similar, output an detailed help.
+     * In this case no rev file is required.
+     */
+    if ( strcmp(subcmd, "help") * strcmp(subcmd, "-help") * strcmp(subcmd, "?") * strcmp(subcmd, "-?") == 0 ) {
 	Usage(TRUE);
 	exit(0);
-	}
+    }
 
 
     if (argc < 3) {
@@ -264,7 +264,7 @@ main(int argc, char **argv)
 		save = TRUE;
 		break;
 	    case '?':
-	    Usage(FALSE);
+		Usage(FALSE);
 		exit(1);
 	    }
 	}
@@ -374,7 +374,7 @@ main(int argc, char **argv)
 	if (save) {
 	    InsertIntoFileAndExit(buf, sizeof (buf), fp, revFile, 0);
 	} else {
-		WarnNotSaved(revFile, terseOutput);
+	    WarnNotSaved(revFile, terseOutput);
 	    fclose(fp);
 	    exit(0);
 	}
@@ -589,8 +589,8 @@ main(int argc, char **argv)
 	if (save) {
 	    InsertIntoFileAndExit(buf, sizeof (buf), fp, revFile, terseOutput);
 	} else {
-		WarnNotSaved(revFile, terseOutput);
-		fclose(fp);
+	    WarnNotSaved(revFile, terseOutput);
+	    fclose(fp);
 	    exit(0);
 	}
     }
@@ -731,21 +731,21 @@ Targ_FmtTime (long time)
  * REVISION HISTORY:
  *	Name	Date		Description
  *	----	----		-----------
- *	??		??			Initial version
+ *	??	??		Initial version
  *	RainerB	01/15/2023	Parameter full added
  *
  *********************************************************************/
 static void
 Usage(int full)
 {
-	if (!full) {
-    puts( "\nUsage:  grev <command> <file> [-PRs] [-B <branch>] [<rev>] [\"comment\"]" );
-    puts( "        Allowed commands: new, info, getproto, newprotomajor, newprotominor, ");
-    puts( "                          neweng, newchange, newrev, help" );
-    puts( "        Must give -s option to commit changes to file." );
-    puts( "\nUse 'grev help' for a detailed description." );
-    return;
-	}
+    if (!full) {
+	puts( "\nUsage:  grev <command> <file> [-PRs] [-B <branch>] [<rev>] [\"comment\"]" );
+	puts( "        Allowed commands: new, info, getproto, newprotomajor, newprotominor, ");
+	puts( "                          neweng, newchange, newrev, help" );
+	puts( "        Must give -s option to commit changes to file." );
+	puts( "\nUse 'grev help' for a detailed description." );
+	return;
+    }
 
     puts( "\nAll commands take the following general form:" );
     puts( "    grev <command> <file> [-PRs] [-B <branch>] [<rev>] [\"comment\"]" );
@@ -789,7 +789,7 @@ Usage(int full)
     puts( "\ngrev help" );
     puts( "    Output detailed help." );
 
-	puts( "\nExample: grev newrev myapp.rev -s 12.7.4 \"New features added\"" );
+    puts( "\nExample: grev newrev myapp.rev -s 12.7.4 \"New features added\"" );
 }
 
 /*********************************************************************
@@ -809,9 +809,9 @@ Usage(int full)
 void
 WarnNotSaved(char *revFile, char noOutput)
 {
-	if (noOutput) return;
-	printf("\nFlag -s not given. No changes made in ");
-	printf(revFile);
-	printf("!");
+    if (noOutput) return;
+    printf("\nFlag -s not given. No changes made in ");
+    printf(revFile);
+    printf("!");
 }
 

--- a/Tools/grev/grev.c
+++ b/Tools/grev/grev.c
@@ -13,8 +13,9 @@
 *	Name	Date		Description
 *	----	----		-----------
 *	jimmy	8/19/92		Initial version
-*       jacob   9/9/96		Win32 port
-*
+*   jacob   9/9/96		Win32 port
+*	RainerB	01/15/2023	Usage() added, command help added
+ *
 *	DESCRIPTION: this file contains code for the DOS version of grev
 *
 *	$Id: grev.c,v 1.1 92/10/27 17:34:47 jimmy Exp $
@@ -64,16 +65,18 @@ Commands are:
     grev  newrev <file> <rev> [<comment>]
 	Set the revision for <file> to <rev> where rev is of the form "1.2.3".
 
+	grev help
+	Output detailed description.
 
-Instead of a comment a special paramter (either -P or -R) may be passed so
+Instead of a comment a special parameter (either -P or -R) may be passed so
 that the output will only be either the Protocol number or the Revision number
 this is used by pmake to get at these values
 
-The stanard pmake include files call 'grev' and pass information to the
+The standard pmake include files call 'grev' and pass information to the
 linker with the -R flag, overriding any revision number specified in the
 geode parameter file. e.g.
 
-	rev=`grev neweng $(GEODE).rev`
+	rev=`grev neweng $(GEODE).rev -s`
 	$(LINK) -R $rev $(LINKFLAGS) $(.ALLSRC) -o $(.TARGET)
 
 The linker places the protocol and revision number in several places:
@@ -126,12 +129,16 @@ typedef enum {
 } SubCommand;
 
 #define EXIT(errstring) {fprintf(stderr, "grev: %s", errstring); \
+						Usage(FALSE); \
                          exit(1);}
 
 const char *InvalidRevisionNumber = "invalid revision number, no changes made\n";
 const char *InvalidRevisionFile = "invalid revision file\n";
 
-
+static void Usage(int full);
+void WarnNotSaved(char *revFile, char noOutput);
+
+
 /*********************************************************************
  *			main
  *********************************************************************
@@ -144,6 +151,7 @@ const char *InvalidRevisionFile = "invalid revision file\n";
  *	Name	Date		Description
  *	----	----		-----------
  *	jimmy	8/19/92		Initial version
+ *	RainerB	01/15/2023	Usage() added, 'help' command added
  *
  *********************************************************************/
 void
@@ -170,17 +178,59 @@ main(int argc, char **argv)
     }
 #endif
 
+/*** DEBUG - log any call to grev ****/
+#if 0
+{
+    int	n;
+	fp = fopen("D:\\gparam.txt", "at");		// <-- at == append text
+	if (fp == NULL) {
+	    printf("GREV Debug: GParam.txt not open");
+	    exit(1);
+	}
+	// dump current path to file
+	getcwd( buf, 256);
+	strcat(buf, ":\n");
+	fwrite(buf, strlen(buf), 1, fp);
+
+	// dump parameters to file
+	sprintf(buf,"   ");
+	for ( n=0; n<argc; n++)
+	{
+		strcat(buf,argv[n]);
+		strcat(buf, "   ");
+	}
+	strcat(buf, " *\n");
+	fwrite(buf, strlen(buf), 1, fp);
+
+	fclose(fp);
+}
+#endif
+/*** DEBUG ENDS ****/
+
     /*
      * The first 2 words on the command-line must be the subcommand
      * followed by the name of the .rev file.
      */
     if (argc < 2) {
 	fprintf(stderr, "grev: no command specified\n");
+	Usage(FALSE);
 	exit(1);
     }
     subcmd = argv[1];
+
+	/*
+	 * If the subcommand is 'help' or similar, output an detailed help.
+	 * In this case no rev file is required.
+	 */
+	if ( strcmp(subcmd, "help") * strcmp(subcmd, "-help") * strcmp(subcmd, "?") * strcmp(subcmd, "-?") == 0 ) {
+	Usage(TRUE);
+	exit(0);
+	}
+
+
     if (argc < 3) {
 	fprintf(stderr, "grev: no .rev file specified\n");
+	Usage(FALSE);
 	exit(1);
     }
     revFile = argv[2];
@@ -214,6 +264,7 @@ main(int argc, char **argv)
 		save = TRUE;
 		break;
 	    case '?':
+	    Usage(FALSE);
 		exit(1);
 	    }
 	}
@@ -323,6 +374,7 @@ main(int argc, char **argv)
 	if (save) {
 	    InsertIntoFileAndExit(buf, sizeof (buf), fp, revFile, 0);
 	} else {
+		WarnNotSaved(revFile, terseOutput);
 	    fclose(fp);
 	    exit(0);
 	}
@@ -400,7 +452,7 @@ main(int argc, char **argv)
 	token = 'P';
     }
 
-    if (strcmp(subcmd, "neweng") == 0) {
+    if (strcmp(subcmd, "neweng") == 0) || strcmp(subcmd, "ne") == 0) {
 	sc = NEW_ENG;
 	token = 'R';
     }
@@ -537,12 +589,14 @@ main(int argc, char **argv)
 	if (save) {
 	    InsertIntoFileAndExit(buf, sizeof (buf), fp, revFile, terseOutput);
 	} else {
-	    fclose(fp);
+		WarnNotSaved(revFile, terseOutput);
+		fclose(fp);
 	    exit(0);
 	}
     }
 
     fprintf(stderr, "grev: unknown command: %s\n", subcmd);
+    Usage(FALSE);
     exit(1);
 }
 
@@ -659,9 +713,104 @@ Targ_FmtTime (long time)
     parts = localtime(&time);
 
     year += parts->tm_year;
-	
+
     sprintf (buf, "%d:%02d:%02d %s %d, %d",
 	     parts->tm_hour, parts->tm_min, parts->tm_sec,
 	     months[parts->tm_mon], parts->tm_mday, year);
     return(buf);
+}
+
+/*********************************************************************
+ *			Usage
+ *********************************************************************
+ * SYNOPSIS:	Display how to use grev
+ * CALLED BY:	main
+ * RETURN:	nothing
+ * SIDE EFFECTS:
+ * STRATEGY:	Routine was taken from VC++ version of grev.c and updated
+ * REVISION HISTORY:
+ *	Name	Date		Description
+ *	----	----		-----------
+ *	??		??			Initial version
+ *	RainerB	01/15/2023	Parameter full added
+ *
+ *********************************************************************/
+static void
+Usage(int full)
+{
+	if (!full) {
+    puts( "\nUsage:  grev <command> <file> [-PRs] [-B <branch>] [<rev>] [\"comment\"]" );
+    puts( "        Allowed commands: new, info, getproto, newprotomajor, newprotominor, ");
+    puts( "                          neweng, newchange, newrev, help" );
+    puts( "        Must give -s option to commit changes to file." );
+    puts( "\nUse 'grev help' for a detailed description." );
+    return;
+	}
+
+    puts( "\nAll commands take the following general form:" );
+    puts( "    grev <command> <file> [-PRs] [-B <branch>] [<rev>] [\"comment\"]" );
+    puts( "    -P\t\tProduce terse output of only protocol number (used by pmake)." );
+    puts( "    -R\t\tProduces terse output of only release number (used by pmake)." );
+    puts( "    -s\t\tSave changes to rev file.  **MUST PASS TO MODIFY .rev FILE**" );
+    puts( "    -B <branch>\tUse <branch> rather then trunk." );
+    puts( "  ** Note the placement of flags and arguments is unforunately important **\n" );
+
+    puts( "\nCommands are:" );
+
+    puts( "\ngrev new <file> [flags] [\"comment\"]" );
+    puts( "    Create a new '.rev' file with protocol revision 0.0 and release\n    number 0.0.0.0." );
+
+    puts( "\ngrev info <file> [flags]" );
+    puts( "    Display information about the given revision file." );
+
+    puts( "\ngrev getproto <file> [flags]" );
+    puts( "    Output the current protocol number to stdout." );
+
+    puts( "\ngrev newprotomajor <file> [flags] [\"comment\"]\ngrev NPM <file> [flags] [\"comment\"]" );
+    puts( "    Add a new major protocol number for <file>.  Adds one line to the .rev" );
+    puts( "    file (if '-s' given).  Outputs the new protocol number to stdout." );
+
+    puts( "\ngrev newprotominor <file> [flags] [\"comment\"]\ngrev npm <file> [flags] [\"comment\"]" );
+    puts( "    Add a new minor protocol number for <file>.  Adds one line to the .rev" );
+    puts( "    file (if '-s' given).  Outputs the new protocol number to stdout." );
+
+    puts( "\ngrev neweng <file> [flags] [\"comment\"]\ngrev ne <file> [flags] [\"comment\"]" );
+    puts( "    Add a new engineering revision for <file>.  Adds one line to the .rev" );
+    puts( "    file (if '-s' given).  Outputs the new release number to stdout." );
+
+    puts( "\ngrev newchange <file> [flags] [\"comment\"]" );
+    puts( "    Add a new running change revision for <file>.  Adds one line to the .rev" );
+    puts( "    file (if '-s' given).  Outputs the new release number to stdout." );
+
+    puts( "\ngrev newrev <file> [flags] <rev> [\"comment\"]" );
+    puts( "    Set the release number for <file> to <rev> where rev is of the form \"1.2.3\"" );
+    puts( "    Must give -s option to commit change to file." );
+
+    puts( "\ngrev help" );
+    puts( "    Output detailed help." );
+
+	puts( "\nExample: grev newrev myapp.rev -s 12.7.4 \"New features added\"" );
+}
+
+/*********************************************************************
+ *			WarnNotSaved
+ *********************************************************************
+ * SYNOPSIS:	Display a warning that change is not saved to rev file
+ * CALLED BY:	main
+ * RETURN:	nothing
+ * SIDE EFFECTS:
+ * STRATEGY:
+ * REVISION HISTORY:
+ *	Name	Date		Description
+ *	----	----		-----------
+ *	RainerB	01/19/2023	Initial version
+ *
+ *********************************************************************/
+void
+WarnNotSaved(char *revFile, char noOutput)
+{
+	if (noOutput) return;
+	printf("\nFlag -s not given. No changes made in ");
+	printf(revFile);
+	printf("!");
 }

--- a/Tools/grev/grev.c
+++ b/Tools/grev/grev.c
@@ -814,3 +814,4 @@ WarnNotSaved(char *revFile, char noOutput)
 	printf(revFile);
 	printf("!");
 }
+

--- a/Tools/grev/grev.c
+++ b/Tools/grev/grev.c
@@ -452,7 +452,7 @@ main(int argc, char **argv)
 	token = 'P';
     }
 
-    if (strcmp(subcmd, "neweng") == 0) || strcmp(subcmd, "ne") == 0) {
+    if (strcmp(subcmd, "neweng") == 0 || strcmp(subcmd, "ne") == 0) {
 	sc = NEW_ENG;
 	token = 'R';
     }


### PR DESCRIPTION
This PR resolves issue #188 (ref files are not updated) by adding the -s flag to grev calls in the geos.mk files.
Since grev must also be executed directly on the command line (e.g. new and newrev commands) the following changes have been made:
- Output of a short instruction if there is a problem
- Warning if the change is not saved
- Detailed instructions with the new command "help"
- Update of the outdated documentation