### PR TITLE
Fix calls to RT_CHILD and LOCAL_CHILD macros in Treplib library

### DIFF
--- a/Library/Breadbox/Treplib/trepcode.goc
+++ b/Library/Breadbox/Treplib/trepcode.goc
@@ -17,6 +17,7 @@
  |    Who  Date:     Comments:
  |    ---  --------  ---------
  |    LES  07/13/99  Created
+ |    RB   07/23/2024 Fix calls to RT_CHILD and LOCAL_CHILD macros
  |
  *-----------------------------------------------------------------------*/
 
@@ -94,35 +95,35 @@
         pself->GTRDI_standardUI = ConstructOptr(
                                       mem,
                                       OptrToChunk(@TextReportTop)) ;
-        @call oself::MSG_GEN_ADD_CHILD(@RT_CHILD(TextReportTop), CCO_LAST) ;
+        @call oself::MSG_GEN_ADD_CHILD(@RT_CHILD(@TextReportTop), CCO_LAST) ;
         app = GeodeGetAppObject(process) ;
         @call app::MSG_META_GCN_LIST_ADD(
-                  @RT_CHILD(TextReportPrintControl),
+                  @RT_CHILD(@TextReportPrintControl),
                   GAGCNLT_SELF_LOAD_OPTIONS,
                   MANUFACTURER_ID_GEOWORKS) ;
         @call app::MSG_META_GCN_LIST_ADD(
-                  @RT_CHILD(TextReportEditControl),
+                  @RT_CHILD(@TextReportEditControl),
                   GAGCNLT_SELF_LOAD_OPTIONS,
                   MANUFACTURER_ID_GEOWORKS) ;
         @call app::MSG_META_GCN_LIST_ADD(
-                  @RT_CHILD(TextReportViewControl),
+                  @RT_CHILD(@TextReportViewControl),
                   GAGCNLT_SELF_LOAD_OPTIONS,
                   MANUFACTURER_ID_GEOWORKS) ;
         @call app::MSG_META_GCN_LIST_ADD(
-                  @RT_CHILD(TextReportViewControl),
+                  @RT_CHILD(@TextReportViewControl),
                   MGCNLT_ACTIVE_LIST,
                   MANUFACTURER_ID_GEOWORKS) ;
         @call app::MSG_META_GCN_LIST_ADD(
-                  @RT_CHILD(TextReportViewControl),
+                  @RT_CHILD(@TextReportViewControl),
                   GAGCNLT_STARTUP_LOAD_OPTIONS,
                   MANUFACTURER_ID_GEOWORKS) ;
         @call (pself->GTRDI_standardUI)::MSG_GEN_SET_USABLE(VUM_DELAYED_VIA_UI_QUEUE) ;
-        @call (@RT_CHILD(TextReportPrintControl))::MSG_PRINT_CONTROL_SET_DOC_NAME_OUTPUT(oself);
-        @call @RT_CHILD(TextReportText)::MSG_VIS_TEXT_SET_OUTPUT(
+        @call (@RT_CHILD(@TextReportPrintControl))::MSG_PRINT_CONTROL_SET_DOC_NAME_OUTPUT(oself);
+        @call @RT_CHILD(@TextReportText)::MSG_VIS_TEXT_SET_OUTPUT(
                   ((dword)process)<<16) ;
     }
 
-    pcon = @RT_CHILD(TextReportPrintControl) ;
+    pcon = @RT_CHILD(@TextReportPrintControl) ;
 
     /* Determine if we need fax and add or delete it */
     ObjLockObjBlock(OptrToHandle(pcon)) ;
@@ -166,7 +167,7 @@
                      ATTR_PRINT_CONTROL_APP_UI,
                      sizeof(optr)) ;
             pself = ObjDerefGen(oself) ;
-            *p_link = @RT_CHILD(TextReportPrinterOptions) ;
+            *p_link = @RT_CHILD(@TextReportPrinterOptions) ;
         }
     }
     MemUnlock(OptrToHandle(pcon)) ;
