### PR TITLE
Gourmet updated.

### DIFF
--- a/Appl/Breadbox/BBGrmt/RBOXUI.goc
+++ b/Appl/Breadbox/BBGrmt/RBOXUI.goc
@@ -1812,12 +1812,11 @@
                              0,                     /* left */
                              0,      /* top */
                              (6.5*72),                 /* right */
-			     (9*72));   /* bottom */
-                         /*  ORIGINAL WAS ((9*72) - 6)); */
-			 /*   the -6 is a half line offset to prevent
+			         ((9*72)-7));   /* bottom */
+                         /* the -6 is a half line offset to prevent
                             an extra line from printing at the bottom
                             of a page 
-                            REMOVED PRINT ONE HALF LINE IN FREEGEOS */
+				  changed to -7 for FreeGeos */
 
        /* Translate the gstate to selected page */
        GrApplyTranslationDWord(gstate, 0,


### PR DESCRIPTION
Gourmet updated RBOXUI.goc addded  -7 tested print to PS file , was before double print of the last line in the new side if reciept was longer than 1 side.
In PR before i have just entered TEST in receipt so i could not see this error.
![image](https://github.com/bluewaysw/pcgeos/assets/118665816/c2355fda-14ef-4bd2-9b06-6f23b8e579a3)
