### PR TITLE
Fixing some small typos in SDK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,20 +76,9 @@ If you want to customize the target environment settings only for yourself, you 
 
 # How to develop?
 
-PC/GEOS comes with extensive technical documentation that describes tools, programming languages and API calls from the perspective of an SDK user. This documentation can be found in the `TechDocs` folder and is available in Markdown format. Here are some entry points to the main volumes:
+PC/GEOS comes with extensive technical documentation that describes tools, programming languages and API calls from the perspective of an SDK user. This documentation can be found in the `TechDocs` folder and is available in Markdown format.
 
-- Introduction
-  - [Tutorial](TechDocs/Markdown/tutorial.md) - the initial chapters describing the development environment are somewhat outdated, and still refer to the original two-machine setup for debugging, but this nevertheless gives a good idea of overall development process.
-  - [Concepts](TechDocs/Markdown/concepts.md)
-  - [Tools](TechDocs/Markdown/tools.md)
-- C development
-  - [GOC keywords and API calls](TechDocs/Markdown/routines.md)
-  - [Objects Reference](TechDocs/Markdown/objects.md)
-  - [Quick Reference](TechDocs/Markdown/quickref.md)
-- Assembly development
-  - [ESP Assembly Language](TechDocs/Markdown/esp.md)
-  - [Assembly Reference](TechDocs/Markdown/asmref.md)
-  - [Driver Development Kit](TechDocs/Markdown/ddk.md)
+You can find a browseable, searchable version of the documentation here: https://bluewaysw.github.io/pcgeos/
 
 ##
 We are on https://bluewaysw.slack.com/ for more efficient collaboration. Please register at https://blog.bluewaysw.de for MyGEOS and use the Slack section and receive access to our developer community. Welcome!

--- a/TechDocs/Markdown/Concepts/cbuild.md
+++ b/TechDocs/Markdown/Concepts/cbuild.md
@@ -87,7 +87,7 @@ the Object Reference Book](../Objects/ogentrg.md).
 
 + Lists  
 Dynamic, static, and scrolling lists are all described in ["The List Objects", 
-Chapter 11 of the Object Reference Book](../Obects/ogenlst.md).
+Chapter 11 of the Object Reference Book](../Objects/ogenlst.md).
 
 + Value Setters  
 The GenValue object allows the user to set a value within a given range. 

--- a/TechDocs/Markdown/Concepts/cbuild.md
+++ b/TechDocs/Markdown/Concepts/cbuild.md
@@ -118,7 +118,7 @@ in ["The Text Objects", Chapter 10 of the Object Reference Book](../Objects/otex
 + Providing Help  
 An application can include an object that automatically provides 
 context-sensitive help to the user. This object is discussed in ["Help Object 
-Library", Chapter 15 of the Object Reference Book](../Objects/ohlep.md).
+Library", Chapter 15 of the Object Reference Book](../Objects/ohelp.md).
 
 + Handling Input  
 Many applications may want to track mouse or keyboard input. Input 
@@ -151,7 +151,7 @@ These commands are described in ["Drawing Graphics", Chapter 24](cshapes.md).
 The Graphic Object Library provides many different graphic objects that 
 know how to position, resize, and draw themselves as well as handle user 
 input. This library is described in ["Drawing Graphics", Chapter 24](cshapes.md) and 
-["Graphic Object Library", Chapter 18 of the Object Reference Book](../Objects/ogropj.md).
+["Graphic Object Library", Chapter 18 of the Object Reference Book](../Objects/ogrobj.md).
 
 #### 2.2.3 Documents and Data Structures
 

--- a/TechDocs/Markdown/Concepts/cclipb.md
+++ b/TechDocs/Markdown/Concepts/cclipb.md
@@ -605,7 +605,7 @@ Code Display 7-5 Handling Clipboard Changes
 As stated above, most applications will simply let a GenEditControl object 
 create and maintain their Edit menu. **GenEditControlClass** is a subclass 
 of GenControlClass (see ["Generic UI Controllers," Chapter 12 of the Object 
-Reference Book](../Objects/ogenctrl.md) for usage of controllers in general).
+Reference Book](../Objects/ogenctl.md) for usage of controllers in general).
 
 The GenEditControl object can provide triggers and/or tools for Undo, Cut, 
 Copy, Paste, Select All, and Delete operations. These operations must all be 

