### PR TITLE
Fix inability to connect with PPP in Watcom build

### DIFF
--- a/Driver/Socket/PPP/fsm.goc
+++ b/Driver/Socket/PPP/fsm.goc
@@ -1011,13 +1011,12 @@ void fsm_event (fsm *f,
     MemLock(OptrToHandle(@fsm_array));
     table = (NearCallback **)LMemDeref(@fsm_array);
 
-#ifdef __HIGHC__
-    (*table[ev * NUM_STATES + f -> state])(f);
-#endif
 #ifdef __BORLANDC__
     /* BorlandC doesn't recognize that the table has near pointers */
     (byte *)table += (ev * NUM_STATES + f->state) * 2;
     (*table)(f);
+#else
+    (*table[ev * NUM_STATES + f -> state])(f);
 #endif
 
     MemUnlock(OptrToHandle(@fsm_array));


### PR DESCRIPTION
With this fix, connecting via PPP works again (tested with a local pppd in the WSL).

What happened was that the Watcom build effectively ifdef'd out the call to advance the state machine for the current protocol, leading to all PPP protocols (especially LCP) getting stuck in "initial" state.