### PR TITLE
Typing Error in geos.ini Section [uiFeatures] "launchLevle" fixed

### DIFF
--- a/Tools/build/product/bbxensem/Template/geos.ini
+++ b/Tools/build/product/bbxensem/Template/geos.ini
@@ -225,7 +225,7 @@ expressOptions = 4041
 docControlOptions = 0
 launchOptions = 32768
 launchModel = 2
-launchLevle = 3
+launchLevel = 3
 windowOptions = 0
 helpOptions = 0
 


### PR DESCRIPTION
Keyword launchLevel was typed wrong as launchLevle