### PR TITLE
Tokenload

### DIFF
--- a/CInclude/token.h
+++ b/CInclude/token.h
@@ -85,7 +85,7 @@ extern Boolean /*XXX*/
 		       VisMonikerSearchFlags searchFlags,
 		       TokenMonikerInfo *tokenMonikerInfo);
 
-extern Boolean /*XXX*/
+extern Boolean
     _pascal TokenLoadMonikerBlock(dword tokenChars,
 			  ManufacturerID manufacturerID,
 			  DisplayType displayType,
@@ -93,7 +93,7 @@ extern Boolean /*XXX*/
 			  word *blockSize,
 			  MemHandle *blockHandle);
 
-extern Boolean /*XXX*/
+extern Boolean 
     _pascal TokenLoadMonikerChunk(dword tokenChars,
 			  ManufacturerID manufacturerID,
 			  DisplayType displayType,
@@ -102,7 +102,7 @@ extern Boolean /*XXX*/
 			  word *chunkSize,
 			  ChunkHandle *chunkHandle);
 
-extern Boolean /*XXX*/
+extern Boolean 
     _pascal TokenLoadMonikerBuffer(dword tokenChars,
 			   ManufacturerID manufacturerID,
 			   DisplayType displayType,
@@ -117,20 +117,20 @@ extern Boolean /*XXX*/
 extern void /*XXX*/
     _pascal TokenGetTokenStats(dword tokenChars, ManufacturerID manufacturerID);
 
-extern Boolean /*XXX*/
+extern Boolean 
     _pascal TokenLoadTokenBlock(dword tokenChars,
 			ManufacturerID manufacturerID,
 			word *blockSize,
 			MemHandle *blockHandle);
 
-extern Boolean /*XXX*/
+extern Boolean 
     _pascal TokenLoadTokenChunk(dword tokenChars,
 			ManufacturerID manufacturerID,
 			MemHandle lmemBlock,
 			word *chunkSize,
 			ChunkHandle *chunkHandle);
 
-extern Boolean /*XXX*/
+extern Boolean 
     _pascal TokenLoadTokenBuffer(dword tokenChars,
 			 ManufacturerID manufacturerID,
 			 TokenEntry *buffer);

--- a/Library/User/Token/tokenC.asm
+++ b/Library/User/Token/tokenC.asm
@@ -413,6 +413,10 @@ TOKENLOADTOKENBLOCK	proc	far	tokenChars:dword,
 	clr	cx			; allocate global heap block
 	call	TokenLoadToken		; cx = #bytes, di = block
 					; carry clear if found
+	jnc 	foundit
+	mov	cx, 0			; return zero block and #bytes
+	mov	di, 0			; preserve carry
+foundit:	
 	les	si, blockSize
 	mov	es:[si], cx		; return #bytes
 	les	si, blockHandle
@@ -457,6 +461,10 @@ TOKENLOADTOKENCHUNK	proc	far	tokenChars:dword,
 	clr	di			; cx = lmemBlock
 	call	TokenLoadToken		; cx = #bytes, di = lmem chunk
 					; carry clear if found
+	jnc 	foundit
+	mov	cx, 0			; return zero chunk handle and #bytes
+	mov	di, 0			; preserve carry
+foundit:	
 	les	si, chunkSize
 	mov	es:[si], cx		; return #bytes
 	les	si, chunkHandle

--- a/Library/User/Token/tokenC.asm
+++ b/Library/User/Token/tokenC.asm
@@ -196,6 +196,10 @@ TOKENLOADMONIKERBLOCK	proc	far	tokenChars:dword,
 	push	cx			; unused buffer size
 	call	TokenLoadMoniker	; cx = #bytes, di = block
 					; carry clear if found
+	jnc 	foundit
+	mov	cx, 0			; return zero block and #bytes
+	mov	di, 0			; preserve carry
+foundit:	
 	les	si, blockSize
 	mov	es:[si], cx		; return #bytes
 	les	si, blockHandle
@@ -247,6 +251,10 @@ TOKENLOADMONIKERCHUNK	proc	far	tokenChars:dword,
 	push	di			; unused buffer size
 	call	TokenLoadMoniker	; cx = #bytes, di = lmem chunk
 					; carry clear if found
+	jnc 	foundit
+	mov	cx, 0			; return zero chunk handle and #bytes
+	mov	di, 0			; preserve carry
+foundit:	
 	les	si, chunkSize
 	mov	es:[si], cx		; return #bytes
 	les	si, chunkHandle
@@ -298,6 +306,10 @@ TOKENLOADMONIKERBUFFER	proc	far	tokenChars:dword,
 	push	bufferSize		; pass size on stack
 	call	TokenLoadMoniker	; cx = #bytes
 					; carry clear if found
+	jnc 	foundit
+	mov	cx, 0			; return #bytes = 0
+					; preserve carry
+foundit:	
 	les	di, bytesReturned
 	mov_tr	ax, cx
 	stosw				; return #bytes

--- a/TechDocs/Markdown/Routines/rroutq_t.md
+++ b/TechDocs/Markdown/Routines/rroutq_t.md
@@ -2401,8 +2401,8 @@ pointers to any chunk in the block.
 			word			* blockSize,		/* returned size of new block */
 			MemHandle		* blockHandle);		/* returned handle of block */
 This routine loads the specified token's **TokenEntry** structure into a 
