### PR TITLE
Update geos.ini

### DIFF
--- a/Tools/build/product/bbxensem/Template/geos.ini
+++ b/Tools/build/product/bbxensem/Template/geos.ini
@@ -301,7 +301,9 @@ usenet = false
 wakeupOptions = 224
 inputOptions = 0
 lockScreen = 1
-specific = EC-long(Last Words)
+AMENGLISH(PCDEMO(specific = EC-long(Last Words))
+AMENGLISH(NTDEMO(specific = EC-long(Last Words))
+GERMAN(NTDEMO(specific = EC-long(Infotext))
 
 [preflvl]
 resetAppCategories = {
@@ -349,8 +351,8 @@ canSlash = true
 lwfont = 4608
 size = 72
 color = 15
-type = 1
-message = {}
+type = 0
+message = PC/GEOS Ensemble
 angle = 0
 randomangle = 0
 motion = 0


### PR DESCRIPTION
Update GEOS.INI for Screensaver Last words and german Infotext. Added Text "PC/GEOS Ensemble" why Last words Graphicfile is not working.

![image](https://github.com/bluewaysw/pcgeos/assets/118665816/6548ceea-e777-45f3-9a29-c87d1b2e2019)
