### PR TITLE
Fix copy-if-different

### DIFF
--- a/Include/Win32/geode.mk
+++ b/Include/Win32/geode.mk
@@ -335,10 +335,10 @@ SETLIBFLAG	= -l
 # script or something, say, called "diffcopy".  For now, we just
 # copy the file over.
 #
-$(LIBOBJ:S/:/\\:/g)       : $(LIBOBJ:T) .NOEXPORT .IGNORE
+$(LIBOBJ:S/:/\\:/g)       : $(LIBOBJ:T) .NOEXPORT
 	$(COPY_IF_DIFF) $(LIBOBJ:T) $(.TARGET)
 #  ifdef PRODUCT_LDFS
-$(LIBOBJ:H:S/:/\\:/g)/$(_COMMALDFS)/$(LIBOBJ:T)	: $(.TARGET:H:T)/$(LIBOBJ:T) .NOEXPORT .IGNORE
+$(LIBOBJ:H:S/:/\\:/g)/$(_COMMALDFS)/$(LIBOBJ:T)	: $(.TARGET:H:T)/$(LIBOBJ:T) .NOEXPORT
 	$(COPY_IF_DIFF) $(.TARGET:H:T)/$(LIBOBJ:T) $(.TARGET)
 #  endif
 

--- a/Tools/scripts/perl/copy-if-different
+++ b/Tools/scripts/perl/copy-if-different
@@ -36,14 +36,16 @@ die "copy-if-different: error: Source file '$source' does not exist\n"
 
 if (-e $dest) {
     #require "stat.pl";
+    $ST_SIZE = 7;
+    $ST_BLKSIZE = 11;
 
     #
     # Both files exist.  Find out how big the source and dest are.
     #
-    local(@sourceStats) = stat($source)
-	|| die "copy-if-different: Cannot access '$source:' $!\n";
-    local(@destStats) = stat($dest)
-	|| die "copy-if-different: Cannot access '$dest:' $!\n";;
+    @sourceStats = stat($source);
+    die "copy-if-different: Cannot access '$source:' $!\n" if (!@sourceStats);
+    @destStats = stat($dest);
+    die "copy-if-different: Cannot access '$dest:' $!\n" if (!@destStats);
 
     #
     # Only if the files are both the same do we need to open 'em up


### PR DESCRIPTION
The updating of ldf files often failed, if there was already an existing copy:

The reason is that the code of `copy-if-different` just never worked correctly and failed to get the sizes of the files. So, if the new file was larger than the old one, the tool would run into a read error and fail (and this failure was ignored in the `geode.mk` makefile to make the build run through, but potentially incorrect library imports and published functions).