### PR TITLE
Tools: perform conversion of \n to \r\n line endings on Windows also in sprintf()

### DIFF
--- a/Tools/goc/output.c
+++ b/Tools/goc/output.c
@@ -1207,7 +1207,7 @@ OutputLineNumberWithCount(int lineNumber, char *fileName,Boolean print)
 		*to = (*from =='\\' && 
 			((compiler==COM_MSC) || (compiler==COM_WATCOM)))? '/' : *from;
 	    }
-	    strcpy(to,"\"\n");
+	    sprintf(to,"\"\n");
 	    prevFile =  fileName;
 	}
 	break;

--- a/Tools/goc/output.c
+++ b/Tools/goc/output.c
@@ -1196,9 +1196,9 @@ OutputLineNumberWithCount(int lineNumber, char *fileName,Boolean print)
       case COM_MSC:
       case COM_BORL:
 	if(fileName == prevFile){/* assumes fileName is in the string table */
-	    sprintf(outputLineNumberBuf,"\n#line %d\n", lineNumber);
+	    sprintf(outputLineNumberBuf,"#line %d", lineNumber);
 	}else{
-	    sprintf(outputLineNumberBuf,"\n#line %d \"", lineNumber);
+	    sprintf(outputLineNumberBuf,"#line %d \"", lineNumber);
 	    /* copy in the filename, changing '\\' to '/' for MSC */
 	    for(from = fileName,
 		to = &outputLineNumberBuf[strlen(outputLineNumberBuf)];
@@ -1207,7 +1207,7 @@ OutputLineNumberWithCount(int lineNumber, char *fileName,Boolean print)
 		*to = (*from =='\\' && 
 			((compiler==COM_MSC) || (compiler==COM_WATCOM)))? '/' : *from;
 	    }
-	    sprintf(to,"\"\n");
+	    sprintf(to,"\"");
 	    prevFile =  fileName;
 	}
 	break;
@@ -1215,12 +1215,11 @@ OutputLineNumberWithCount(int lineNumber, char *fileName,Boolean print)
 	assert(0);
     }
     if(print){
-	length = Output("%s",outputLineNumberBuf);
+	length = Output("\n%s\n",outputLineNumberBuf);
     } else {
-	/* there are two newlines in the string, but they won't be counted */
-	/* correctly by strlen, because the different OS's will print them */
+	/* there are two newlines added, but different OS's will print them */
 	/* differently */
-	length  = strlen(outputLineNumberBuf)  -2 + 2 * NEWLINE_SIZE;
+	length  = strlen(outputLineNumberBuf) + 2 * NEWLINE_SIZE;
     }
 
     return length;

--- a/Tools/utils/printf.c
+++ b/Tools/utils/printf.c
@@ -675,9 +675,9 @@ i_vfprintf(FILE *stream,		/* Where to output formatted results. */
 	     * automatically.
 	     */
 #if defined(__HIGHC__) || defined(_MSC_VER) || defined(__WATCOMC__)
-	    if (isstrm && (c == '\n') && (stream->_flag & _O_BINARY)) {
+	    if ((c == '\n') && (!isstrm || (stream->_flag & _O_BINARY))) {
 #else
-	    if (isstrm && (c == '\n') && (stream->flags & _F_BIN)) {
+	    if ((c == '\n') && (!isstrm || (stream->flags & _F_BIN))) {
 #endif
 		i_putc('\r', stream);
 	    }

--- a/Tools/utils/printf.c
+++ b/Tools/utils/printf.c
@@ -621,8 +621,8 @@ i_vfprintf(FILE *stream,		/* Where to output formatted results. */
 				 * printed.  See the man page for details. */
 	 va_list args,		/* Variable number of values to be formatted
 				 * and printed. */
-	 int isstrm) /* TRUE if the stream paramater is actually a
-										 pointer to a buffer pointer */
+	 int isstrm)		/* FALSE if the stream paramater is actually a
+				 * pointer to a buffer pointer */
 {
     int leftAdjust;		/* TRUE means field should be left-adjusted*/
     int minWidth;		/* Minimum width of field. */
@@ -674,10 +674,12 @@ i_vfprintf(FILE *stream,		/* Where to output formatted results. */
 	     * but only if the stream is in binary mode, otherwise it happens
 	     * automatically.
 	     */
-#if defined(__HIGHC__) || defined(_MSC_VER) || defined(__WATCOMC__)
-	    if ((c == '\n') && (!isstrm || (stream->_flag & _O_BINARY))) {
+#if defined(__HIGHC__) || defined(_MSC_VER)
+	    if (isstrm && (c == '\n') && (stream->_flag & _O_BINARY)) {
+#elif defined(__WATCOMC__)
+	    if (isstrm && (c == '\n') && (stream->_flag & _BINARY)) {
 #else
-	    if ((c == '\n') && (!isstrm || (stream->flags & _F_BIN))) {
+	    if (isstrm && (c == '\n') && (stream->flags & _F_BIN)) {
 #endif
 		i_putc('\r', stream);
 	    }


### PR DESCRIPTION
Fixes #611.

This fix deals with the weird way how _goc_ (and possibly other tools) apply the LF -> CR LF transformation of line endings in Windows. Rather than relying on opening the input and output files in "text" mode (which lets the compiler's runtime library take care of the translation), files are opened in binary mode, and any translation happens explicitly in the code:

- Some CR characters (\r) are removed explicitly in the input parser
- The custom `fprintf()` implementation translates \r to \r\n in formatting strings, when writing to a stream in binary mode
- The custom `sprintf()` implementation translates \r to \r\n in formatting strings all the time (this is what was broken in #611, because it seems to have relied on a weird combination of misinterpreting memory accessed through a pointer)
