### PR TITLE
Fix spurious glue failures when building browser

### DIFF
--- a/Tools/geodump/geodis.c
+++ b/Tools/geodump/geodis.c
@@ -260,16 +260,16 @@ char *test_fixup(unsigned ofs,int type,char *buf,int addinfo)
                                         // has already been removed, so ignore
                                         // missing fixup)
       sprintf(buffer,(type==4)?"%s":"offset %s",
-         create_label(*(unsigned *)(buf+dist),*(unsigned *)buf,'H'));
+         create_label(*(unsigned short *)(buf+dist),*(unsigned short *)buf,'H'));
                                         // successive segment/offset is as
                                         // good as a seg/ofs single fixup
-      add_global_jmp(*(unsigned *)(buf+dist),*(unsigned *)buf,NULL,0);
+      add_global_jmp(*(unsigned short *)(buf+dist),*(unsigned short *)buf,NULL,0);
       if((dist<0 || type==4) && j<code_fixlen) code_fixup[j].ofs=0xFFFF;
                                         // segment fixup has been handled
     }
     else if(type==2 && addinfo==0xFFFF) {
-      strcpy(buffer, create_label(0xFFFF,*(unsigned *)buf,'H') );
-      add_global_jmp(this_seg,*(unsigned *)buf,NULL,0);
+      strcpy(buffer, create_label(0xFFFF,*(unsigned short *)buf,'H') );
+      add_global_jmp(this_seg,*(unsigned short *)buf,NULL,0);
     }
     else
       return NULL;
@@ -283,8 +283,8 @@ char *test_fixup(unsigned ofs,int type,char *buf,int addinfo)
     if((code_fixup[i].type & 0xFE)==0x22) {
       dist = (addinfo & 0x0FFF)-0x800;  // extract distance
       sprintf(buffer,"seg %s",
-         create_label(*(unsigned *)buf,*(unsigned *)(buf+dist),'H'));
-      add_global_jmp(*(unsigned *)buf,*(unsigned *)(buf+dist),NULL,0);
+         create_label(*(unsigned short *)buf,*(unsigned short *)(buf+dist),'H'));
+      add_global_jmp(*(unsigned short *)buf,*(unsigned short *)(buf+dist),NULL,0);
     }
   }
 
@@ -309,24 +309,24 @@ char *test_fixup(unsigned ofs,int type,char *buf,int addinfo)
       switch(code_fixup[i].type & 0xFF) {
       case 0x11:                        // offset of library entry
         strcpy(buffer,"offset ");
-        create_libref(buffer+strlen(buffer),buf2,*(unsigned *)buf);
+        create_libref(buffer+strlen(buffer),buf2,*(unsigned short *)buf);
         break;
       case 0x12:                        // segment of library entry
         strcpy(buffer,"segment ");
-        create_libref(buffer+strlen(buffer),buf2,*(unsigned *)buf);
+        create_libref(buffer+strlen(buffer),buf2,*(unsigned short *)buf);
         break;
       case 0x13:                        // handle of library
         sprintf(buffer,"handle %s",buf2);
         break;
       case 0x22:                        // fixup program segments
-        if(*(unsigned *)buf!=1)
-          sprintf(buffer,"SEG%u",*(unsigned *)buf);
+        if(*(unsigned short *)buf!=1)
+          sprintf(buffer,"SEG%u",*(unsigned short *)buf);
         else
           strcpy(buffer,"dgroup");      // special case for default data segment
         break;
       case 0x23:                        // fixup handles of program segments
-        if(*(unsigned *)buf)
-          sprintf(buffer,"handle SEG%u",*(unsigned *)buf);
+        if(*(unsigned short *)buf)
+          sprintf(buffer,"handle SEG%u",*(unsigned short *)buf);
         else
           strcpy(buffer,"handle 0");    // special case for CoreBlock
         break;
@@ -337,7 +337,7 @@ char *test_fixup(unsigned ofs,int type,char *buf,int addinfo)
     case 4:
       switch(code_fixup[i].type & 0xFF) {
       case 0x00:
-        create_libref(buffer,"geos",*(unsigned *)buf);
+        create_libref(buffer,"geos",*(unsigned short *)buf);
         break;
       case 0x11:                        // offset of library entry
                                         // segment might follow...
@@ -347,17 +347,17 @@ char *test_fixup(unsigned ofs,int type,char *buf,int addinfo)
             j++)
           ;
         if(j==code_fixlen) return NULL;
-        create_libref(buffer,buf2,*(unsigned *)buf);
+        create_libref(buffer,buf2,*(unsigned short *)buf);
                                         // successive segment/offset is as
                                         // good as a seg/ofs single fixup
         code_fixup[j].ofs=0xFFFF;       // segment fixup has been handled
         break;
       case 0x14:
-        create_libref(buffer,buf2,*(unsigned *)buf);
+        create_libref(buffer,buf2,*(unsigned short *)buf);
         break;
       case 0x24:
-        strcpy(buffer,create_label(*(unsigned *)buf,*(unsigned *)(buf+2),'H'));
-        add_global_jmp(*(unsigned *)buf,*(unsigned *)(buf+2),NULL,0);
+        strcpy(buffer,create_label(*(unsigned short *)buf,*(unsigned short *)(buf+2),'H'));
+        add_global_jmp(*(unsigned short *)buf,*(unsigned short *)(buf+2),NULL,0);
         break;
       default: return NULL;
       }