-newly-allocated global memory block. If the token is not found, the returned 
-error flag will be *true*; otherwise, it will be *false*.
+newly-allocated global memory block. The returned Boolean will be *true* if the 
+token was found, *false* otherwise.
 
 Pass this routine the following:
 
@@ -2428,7 +2428,7 @@ newly-allocated block will be returned.
 			ManufacturerID	manufacturerID,		/* manufacturer ID of token */
 			TokenEntry		* buffer);			/* buffer for returned token */
 This routine loads the specified token's **TokenEntry** structure into a passed 
-buffer. The returned error flag will be *true* if the token was not found, *false* 
+buffer. The returned Boolean will be *true* if the token was found, *false* 
 otherwise. Pass this routine the following:
 
 *tokenChars* - The four token characters that identify the token database 
@@ -2452,8 +2452,8 @@ will be copied.
 			word			* chunkSize,		/* returned size of new chunk */
 			ChunkHandle		* chunkHandle);		/* returned chunk handle */
 This routine loads the specified token's **TokenEntry** structure into a 
-newly-allocated chunk. The returned error flag will be *true* if the token could 
-not be found, *false* otherwise.
+newly-allocated chunk. The returned Boolean will be *true* if the token was found, 
+*false* otherwise.
 
 Pass this routine the following:
 

--- a/TechDocs/Markdown/Routines/rroutq_t.md
+++ b/TechDocs/Markdown/Routines/rroutq_t.md
@@ -2280,8 +2280,8 @@ This routine extracts the MemHandle from the value returned by
 			word					* blockSize,	/* returned block size */
 			MemHandle				* blockHandle);	/* returned block handle */
 This routine loads a specified token's moniker, allocating a new global 
-memory block for the moniker. The returned Boolean will be *false* if the 
-moniker was found, *true* otherwise. Information about the moniker is 
+memory block for the moniker. The returned Boolean will be *true* if the 
+moniker was found, *false* otherwise. Information about the moniker is 
 returned in the values pointed to by *blockSize* (the size of the newly allocated 
 block) and *blockHandle* (the handle of the new block). If the moniker is not 
 found, both return pointers will be NULL and no block will be allocated.
@@ -2320,7 +2320,7 @@ returned.
 			word					bufSize,			/* size of passed buffer */
 			word					* bytesReturned);	/* number of bytes returned */
 This routine loads a specified token's moniker into a provided buffer. The 
-return value will be *false* if the moniker was found, *true* otherwise. The size 
+returned Boolean will be *true* if the moniker was found, *false* otherwise. The size 
 of the returned moniker will be returned in the word pointed to by the 
 *bytesReturned* parameter.
 
