### PR TITLE
Performance of fonts with kerning table imporved.

### DIFF
--- a/Driver/Font/TrueType/Adapter/ttadapter.h
+++ b/Driver/Font/TrueType/Adapter/ttadapter.h
@@ -66,7 +66,7 @@ extern TEngine_Instance engineInstance;
 #define FAMILY_NAME_LENGTH                  20
 #define STYLE_NAME_LENGTH                   16
 
-#define MAX_KERN_TABLE_LENGTH               6000
+#define KERN_VALUE_DIVIDENT                 100
 
 #define STANDARD_GRIDSIZE                   1000
 #define MAX_NUM_GLYPHS                      2000

--- a/Driver/Font/TrueType/Adapter/ttinit.c
+++ b/Driver/Font/TrueType/Adapter/ttinit.c
@@ -1015,6 +1015,7 @@ static word GetKernCount( TRUETYPE_VARS )
         for( table = 0; table < kerningDir.nTables; ++table )
         {
                 word i;
+                word minKernValue = UNITS_PER_EM / KERN_VALUE_DIVIDENT;
 
                 if( TT_Load_Kerning_Table( FACE, table ) )
                         goto Fail;
@@ -1025,8 +1026,13 @@ static word GetKernCount( TRUETYPE_VARS )
                 pairs = GEO_LOCK( kerningDir.tables->t.kern0.pairsBlock );
 
                 for( i = 0; i < kerningDir.tables->t.kern0.nPairs; ++i )
+                {
+                        if( ABS( pairs[i].value ) < minKernValue )
+                                continue;
+
                         if( isGeosCharPair( pairs[i].left, pairs[i].right ) )
                                 ++numGeosKernPairs;
+                }
 
                 GEO_UNLOCK( kerningDir.tables->t.kern0.pairsBlock );
         }

--- a/Driver/Font/TrueType/Adapter/ttwidths.c
+++ b/Driver/Font/TrueType/Adapter/ttwidths.c
@@ -354,6 +354,7 @@ EC(     ECCheckBounds( (void*)kernValue ) );
         for( table = 0; table < kerningDir.nTables; ++table )
         {
                 word i;
+                word minKernValue = UNITS_PER_EM / KERN_VALUE_DIVIDENT;
 
                 if( TT_Load_Kerning_Table( FACE, table ) )
                         return;
@@ -366,13 +367,17 @@ EC(             ECCheckBounds( pairs ) );
 
                 for( i = 0; i < kerningDir.tables->t.kern0.nPairs; ++i )
                 {
-                        char left  = getGeosCharForIndex( pairs[i].left );
-                        char right = getGeosCharForIndex( pairs[i].right );
+                        char left   = getGeosCharForIndex( pairs[i].left );
+                        char right  = getGeosCharForIndex( pairs[i].right );
+                        
 
+                        if( ABS( pairs[i].value ) < minKernValue )
+                                continue;
 
                         if( left && right )
                         {
                                 WWFixedAsDWord  scaledKernValue;
+
 
                                 kernPair->KP_charLeft  = left;
                                 kernPair->KP_charRight = right;
@@ -556,7 +561,7 @@ static word AllocFontBlock( word        additionalSpace,
                             MemHandle*  fontHandle )
 {
         word size = sizeof( FontBuf ) + numOfCharacters * sizeof( CharTableEntry ) +
-                numOfKernPairs * ( sizeof( KernPair ) + sizeof( WBFixed ) ) +
+                numOfKernPairs * ( sizeof( KernPair ) + sizeof( BBFixed ) ) +
                 additionalSpace; 
                      
         /* allocate memory for FontBuf, CharTableEntries, KernPairs and additional space */


### PR DESCRIPTION
Fixing kerning support of the ttf driver:
- To keep the number of kerning pairs low, only kerning pairs with a kerning value of at least 1% of the units per EM are registered.
- Calculation of size of FontBuf corrected.

fixes #622 