--- a/Tools/geodump/geodump.c
+++ b/Tools/geodump/geodump.c
@@ -614,7 +614,7 @@ void DisplayDbHdr(FILE *f,long pos,unsigned size)
 
         GetStructP(dh,pos);             // Get header block
         printf("      Mem Hdl: [%04x]    Map: Group/Item:[%04x]/<%04x>  _x: %04x\n",
-               dh.seg,dh.prim.group,dh.prim.item,dh._x);
+               dh.seg,dh.prim.group,dh.prim.item,dh.x);
 }
 
 void DisplayIdx(FILE *f,long pos,unsigned size)
@@ -641,7 +641,7 @@ void DisplayIdx(FILE *f,long pos,unsigned size)
             i+=sizeof(GEOSdbitemlist)) {
                                         // Dump items
           while(i==nextfree && nextfree) {
-            nextfree = *(unsigned *)(bl+i);
+            nextfree = *(unsigned short *)(bl+i);
                                         // Get pointer to next free entry
             i+=sizeof(GEOSdbitemlist);  // Skip over free entry
           }

--- a/Tools/glue/msobj.c
+++ b/Tools/glue/msobj.c
@@ -2504,7 +2504,8 @@ MSObj_PerformRelocations(const char	*file,	    /* Name of object file */
 				if ((os != NULL) &&
 				    ((os->type == OSYM_PROC) ||
 				     (os->type == OSYM_LABEL) ||
-				     (os->type == OSYM_LOCLABEL)))
+				     (os->type == OSYM_LOCLABEL) ||
+				     (os->type == OSYM_PROTOMINOR)))
 				{
 				    offset += fixme[0] | (fixme[1] << 8);
 

--- a/Tools/glue/obj.c
+++ b/Tools/glue/obj.c
@@ -2384,12 +2384,12 @@ Obj_EnterTypeSyms(const char   	*file,	/* File name */
 
 	data.types = osh->types;
 	data.nextType = (ObjType *)VMLock(symbols, data.types, &data.tmem);
+	MemInfo(data.tmem, (genptr *)NULL, &n);
 	data.typeSize = n;
 	data.typeOff = sd->typeNext;
 	data.nextType = (ObjType *)((genptr)data.nextType + data.typeOff);
 
 	VMUnlock(symbols, sd->symT);
-	MemInfo(data.tmem, (genptr *)NULL, &n);
     } else {
 	/*
 	 * Neither symbol block nor type block can we use -- record this.

--- a/Tools/glue/pass2ms.c
+++ b/Tools/glue/pass2ms.c
@@ -891,6 +891,7 @@ Pass2MSProcessRels(const char 	*file,	    /* Object file being read */
 	unsigned    len = (genptr)nextRel - (genptr)rbase;
 
 	assert(((byte *)rbase)[0] != 0);
+	assert(len <= (unsigned)(sd->nrel * fileOps->rtrelsize));
 
 	Out_Block(sd->roff, rbase, len);
 	sd->roff += len;


### PR DESCRIPTION
This patch should resolve the issues that we have occasionally seen when build `bbxbrow.geo` (#120). There are actually two separate issues that caused build failures through memory overwrites:

- An uninitialized variable because of a wrong order of function calls (this is the main cause of #120).
- A less common bug that results from inconsistent calculation of relocations between pass1 and pass2 in glue: what happens is that glue tries to predict the number of relocations in each segment in pass 1 and then builds the actual relocations in pass 2, sometimes adjusting the count. However, with Watcom this fails for the special case of the pseudo-symbols created for "protominor" versions in libraries. These are predicted as function pointers with 1 combined relocation for segment+offset, while pass2 does not expect this type of relocation to occur for protominor symbols and therefore misses the adjustment from 2 to 1 relocations. As a result, pass2 only allocates memory for 1 relocation for each symbol, but eventually writes out 2 of them, causing an out-of-bounds write.

This patch fixes both issues and adds an assert to catch the second one more reliably.

I have also included some small fixes to _geodump_ that resolve an issue with reloc parsing when trying to use the disassembler.

Fixes #120.