### PR TITLE
Fix code segment pragmas in some apps

### DIFF
--- a/Appl/IDialup/IDInfo.goc
+++ b/Appl/IDialup/IDInfo.goc
@@ -65,7 +65,12 @@ word GetBaudRate(void);
 Boolean IAppRunning(void);
 void IDialupNotifyIdle(dword total);
 
+#ifdef __BORLANDC__
 #pragma codeseg IDINFO_TIMER_TEXT
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("IDINFO_TIMER_TEXT")
+#endif
 
 /***********************************************************************
  *	MSG_IDP_TIMER_HANDLE for IDialupProcessClass
@@ -208,7 +213,12 @@ void IDialupNotifyIdle(dword total);
     }
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg()
+#endif
 
 
 /***********************************************************************

--- a/Appl/PDFViewer/main/gfx.goc
+++ b/Appl/PDFViewer/main/gfx.goc
@@ -1896,7 +1896,12 @@ void GfxUpdateFont(Gfx *gfx) {
 }
 
 
+#ifdef __BORLANDC__
 #pragma codeseg GFXImage
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("GFXImage")
+#endif
 
 //------------------------------------------------------------------------
 // XObject operators

--- a/Appl/PDFViewer/main/stream.goc
+++ b/Appl/PDFViewer/main/stream.goc
@@ -975,7 +975,12 @@ long EOFStreamLookChar(Stream *str) {
 // ASCIIHexStream
 //------------------------------------------------------------------------
 
+#ifdef __BORLANDC__
 #pragma codeseg ASCIIHexStream
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("ASCIIHexStream")
+#endif
 
 void ASCIIHexStreamInit(Stream *str, Stream *str1) {
   StreamInit(str);
@@ -1166,7 +1171,12 @@ GBool ASCII85Stream::isBinary(GBool last) {
 // LZWStream
 //------------------------------------------------------------------------
 
+#ifdef __BORLANDC__
 #pragma codeseg LZWStream
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("LZWStream")
+#endif
 
 /* code copied from Acorn port of xpdf */
 
