### PR TITLE
Gourmet Textzeile abgeschnitten. #413

### DIFF
--- a/Appl/Breadbox/BBGrmt/RBOXUI.goc
+++ b/Appl/Breadbox/BBGrmt/RBOXUI.goc
@@ -1812,10 +1812,12 @@
                              0,                     /* left */
                              0,      /* top */
                              (6.5*72),                 /* right */
-			     ((9*72) - 6));   /* bottom */
-                         /* the -6 is a half line offset to prevent
+			     (9*72));   /* bottom */
+                         /*  ORIGINAL WAS ((9*72) - 6)); */
+			 /*   the -6 is a half line offset to prevent
                             an extra line from printing at the bottom
-                            of a page */
+                            of a page 
+                            REMOVED PRINT ONE HALF LINE IN FREEGEOS */
 
        /* Translate the gstate to selected page */
        GrApplyTranslationDWord(gstate, 0,


### PR DESCRIPTION
Gourmet Textzeile abgeschnitten. #413

LÖSUNG :
   GrSetClipRect(gstate, PCT_REPLACE,
                         0,                     /* left */
                         0,      /* top */
                         (6.5 * 72),                 /* right */
		         (9 * 72));   /* bottom */  
   Die -6 entfernt und es getestet mit Druck in PS Datei.

![GOURMET-DRUCK](https://github.com/bluewaysw/pcgeos/assets/118665816/eefb6765-7695-45c2-bc18-dc2e2b103e17)
