### PR TITLE
GEOS.INI: 'German keyboard' replaced by 'German extended keyboard'

### DIFF
--- a/Tools/build/product/bbxensem/Template/geos.ini
+++ b/Tools/build/product/bbxensem/Template/geos.ini
@@ -182,8 +182,8 @@ NTDEMO(info = 0)
 [keyboard]
 AMENGLISH(PCDEMO(driver = kbd.geo))
 AMENGLISH(NTDEMO(driver = kbd.geo))
-GERMAN(NTDEMO(driver = German Keyboard Driver))
-GERMAN(NTDEMO(device = Deutsche Tastatur))
+GERMAN(NTDEMO(driver = German Extended Keyboard Driver))
+GERMAN(NTDEMO(device = Deutsche erweiterte Tastatur))
 [heapspace]
 heapSpaceLimitsEnforced = false
 


### PR DESCRIPTION
The extended keyboard is the standard keyboard used today and contains 102 keys. The currently activated keyboard layout does not contain some keys or contains them at the wrong position. For example # and ^. 