### PR TITLE
Fixed jpeg library build and integration issues #250

### DIFF
--- a/CInclude/jmorecfg.h
+++ b/CInclude/jmorecfg.h
@@ -192,14 +192,33 @@ typedef unsigned int JDIMENSION;
 /* a function used only in its module: */
 #define LOCAL(type)     static type _pascal _near
 /* a function referenced thru EXTERNs: */
-#define GLOBAL(type)    type _pascal _export
+#define GLOBAL(type)    type _pascal _export 
 /* a reference to a GLOBAL function: */
-#define EXTERN(type)    extern type _pascal
+#define EXTERN(type)    extern type _pascal _export
 
 
 /* Macros to assign a const function pointer in a glue-friendly way. All
    but the first are only required because glue doesn't like to *local*
    variables in different scopes to have the same name... */
+#ifdef __WATCOMC__
+
+#define MASSIGN(dst, src) {\
+    (void *)(dst) = src;\
+  }
+#define MASSIGN2(dst, src) {\
+    (void *)(dst) = src;\
+  }
+#define MASSIGN3(dst, src) {\
+    (void *)(dst) = src;\
+  }
+#define MASSIGN4(dst, src) {\
+    (void *)(dst) = src;\
+  }
+#define MASSIGN5(dst, src) {\
+    (void *)(dst) = src;\
+  }
+
+#else
 
 #define MASSIGN(dst, src) {\
     static void *method_##src = src;\
@@ -222,6 +241,8 @@ typedef unsigned int JDIMENSION;
     (void *)(dst) = method5_##src;\
   }
 
+#endif
+
 /* This macro is used to declare a "method", that is, a function pointer.
  * We want to supply prototype parameters if the compiler can cope.
  * Note that the arglist parameter must be parenthesized!
@@ -229,9 +250,9 @@ typedef unsigned int JDIMENSION;
  */
 
 #ifdef HAVE_PROTOTYPES
-#define JMETHOD(type,methodname,arglist)  type (*methodname) arglist
+#define JMETHOD(type,methodname,arglist)  type _pascal (*methodname) arglist
 #else
-#define JMETHOD(type,methodname,arglist)  type (*methodname) ()
+#define JMETHOD(type,methodname,arglist)  type _pascal (*methodname) ()
 #endif
 
 

--- a/Library/Breadbox/Ijgjpeg/local.mk
+++ b/Library/Breadbox/Ijgjpeg/local.mk
@@ -6,5 +6,8 @@ XGOCFLAGS = -L ijgjpeg
 # -d   reduces the size of the dgroup by merging duplicate strings.
 # -w-  turn off some warnings
 #XCCOMFLAGS = -d -Z -Os -O -w-stu -w-par -WDE
+XCCOMFLAGS = -zu 
+# -dc (Borland) is not set to push literals into code segment, not
+# sure why, but trying -zc is not working properly
 
 #XLINKFLAGS = -N \(C\)98\20Breadbox\20Computer\20Company

--- a/Library/Breadbox/ImpGraph/ASMIMP/impgif.asm
+++ b/Library/Breadbox/ImpGraph/ASMIMP/impgif.asm
@@ -3617,10 +3617,10 @@ ImpGIFGetInfo endp
 ; C stubs:
 ;----------------------------------------------------------------------------
 IMPGIFCREATE proc far file:word, allocwatcher:word, useSysPal:word, mimeStatus:fptr
-        uses bx, cx, dx, es, di
+        uses bx, cx, dx, es, si, di
         .enter
 
-		movdw esdi, mimeStatus, ax
+	movdw esdi, mimeStatus, ax
         mov ax, file
         mov cx, allocwatcher
         mov si, useSysPal

--- a/Library/Impex/Main/mainC.asm
+++ b/Library/Impex/Main/mainC.asm
@@ -197,7 +197,7 @@ REVISION HISTORY:
 
 -----------------------------------------------------------------------------@
 IMPEXUPDATEIMPORTEXPORTSTATUS	proc far	message:fptr, percent:word
-	uses	ds
+	uses	si, ds
 	.enter
 
 	movdw	dxsi, message


### PR DESCRIPTION
- forces _pascal conventions for callback (it is not the default for the WATCOM based tool chain)
- made callback assignment WATCOM compatible
- for ds loading at library entry
- fix 2 C stubs (keeping si unchanged [real bugs unrelated to jpeg library])