### PR TITLE
Update geos.ini

### DIFF
--- a/Tools/build/product/bbxensem/Template/geos.ini
+++ b/Tools/build/product/bbxensem/Template/geos.ini
@@ -301,7 +301,8 @@ usenet = false
 wakeupOptions = 224
 inputOptions = 0
 lockScreen = 1
-specific = EC-long(Last Words)
+AMENGLISH(NTDEMO(specific = EC-long(Last Words))
+GERMAN(NTDEMO(specific = EC-long(Infotext))
 
 [preflvl]
 resetAppCategories = {
@@ -350,7 +351,7 @@ lwfont = 4608
 size = 72
 color = 15
 type = 1
-message = {}
+message = PC/GEOS
 angle = 0
 randomangle = 0
 motion = 0


### PR DESCRIPTION
Update geos.ini
Correcting Lat words for German Infotext
Added Text PC/GEOS for Screensaver Last words and Infotext.

![image](https://github.com/bluewaysw/pcgeos/assets/118665816/cfe37bf7-3b54-432a-ae19-0ea03d99a869)