--- a/TechDocs/Markdown/Concepts/cfile.md
+++ b/TechDocs/Markdown/Concepts/cfile.md
@@ -1837,7 +1837,7 @@ If you want to find out the handle of the disk containing an open file, call
 **FileGetDiskHandle()**. This routine is passed the file handle; it returns the disk 
 handle. This is useful if the geode has to prepare for a shutdown; it can get the 
 disk handle with **FileGetDiskHandle()**, then save that handle with **DiskSave()** (see 
-["Saving and Restoring a Disk Handle"](17323-saving-and-restoring-a-disk-handle)). With 
+["Saving and Restoring a Disk Handle"](#17323-saving-and-restoring-a-disk-handle)). With 
 this information (and the file name), the geode will be able to reopen the file 
 when it restarts.
 

--- a/TechDocs/Markdown/Concepts/cgeom.md
+++ b/TechDocs/Markdown/Concepts/cgeom.md
@@ -45,7 +45,7 @@ Then it discusses how to manage generic UI objects (using a dialog box as an
 example) in [section 12.2](#122-arranging-your-generic-objects). For the hints 
 you can apply to window objects, see [section 12.3](#123-positioning-and-sizing-windows). 
 For descriptions of managing the geometry of visible object trees and composites, see 
-["VisClass," Chapter 23 of the Object Reference Book](../Objects/oviscla.md).
+["VisClass," Chapter 23 of the Object Reference Book](../Objects/ovis.md).
 
 #### 12.1.1 Geometry Manager Features
 
@@ -765,7 +765,7 @@ HINT_CENTER_MONIKER. Figure 12-9 shows several different moniker
 placements.
 
 ![](Art/figure_12-9.png)
-![](Art/figure_12-9a-png)
+![](Art/figure_12-9a.png)
 
 **Figure 12-9** Placing Monikers  
 _The top-left has the moniker placed to the left by default. The second uses 

--- a/TechDocs/Markdown/Concepts/cgraph.md
+++ b/TechDocs/Markdown/Concepts/cgraph.md
@@ -363,7 +363,7 @@ of the Object Reference Book.
 Geodes that wish to allow the user to edit graphical elements would do well 
 to incorporate a Graphic Object into their hierarchies. These objects have 
 considerable power and include UI to allow the user to work graphics within 
-them. See ["Graphic Object Library," Chapter 18](../Objects/cgrobj.md) of the 
+them. See ["Graphic Object Library," Chapter 18](../Objects/ogrobj.md) of the 
 Object Reference Book for more information about these object classes.
 
 As you learn more advanced graphics concepts you may discover shortcuts. 
@@ -426,7 +426,7 @@ graphics system will do all the worrying about device coordinates so your
 program doesn't have to. (Note, however, that **GrDrawImage()**, 
 **GrDrawHugeImage()**, and **GrBrushPolyline()** are more device-dependant than most 
 routines; see section [24.2.10 of chapter 24](cshapes.md#24210-drawing-bitmaps) and 
-[section 24.2.8 of chapter 24](2428-polylines-and-polygons) for information on these routines).
+[section 24.2.8 of chapter 24](cshapes.md#2428-polylines-and-polygons) for information on these routines).
 
 Standard GEOS coordinates depart from the device model, taking an 
 approach closer to a pure mathematical Cartesian plane. Programmers used 

--- a/TechDocs/Markdown/Concepts/cinput.md
+++ b/TechDocs/Markdown/Concepts/cinput.md
@@ -766,7 +766,7 @@ pre-passive grab allows the visible object to receive keyboard events before
 the focus object gets them. A post-passive grab delivers events to the visible 
 object after they have been sent to the focus. For more information about 
 gaining and releasing the passive keyboard grabs, see ["VisClass," Chapter 23 
-of the Object Reference Book](../Object/ovis.md).
+of the Object Reference Book](../Objects/ovis.md).
 
 If you intercept keyboard events, you must be sure to return any events that 
 you don't use. For example, if you only want to detect when the user hits the 

--- a/TechDocs/Markdown/Concepts/cintro.md
+++ b/TechDocs/Markdown/Concepts/cintro.md
@@ -71,7 +71,7 @@ language in which most of the GEOS kernel is written. Using Esp, you
 will be able to write optimized routines and applications to handle your 
 most processing-intensive tasks.
 
-**[C Reference Book](cref.md)**  
+**[C Reference Book](../routines.md)**  
 The Routines Book details the data structures, routines, and other 
 typical reference material you'll need. It focuses on the routines and 
 functions provided by the GEOS kernel including the Graphics System 

--- a/TechDocs/Markdown/Concepts/cintro.md
+++ b/TechDocs/Markdown/Concepts/cintro.md
@@ -71,7 +71,7 @@ language in which most of the GEOS kernel is written. Using Esp, you
 will be able to write optimized routines and applications to handle your 
 most processing-intensive tasks.
 
-**[C Reference Book](../cref.md)**  
+**[C Reference Book](cref.md)**  
 The Routines Book details the data structures, routines, and other 
 typical reference material you'll need. It focuses on the routines and 
 functions provided by the GEOS kernel including the Graphics System 
@@ -240,7 +240,7 @@ This details the Database Library provided with GEOS. The Database
 Library provides the low-level routines to create, edit, free up, and 
 organize individual database items.
 
-20. [Parse Library](cparce.md)  
+20. [Parse Library](cparse.md)  
 This details the Parse Library. This library implements a special 
 mathematical description language.
 
@@ -341,7 +341,7 @@ This details the different types of lists you can create with the various
 list-related classes including GenBoolean, GenBooleanGroup, GenItem, 
 GenItemGroup, and GenDynamicList.
 
-12. [GenControl/GenToolControl](../Objects/ogenctrl.md)  
+12. [GenControl/GenToolControl](../Objects/ogenctl.md)  
 This details the controller and toolbox classes that allow an application 
 to use and create controllers. Controller objects automatically build 
 menus and dialog boxes to manage a certain feature set of an application. 
@@ -443,7 +443,7 @@ This introduces you to Swat, the powerful system debugger supplied in
 the SDK. This chapter also gives you the most popular Swat commands 
 and explains how you can put them to use for you.
 
-4. [Swat Referenc](../Tools/tswta-i.md)  
+4. [Swat Referenc](../Tools/tswta_i.md)  
 This gives detailed command reference entries for each Swat command. 
 You should use this section when you need to know the specifics of one or 
 more Swat commands.
@@ -452,7 +452,7 @@ more Swat commands.
 This explains how to use the Debug tool, which allows you to simulate a 
 number of GEOS platforms and hardware configurations.
 
-6. [Tool Command Language](../Tools/ttlc.md)  
+6. [Tool Command Language](../Tools/ttcl.md)  
 This describes Tcl, the Tool Command Language that allows you to 
 extend Swat's functionality. Nearly all Swat commands are programmed 
 in Tcl, and most are accessible as functions within other Tcl commands. 

--- a/TechDocs/Markdown/Concepts/cuiover.md
+++ b/TechDocs/Markdown/Concepts/cuiover.md
@@ -452,7 +452,7 @@ normal graphics commands to draw anything wherever it wants (not just
 within its bounds).
 
 For examples of visible objects that know their bounds and that handle 
-MSG_VIS_DRAW, see ["A UI Example"](105-a-ui-example).
+MSG_VIS_DRAW, see ["A UI Example"](#105-a-ui-example).
 
 #### 10.4.3 Visible Object Abilities
 
@@ -734,7 +734,7 @@ When the user presses the New Game trigger, the trigger sends its message,
 MSG_TICTAC_NEW_GAME, to the TicTacBoard object. The TicTacBoard 
 object is the top object in the visible tree and, upon receipt of this message, 
 resets the game board and notifies all the piece objects of the reset. This 
-process is described below in ["TicTacBoard Specifics"](1054-tictacboard-specifics).
+process is described below in ["TicTacBoard Specifics"](#1054-tictacboard-specifics).
 
 ---
 Code Display 10-2 The TicTac Game Menu

--- a/TechDocs/Markdown/Concepts/cvm.md
+++ b/TechDocs/Markdown/Concepts/cvm.md
@@ -1259,7 +1259,7 @@ thus, you can often make many array accesses with a single Huge Array
 lookup command.) There is also a certain amount of memory overhead for 
 Huge Arrays. Thus, if you are confident that the array size will be small 
 enough for a single block, you are generally better off with a Chunk Array 
-(see [section 16.4.1 of chapter 16](lmem.md#1641-chunk-arrays)).
+(see [section 16.4.1 of chapter 16](clmem.md#1641-chunk-arrays)).
 
 Huge arrays may have fixed-size or variable-sized elements. If elements are 
 variable-sized, there is a slight increase in memory overhead, but no 

--- a/TechDocs/Markdown/Ddk/ddkpcmcia.md
+++ b/TechDocs/Markdown/Ddk/ddkpcmcia.md
@@ -641,7 +641,7 @@ must be passed a structure of CSRegisterClientArgs containing (among
 other things) the address of the callback routine with which CardServices
 should contact the driver. CardServices will send CardServicesEventCode
 types to this callback routine. (For more information on defining your
-callback routine see [“CardServices Events”](34-CardService-Events).)  
+callback routine see [“CardServices Events”](#34-CardService-Events).)  
 This registration should occur when the driver is first loaded, upon receipt of
 DR_INIT.
 ~~~

--- a/TechDocs/Markdown/Objects/ovis.md
+++ b/TechDocs/Markdown/Objects/ovis.md
@@ -4786,5 +4786,5 @@ that is on the screen. MSG_VIS_DESTROY first removes the
 object from the tree (with MSG_VIS_REMOVE) and then destroys it 
 (through the **MetaClass** detach and destroy mechanisms).
 
-[Config Library](ocinfig.md) <-- [Table of Contents](../objects.md) &nbsp;&nbsp; --> [VisComp](oviscmp.md)
+[Config Library](oconfig.md) <-- [Table of Contents](../objects.md) &nbsp;&nbsp; --> [VisComp](oviscmp.md)
 

--- a/TechDocs/Markdown/Tutorial/Data_Structures_and_UI.md
+++ b/TechDocs/Markdown/Tutorial/Data_Structures_and_UI.md
@@ -1986,4 +1986,4 @@ ChunkHandle tempListItem; /*Chunk handle we will use when traversing lists */
 ListNode *tempNode; /* List item which we will use when traversing lists. */
 ~~~
 
-[The Primary Window](The_Primary_Window.md) <-- &nbsp;&nbsp; [table of contents](../Tutorial.md) &nbsp;&nbsp; --> [Views and Visual Objects](Views_and_Visual_Objects.md)
+[The Primary Window](The_Primary_Window.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Views and Visual Objects](Views_and_Visual_Objects.md)

--- a/TechDocs/Markdown/Tutorial/Documents_and_Displays.md
+++ b/TechDocs/Markdown/Tutorial/Documents_and_Displays.md
@@ -1674,4 +1674,4 @@ typedef struct {
 } /* end of MSG_MCC_RESIZE_BAR */
 ~~~
 
-[Views and Visual Objects](Views_and_Visual_Objects.md) <-- &nbsp;&nbsp; [table of contents](../Tutorial.md) &nbsp;&nbsp; --> [Troubleshooting Communications](Troubleshooting_Communications.md)
+[Views and Visual Objects](Views_and_Visual_Objects.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Troubleshooting Communications](Troubleshooting_Communications.md)

--- a/TechDocs/Markdown/Tutorial/Introduction.md
+++ b/TechDocs/Markdown/Tutorial/Introduction.md
@@ -25,4 +25,4 @@ structured, and you'll program an application that uses
 many of the user interface and object-oriented features 
 of GEOS.
 
-[table of contents](../Tutorial.md) &nbsp;&nbsp; --> [Setting Up](Setting_Up.md)
+[table of contents](../tutorial.md) &nbsp;&nbsp; --> [Setting Up](Setting_Up.md)

--- a/TechDocs/Markdown/Tutorial/Setting_Up.md
+++ b/TechDocs/Markdown/Tutorial/Setting_Up.md
@@ -516,5 +516,5 @@ To exit from Swat (so that you can go on to other things), type quit at the
 Swat prompt. You may need to enter the DOS command cls to reset your 
 screen after exiting Swat.
 
-[Introduction](Introduction.md) <-- &nbsp;&nbsp; [table of contents](../Tutorial.md) &nbsp;&nbsp; --> [The Plan](The_Plan.md)
+[Introduction](Introduction.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [The Plan](The_Plan.md)
 

--- a/TechDocs/Markdown/Tutorial/The_Plan.md
+++ b/TechDocs/Markdown/Tutorial/The_Plan.md
@@ -90,4 +90,4 @@ will have behavior added so that it will draw axes and the bars of the
 chart. It will draw these things using kernel graphics routines.
 
 
-[Setting Up](Setting_Up.md) <-- &nbsp;&nbsp; [table of contents](../Tutorial.md) &nbsp;&nbsp; --> [The Primary Window](The_Primary_Window.md)
+[Setting Up](Setting_Up.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [The Primary Window](The_Primary_Window.md)

--- a/TechDocs/Markdown/Tutorial/The_Primary_Window.md
+++ b/TechDocs/Markdown/Tutorial/The_Primary_Window.md
@@ -1051,4 +1051,4 @@ Code Display 3-2 MCHRT.GOC
 @end Interface;
 ~~~
 
-[The Plan](The_Plan.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Data Structures and UI Gadgetry](Data_Structures_and_UI_Gadgetry.md)
+[The Plan](The_Plan.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Data Structures and UI Gadgetry](Data_Structures_and_UI.md)

--- a/TechDocs/Markdown/Tutorial/The_Primary_Window.md
+++ b/TechDocs/Markdown/Tutorial/The_Primary_Window.md
@@ -1051,4 +1051,4 @@ Code Display 3-2 MCHRT.GOC
 @end Interface;
 ~~~
 
-[The Plan](The_Plan.md) <-- &nbsp;&nbsp; [table of contents](../Tutorial.md) &nbsp;&nbsp; --> [Data Structures and UI Gadgetry](Data_Structures_and_UI_Gadgetry.md)
+[The Plan](The_Plan.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Data Structures and UI Gadgetry](Data_Structures_and_UI_Gadgetry.md)

--- a/TechDocs/Markdown/Tutorial/Troubleshooting_Communications.md
+++ b/TechDocs/Markdown/Tutorial/Troubleshooting_Communications.md
@@ -220,4 +220,4 @@ see what happens. The pccom communication is
 bi-directional, so you may use the above tests just as well, 
 substituting the word "host" for "target," and vice versa.
 
-[Documents and Displays](Documents_and_Displays.md) <-- &nbsp;&nbsp; [table of contents](../Tutorial.md) 
+[Documents and Displays](Documents_and_Displays.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) 

--- a/TechDocs/Markdown/Tutorial/Views_and_Visual_Objects.md
+++ b/TechDocs/Markdown/Tutorial/Views_and_Visual_Objects.md
@@ -1453,4 +1453,4 @@ sd mchrt
 run mchrt
 ~~~
 
-[Data Structures and UI Gadgetry](Data_Structures_and_UI_Gadgetry.md) <-- &nbsp;&nbsp; [table of contents](../Tutorial.md) &nbsp;&nbsp; --> [Troubleshooting Communications](Troubleshooting_Communications.md)
+[Data Structures and UI Gadgetry](Data_Structures_and_UI_Gadgetry.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Troubleshooting Communications](Troubleshooting_Communications.md)

--- a/TechDocs/Markdown/Tutorial/Views_and_Visual_Objects.md
+++ b/TechDocs/Markdown/Tutorial/Views_and_Visual_Objects.md
@@ -1453,4 +1453,4 @@ sd mchrt
 run mchrt
 ~~~
 
-[Data Structures and UI Gadgetry](Data_Structures_and_UI_Gadgetry.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Troubleshooting Communications](Troubleshooting_Communications.md)
+[Data Structures and UI Gadgetry](Data_Structures_and_UI.md) <-- &nbsp;&nbsp; [table of contents](../tutorial.md) &nbsp;&nbsp; --> [Troubleshooting Communications](Troubleshooting_Communications.md)


### PR DESCRIPTION
...after running a link checker on the documentation site.

Also changes the main README.md to point to the deployed version of the documentation.