@@ -1358,7 +1368,12 @@ GBool LZWStreamIsBinary(Stream *str, GBool last) {
 // RunLengthStream
 //------------------------------------------------------------------------
 
+#ifdef __BORLANDC__
 #pragma codeseg RunLengthStream
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("RunLengthStream")
+#endif
 
 void RunLengthStreamInit(Stream *str, Stream *str1) {
   StreamInit(str);
@@ -1441,7 +1456,12 @@ long RunLengthStreamLookChar(Stream *str) {
 // CCITTFaxStream
 //------------------------------------------------------------------------
 
+#ifdef __BORLANDC__
 #pragma codeseg CCITTFaxStream
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("CCITTFaxStream")
+#endif
 
 void CCITTFaxStreamInit(Stream *str, Stream *str1, long encoding1, GBool byteAlign1,
 			       long columns1, long rows1, GBool black1) {
@@ -1872,7 +1892,12 @@ GBool CCITTFaxStream::isBinary(GBool last) {
 // DCTStream
 //------------------------------------------------------------------------
 
+#ifdef __BORLANDC__
 #pragma codeseg DCTStream
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("DCTStream")
+#endif
 
 // IDCT constants (20.12 fixed point format)
 #ifndef FP_IDCT
@@ -2891,7 +2916,12 @@ GBool DCTStream::isBinary(GBool last) {
 // FlateStream
 //------------------------------------------------------------------------
 
+#ifdef __BORLANDC__
 #pragma codeseg FlateStream
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("FlateStream")
+#endif
 
 @start FLATEDATA, data;
 

--- a/Appl/SafBuild/safbuildDoc.goc
+++ b/Appl/SafBuild/safbuildDoc.goc
@@ -20,6 +20,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg DocCode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DocCode")
+#endif
 
 void
 ResetQuestionUI(void);

--- a/Appl/SafBuild/safbuildQuestion.goc
+++ b/Appl/SafBuild/safbuildQuestion.goc
@@ -18,6 +18,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg UICode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("UICode")
+#endif
 
 
 /***********************************************************************

--- a/Appl/SafBuild/safbuildQuiz.goc
+++ b/Appl/SafBuild/safbuildQuiz.goc
@@ -19,6 +19,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg UICode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("UICode")
+#endif
 
 
 /***********************************************************************

--- a/Appl/SafBuild/safbuildVerify.goc
+++ b/Appl/SafBuild/safbuildVerify.goc
@@ -17,6 +17,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg DocCode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DocCode")
+#endif
 
 void
 VfyAppendChunk(optr textCh)

--- a/Appl/Safari2/safari2App.goc
+++ b/Appl/Safari2/safari2App.goc
@@ -22,6 +22,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg UtilCode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("UtilCode")
+#endif
 
 
 /***********************************************************************

--- a/Appl/Safari2/safari2File.goc
+++ b/Appl/Safari2/safari2File.goc
@@ -18,6 +18,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg UtilCode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("UtilCode")
+#endif
 
 
 /***********************************************************************

--- a/Appl/Safari2/safari2Game.goc
+++ b/Appl/Safari2/safari2Game.goc
@@ -21,6 +21,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg GameFileCode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("GameFileCode")
+#endif
 
 
 /**************************************************************

--- a/Appl/Safari2/safari2Timer.goc
+++ b/Appl/Safari2/safari2Timer.goc
@@ -20,6 +20,9 @@
 #ifdef __BORLANDC__
 #pragma codeseg UtilCode
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("UtilCode")
+#endif
 
 
 /***********************************************************************

--- a/Library/FlatFile/Database/ffDatabase.goc
+++ b/Library/FlatFile/Database/ffDatabase.goc
@@ -1492,6 +1492,9 @@ pragma Code ("DATABASEINITIALIZATION");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEINITIALIZATION
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEINITIALIZATION")
+#endif
 
 /***********************************************************************
 *
@@ -1558,6 +1561,9 @@ pragma Code ("DATABASEFIELDPROPERTIES");
 #endif
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEFIELDPROPERTIES
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEFIELDPROPERTIES")
 #endif
 
 /***********************************************************************
@@ -3997,6 +4003,9 @@ pragma Code("DATABASEDATAENTRYSUPPORT");
 #endif
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEDATAENTRYSUPPORT
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEDATAENTRYSUPPORT")
 #endif
 
 /***********************************************************************
@@ -7316,6 +7325,9 @@ pragma Code("DATABASENEWRECORDSUPPORT");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASENEWRECORDSUPPORT
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASENEWRECORDSUPPORT")
+#endif
 
 /***********************************************************************
  *
@@ -8083,6 +8095,9 @@ pragma Code ("DATABASEFILE");
 #endif
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEFILE
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEFILE")
 #endif
 
 

--- a/Library/FlatFile/Database/ffDatabaseCreate.goc
+++ b/Library/FlatFile/Database/ffDatabaseCreate.goc
@@ -23,6 +23,9 @@ pragma Code ("DATABASEFIELDCREATION");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEFIELDCREATION
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEFIELDCREATION")
+#endif
 
 @include <stdapp.goh>
 #include <geoworks.h>
@@ -3524,6 +3527,9 @@ pragma Code("DATABASEPAGENUMBERING");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEPAGENUMBERING
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEPAGENUMBERING")
+#endif
 
 /***********************************************************************
  *
@@ -4064,6 +4070,9 @@ pragma Code("DATABASETYPECONVERSION");
 #endif
 #ifdef __BORLANDC__
 #pragma codeseg DATABASETYPECONVERSION
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASETYPECONVERSION")
 #endif
 
 /***********************************************************************

--- a/Library/FlatFile/Database/ffDatabaseFieldOrder.goc
+++ b/Library/FlatFile/Database/ffDatabaseFieldOrder.goc
@@ -84,6 +84,9 @@ pragma Code ("DATABASEFIELDORDER");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEFIELDORDER
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEFIELDORDER")
+#endif
 
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Library/FlatFile/Database/ffDatabaseImpex.goc
+++ b/Library/FlatFile/Database/ffDatabaseImpex.goc
@@ -32,6 +32,9 @@ pragma Code ("DATABASEIMPEX");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEIMPEX
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEIMPEX")
+#endif
 
 @include <stdapp.goh>
 #include <system.h>

--- a/Library/FlatFile/Database/ffDatabaseLayout.goc
+++ b/Library/FlatFile/Database/ffDatabaseLayout.goc
@@ -23,6 +23,9 @@ pragma Code("DATABASELAYOUTMANAGEMENT");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASELAYOUTMANAGEMENT
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASELAYOUTMANAGEMENT")
+#endif
 
 typedef struct
 {
@@ -4408,6 +4411,9 @@ pragma Code ("DATABASEPRINT");
 #endif
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEPRINT
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEPRINT")
 #endif
 
 /***********************************************************************

--- a/Library/FlatFile/Database/ffDatabaseMeta.goc
+++ b/Library/FlatFile/Database/ffDatabaseMeta.goc
@@ -23,6 +23,9 @@ pragma Code ("DATABASEMETAHANDLERS");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEMETAHANDLERS
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEMETAHANDLERS")
+#endif
 
 @include <stdapp.goh>
 #include <system.h>

--- a/Library/FlatFile/Database/ffDatabaseParse.goc
+++ b/Library/FlatFile/Database/ffDatabaseParse.goc
@@ -23,6 +23,9 @@ pragma Code ("DATABASEPARSER");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASEPARSER
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASEPARSER")
+#endif
 
 @include <stdapp.goh>			/* PC/GEOS	*/
 #include <geoworks.h>

--- a/Library/FlatFile/Database/ffDatabaseSort.goc
+++ b/Library/FlatFile/Database/ffDatabaseSort.goc
@@ -128,6 +128,9 @@ pragma Code ("DATABASESORT");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASESORT
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASESORT")
+#endif
 
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Library/FlatFile/Database/ffDatabaseSubset.goc
+++ b/Library/FlatFile/Database/ffDatabaseSubset.goc
@@ -43,6 +43,9 @@ pragma Code ("DATABASESUBSET");
 #ifdef __BORLANDC__
 #pragma codeseg DATABASESET
 #endif
+#ifdef __WATCOMC__
+#pragma code_seg("DATABASESET")
+#endif
 
 
 /*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/Library/FlatFile/FieldProperties/ffFieldProperties.goc
+++ b/Library/FlatFile/FieldProperties/ffFieldProperties.goc
@@ -1246,7 +1246,7 @@ FFFPStoreFieldInfo(optr oself, Message messageToSendBack, FieldID colNum)
      * Create structure of field properties 
      */
     fpmbHandle = MemAlloc(sizeof(FFFieldPropertiesMessageBlock), 
-				HF_SHARABLE, 
+				HF_DYNAMIC | HF_SHARABLE, 
 				HAF_ZERO_INIT);
     /*
      * Was there enough memory? If not, notify the user and exit out


### PR DESCRIPTION
This fixes an issue I came across when looking at #438: some of our code still contains only the old, Borland-style code segment pragmas, so that splitting source files into multiple resources (to keep them below 10k) does not work everywhere. The streams code in the PDFViewer was the most severe case (>40k), but there are some other places as well.

I have not yet fixed this for the browser, HTML impex lib and mail app, as these are probably most useful on the _149-host-tcpip-socket-driver_ branch anyway at the moment. So I will fix them there first and wait for the merge of the internet connectivity to master.

This PR also fixes a small issue with flags on a memory allocation in GeoFile that I saw when smoketesting.