@@ -283,7 +284,7 @@
     dword start ;
 
     if ((pself->GTRDI_destination) && (pself->GTRDI_generateMsg))  {
-        text = @RT_CHILD(TextReportText) ;
+        text = @RT_CHILD(@TextReportText) ;
         @call text::MSG_VIS_TEXT_DELETE_ALL() ;
         start = 0 ;
         @call text::MSG_VIS_TEXT_SET_LEFT_MARGIN(0, TEXT_ADDRESS_PAST_END, start) ;
@@ -501,9 +502,9 @@
     @callsuper();
 
     LMemReAlloc(
-        @LOCAL_CHILD(TextReportVLTextReportRegionArray),
+        @LOCAL_CHILD(@TextReportVLTextReportRegionArray),
         sizeof(ChunkArrayHeader));
-    cahp = LMemDeref(@LOCAL_CHILD(TextReportVLTextReportRegionArray));
+    cahp = LMemDeref(@LOCAL_CHILD(@TextReportVLTextReportRegionArray));
     cahp->CAH_count = 0;
     cahp->CAH_elementSize = sizeof(VisLargeTextRegionArrayElement);
     cahp->CAH_curOffset = 0;
@@ -768,7 +769,7 @@
 
 
     /* if user wants B/W printing */
-    if (@call @LOCAL_CHILD(BWPrintOpts)::MSG_GEN_ITEM_GROUP_GET_SELECTION() == 1)
+    if (@call @LOCAL_CHILD(@BWPrintOpts)::MSG_GEN_ITEM_GROUP_GET_SELECTION() == 1)
         @call self::MSG_VIS_TEXT_SET_COLOR(
             bwPrint,
             TEXT_ADDRESS_PAST_END,
@@ -815,7 +816,7 @@
         GrNewPage(gstate, PEC_FORM_FEED);
     }
 
-    @send @LOCAL_CHILD(TextReportPrintControl)::
+    @send @LOCAL_CHILD(@TextReportPrintControl)::
               MSG_PRINT_CONTROL_PRINTING_COMPLETED();
 
     /* reset things back to where the user had them */
@@ -974,7 +975,7 @@
 
     @callsuper();
 
-    text = @LOCAL_CHILD(TextReportText) ;
+    text = @LOCAL_CHILD(@TextReportText) ;
     /* Set up the geometry for the content so that the geometry manager
      * is not used. */
     pself->VI_attrs &= ~VA_MANAGED;
@@ -987,7 +988,7 @@
     @call oself::MSG_VIS_ADD_CHILD(text, CCO_FIRST);
 
     /* Set up the text object to be large */
-    parent = @call @LOCAL_CHILD(TextReportTop)::MSG_GEN_FIND_PARENT() ;
+    parent = @call @LOCAL_CHILD(@TextReportTop)::MSG_GEN_FIND_PARENT() ;
 	 file = @call parent::MSG_GEN_TEXT_REPORT_GET_FILE() ;
     @call text::MSG_VIS_TEXT_SET_VM_FILE(file);
     @call text::MSG_VIS_LARGE_TEXT_CREATE_DATA_STRUCTURES();
@@ -1032,8 +1033,8 @@
     @callsuper();
 
     /* Unlink the text object and destroy its ddata */
-    parent = @call @LOCAL_CHILD(TextReportTop)::MSG_GEN_FIND_PARENT() ;
-    text = @LOCAL_CHILD(TextReportText) ;
+    parent = @call @LOCAL_CHILD(@TextReportTop)::MSG_GEN_FIND_PARENT() ;
+    text = @LOCAL_CHILD(@TextReportText) ;
     @call text::MSG_VIS_TEXT_DELETE_ALL() ;
     @call text::MSG_VIS_TEXT_FREE_ALL_STORAGE(TRUE);
     @call text::MSG_VIS_TEXT_SET_VM_FILE(NullHandle);


### PR DESCRIPTION
This PR fixes  Outliner crash if choose printpreview. #597 