@@ -2360,8 +2360,8 @@ moniker that may be returned.
 			word					* chunkSize,	/* returned new chunk size */
 			ChunkHandle				* chunkHandle);	/* returned new chunk handle */
 This routine loads a specified token's moniker, allocating a new chunk in a 
-local memory block for the moniker. The returned error flag will be *true* if the 
-moniker was not found, *false* otherwise.
+local memory block for the moniker. The returned Boolean will be *true* if the 
+moniker was found, *false* otherwise.
 
 Pass this routine the following:
 

--- a/TechDocs/ascii/Routines/rroutq-t.txt
+++ b/TechDocs/ascii/Routines/rroutq-t.txt
@@ -2963,8 +2963,8 @@ Boolean	TokenLoadMonikerBlock(
 	MemHandle		* blockHandle);					/* returned block handle */
 
 This routine loads a specified token's moniker, allocating a new global 
-memory block for the moniker. The returned Boolean will be false if the 
-moniker was found, true otherwise. Information about the moniker is 
+memory block for the moniker. The returned Boolean will be true if the 
+moniker was found, false otherwise. Information about the moniker is 
 returned in the values pointed to by blockSize (the size of the newly allocated 
 block) and blockHandle (the handle of the new block). If the moniker is not 
 found, both return pointers will be NULL and no block will be allocated.
@@ -3015,7 +3015,7 @@ Boolean	TokenLoadMonikerBuffer(
 	word		* bytesReturned);						/* number of bytes returned */
 
 This routine loads a specified token's moniker into a provided buffer. The 
-return value will be false if the moniker was found, true otherwise. The size 
+returned Boolean will be true if the moniker was found, false otherwise. The size 
 of the returned moniker will be returned in the word pointed to by the 
 bytesReturned parameter.
 
@@ -3067,8 +3067,8 @@ Boolean	TokenLoadMonikerChunk(
 	ChunkHandle		* chunkHandle);					/* returned new chunk handle */
 
 This routine loads a specified token's moniker, allocating a new chunk in a 
-local memory block for the moniker. The returned error flag will be true if the 
-moniker was not found, false otherwise.
+local memory block for the moniker. The returned Boolean will be true if the 
+moniker was found, false otherwise.
 
 Pass this routine the following:
 
@@ -3117,8 +3117,8 @@ Boolean	TokenLoadTokenBlock(
 	MemHandle		* blockHandle);					/* returned handle of block */
 
 This routine loads the specified token's TokenEntry structure into a 
-newly-allocated global memory block. If the token is not found, the returned 
-error flag will be true; otherwise, it will be false.
+newly-allocated global memory block. The returned Boolean will be true if the 
+token was found, false otherwise.
 
 Pass this routine the following:
 
@@ -3150,7 +3150,7 @@ Boolean	TokenLoadTokenBuffer(
 	TokenEntry		* buffer);					/* buffer for returned token */
 
 This routine loads the specified token's TokenEntry structure into a passed 
-buffer. The returned error flag will be true if the token was not found, false 
+buffer. The returned Boolean will be true if the token was found, false 
 otherwise. Pass this routine the following:
 
 tokenChars	The four token characters that identify the token database 
@@ -3181,8 +3181,8 @@ Boolean	TokenLoadTokenChunk(
 	ChunkHandle		* chunkHandle);					/* returned chunk handle */
 
 This routine loads the specified token's TokenEntry structure into a 
-newly-allocated chunk. The returned error flag will be true if the token could 
-not be found, false otherwise.
+newly-allocated chunk. The returned Boolean will be true if the 
+token was found, false otherwise.
 
 Pass this routine the following:
 

--- a/TechDocs/html/CRef/Routines/R_9b.htm
+++ b/TechDocs/html/CRef/Routines/R_9b.htm
@@ -157,9 +157,9 @@ TokenLoadMonikerBlock()</H1>
         MemHandle		* blockHandle);					/* returned block handle */</PRE>
 <P>
 This routine loads a specified token's moniker, allocating a new global memory block for the moniker. The returned Boolean will be <CODE>
-false</CODE>
- if the moniker was found, <CODE>
 true</CODE>
+ if the moniker was found, <CODE>
+false</CODE>
  otherwise. Information about the moniker is returned in the values pointed to by <CODE>
 blockSize</CODE>
  (the size of the newly allocated block) and <CODE>

--- a/TechDocs/html/CRef/Routines/R_9c.htm
+++ b/TechDocs/html/CRef/Routines/R_9c.htm
@@ -35,10 +35,10 @@ TokenLoadMonikerBuffer()</H1>
         word		bufSize,					/* size of passed buffer */
         word		* bytesReturned);						/* number of bytes returned */</PRE>
 <P>
-This routine loads a specified token's moniker into a provided buffer. The return value will be <CODE>
-false</CODE>
- if the moniker was found, <CODE>
+This routine loads a specified token's moniker into a provided buffer. The returned Boolean will be <CODE>
 true</CODE>
+ if the moniker was found, <CODE>
+false</CODE>
  otherwise. The size of the returned moniker will be returned in the word pointed to by the <CODE>
 bytesReturned</CODE>
  parameter.</P>
@@ -101,9 +101,9 @@ TokenLoadMonikerChunk()</H1>
         word		* chunkSize,					/* returned new chunk size */
         ChunkHandle		* chunkHandle);					/* returned new chunk handle */</PRE>
 <P>
-This routine loads a specified token's moniker, allocating a new chunk in a local memory block for the moniker. The returned error flag will be <CODE>
+This routine loads a specified token's moniker, allocating a new chunk in a local memory block for the moniker. The returned Boolean will be <CODE>
 true</CODE>
- if the moniker was not found, <CODE>
+ if the moniker was found, <CODE>
 false</CODE>
  otherwise.</P>
 <P>

--- a/TechDocs/html/CRef/Routines/R_9c.htm
+++ b/TechDocs/html/CRef/Routines/R_9c.htm
@@ -166,9 +166,9 @@ TokenLoadTokenBlock()</H1>
 <P>
 This routine loads the specified token's <CODE>
 TokenEntry</CODE>
- structure into a newly-allocated global memory block. If the token is not found, the returned error flag will be <CODE>
+ structure into a newly-allocated global memory block. The returned Boolean will be <CODE>
 true</CODE>
-; otherwise, it will be <CODE>
+if the token was found; otherwise, it will be <CODE>
 false</CODE>
 .</P>
 <P>
@@ -210,11 +210,10 @@ TokenLoadTokenBuffer()</H1>
 <P>
 This routine loads the specified token's <CODE>
 TokenEntry</CODE>
- structure into a passed buffer. The returned error flag will be <CODE>
+ structure into a passed buffer. The returned Boolean will be <CODE>
 true</CODE>
- if the token was not found, <CODE>
-false</CODE>
- otherwise. Pass this routine the following:</P>
+if the token was found; otherwise, it will be <CODE>
+false</CODE>. Pass this routine the following:</P>
 <DL>
 <DT>
 <CODE>

--- a/TechDocs/html/CRef/Routines/R_9d.htm
+++ b/TechDocs/html/CRef/Routines/R_9d.htm
@@ -35,11 +35,11 @@ TokenLoadTokenChunk()</H1>
 <P>
 This routine loads the specified token's <CODE>
 TokenEntry</CODE>
- structure into a newly-allocated chunk. The returned error flag will be <CODE>
+ structure into a newly-allocated chunk. The returned Boolean will be <CODE>
 true</CODE>
- if the token could not be found, <CODE>
+if the token was found; otherwise, it will be <CODE>
 false</CODE>
- otherwise.</P>
+.</P>
 <P>
 Pass this routine the following:</P>
 <DL>


### PR DESCRIPTION
The documentation for TokenLoadMoniker~ and TokenLoadToken~ routines was wrong. They all return TRUE if the token was found.
Also, the routines now return zero values for mem handles, chunks and sizes if the moniker was not found.
