### PR TITLE
Various browser fixes

### DIFF
--- a/Appl/Breadbox/BbxBrow/local.mk
+++ b/Appl/Breadbox/BbxBrow/local.mk
@@ -22,7 +22,8 @@ GOCFLAGS += $(COMPILE_OPTIONS)
 # -Os: favor size of execution speed
 # JavaScript code uses #if rather than #ifdef
 #XCCOMFLAGS = -d -dc -Z -Os -O $(COMPILE_OPTIONS:S|JAVASCRIPT_SUPPORT|JAVASCRIPT_SUPPORT=1|g)
-XCCOMFLAGS = -zu -zc $(COMPILE_OPTIONS:S|JAVASCRIPT_SUPPORT|JAVASCRIPT_SUPPORT=1|g)
+XCCOMFLAGS = -zu $(COMPILE_OPTIONS:S|JAVASCRIPT_SUPPORT|JAVASCRIPT_SUPPORT=1|g)
+# removed -zc because it is not compatible with code_seg() pragma
 
 # -N:  Add stack probes to every routine (only for EC builds)
 #ifndef NO_EC

--- a/Appl/Breadbox/BbxBrow/urlframe/FRFETCH.goc
+++ b/Appl/Breadbox/BbxBrow/urlframe/FRFETCH.goc
@@ -1301,8 +1301,13 @@ Boolean LOCAL testScriptCode(VMFileHandle file, VMBlockHandle code, dword offset
 
 /* We put this into a seperate resource because it is the only part that
    stays in the call stack all the time during parsing. */
+#ifdef __BORLANDC__
 #pragma codeseg FRFETCH2_TEXT
 #pragma option -dc-
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("FRFETCH2_TEXT")
+#endif
 
 @extern method URLFrameClass, MSG_URL_FRAME_URL_FETCHED
 {
@@ -1519,7 +1524,7 @@ Boolean LOCAL testScriptCode(VMFileHandle file, VMBlockHandle code, dword offset
 	  if(!pself->UFI_pendingURLs)
             @call self::MSG_URL_FRAME_DESTROY_SCRIPT_CONTEXT(TRUE);
 @endif
-          if(!strcmpi(result.mimeType,_TEXT("text/html")) && request.dir != DIR_SOURCE)
+	  if(!strcmpi(result.mimeType,_TEXT("text/html")) && request.dir != DIR_SOURCE)
           {
             ret = ParseAnyFile(HFTT_ASSUME_HTML,
               HFTT_SOURCE_FILENAME, (dword)(result.curHTML), &ext, &item,
@@ -1690,8 +1695,13 @@ Boolean LOCAL testScriptCode(VMFileHandle file, VMBlockHandle code, dword offset
  *              Handling of received Hypertext Transfer Items
  ***************************************************************************/
 
+#ifdef __BORLANDC__
 #pragma codeseg FRFETCH3_TEXT
 #pragma option -dc-
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("FRFETCH3_TEXT")
+#endif
 
 /* returns TRUE if page contains an instant redirect */
 Boolean EvaluateMetaData(optr frame, optr metaArray, NameToken curURL)

--- a/Appl/Breadbox/BbxBrow/urlframe/URLFRAME.goc
+++ b/Appl/Breadbox/BbxBrow/urlframe/URLFRAME.goc
@@ -1800,9 +1800,14 @@ void PCAddRemoveHostFromURL(TCHAR *url, ParentalControlFlags *pcFlags,
  *              JS-related methods of URL Frame Class
  ***************************************************************************/
 
+#ifdef __BORLANDC__
 #pragma codeseg FRAME_JS_TEXT
 /* String constants would still go into the original codeseg... */
 #pragma option -dc-
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("FRAME_JS_TEXT")
+#endif
 
 @method URLFrameClass, MSG_URL_FRAME_CAN_WINDOW_OPEN
 {

--- a/Appl/Breadbox/BbxBrow/urltext/URLTEXT.goc
+++ b/Appl/Breadbox/BbxBrow/urltext/URLTEXT.goc
@@ -2180,8 +2180,14 @@ extern void PCAddRemoveHostFromURL(TCHAR *url, ParentalControlFlags *, Boolean a
     NamePoolReleaseToken(namePool, result.url);
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg URLTextJS
+/* String constants would still go into the original codeseg... */
 #pragma option -dc-
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("URLTextJS")
+#endif
 
 @method URLTextClass, MSG_URL_TEXT_FIND_LINK_FROM_NAME
 {
@@ -2279,7 +2285,13 @@ extern void PCAddRemoveHostFromURL(TCHAR *url, ParentalControlFlags *, Boolean a
     return ret;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg
 #pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg()
+#endif
+
 
 @endif  /* JAVASCRIPT_SUPPORT */

--- a/Library/Breadbox/Html4Par/htmlclas/htmlclas.goc
+++ b/Library/Breadbox/Html4Par/htmlclas/htmlclas.goc
@@ -142,10 +142,14 @@
 @extern method HTMLTextClass, MSG_HTML_TEXT_INTERNAL_COLLECT_INVAL_AREA ;
 @extern method HTMLTextClass, MSG_HTML_TEXT_INTERNAL_FLUSH_INVAL_AREA ;
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_INIT_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_INIT_TEXT")
+#endif
 
 @method HTMLTextClass, MSG_HTML_TEXT_INIT_STORAGE
 {
@@ -409,10 +413,14 @@
     return ((int)i >= 0);               /* return success state */
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_IMAGE_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_IMAGE_TEXT")
+#endif
 
 /**************************************************************************
  *            MSG_HTML_TEXT_CREATE_POSITION_ANCHOR for HTMLTextClass
@@ -632,10 +640,14 @@ void LOCAL TrackArrayReplace(optr array, dword pos, sword len,
     }
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_FREE_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_FREE_TEXT")
+#endif
 
 void LOCAL FreeElementArray(VMFileHandle vmf, VMBlockHandle runs)
 {
@@ -691,10 +703,14 @@ void LOCAL FreeElementArrayVD(VMFileHandle vmf, optr obj, VardataKey key)
     pself->VLTI_regionArray = 0;        /* region array freed by superclass */
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_TEXT
-
-/* restore strings in code segment */
+/* "-dc" causes vptrs for text constants if different code segments are used */
 #pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_TEXT")
+#endif
 
 #if 0
 #if COMPILE_OPTION_HUGE_ARRAY_REGIONS
@@ -850,10 +866,15 @@ void _export FreeHTMLTransferItem(VMFileHandle vmf, VMChain vmc)
     VMFreeVMChain(vmf, vmc);            // Remove the chain itself
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_UPDATE_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_UPDATE_TEXT")
+#endif
+
 
 void LOCAL IMarkAllImagesUnresolved(optr imageArray)
 {
@@ -878,11 +899,6 @@ void LOCAL IMarkAllImagesUnresolved(optr imageArray)
       MemUnlock(OptrToHandle(imageArray));
     }
 }
-
-#pragma codeseg HTMLCLAS_UPDATE_TEXT
-
-/* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
 
 optr LOCAL LMemCopyToBlock(MemHandle srcMem, ChunkHandle srcArray)
 {
@@ -935,11 +951,6 @@ ChunkHandle LOCAL LMemCopyToChunk(MemHandle dstMem, ChunkHandle dstArray, optr a
     
     return dstArray;
 }
-
-#pragma codeseg HTMLCLAS_UPDATE_TEXT
-
-/* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
 
 @method HTMLTextClass, MSG_HTML_TEXT_UPDATE_ITEM
 {
@@ -1319,10 +1330,14 @@ ChunkHandle LOCAL LMemCopyToChunk(MemHandle dstMem, ChunkHandle dstArray, optr a
     HWChecksumCheck() ;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_TEXT
-
-/* restore strings in code segment */
+/* "-dc" causes vptrs for text constants if different code segments are used */
 #pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_TEXT")
+#endif
 
 @method HTMLTextClass, MSG_HTML_TEXT_SHOW_ITEM
 {
@@ -1395,10 +1410,14 @@ ChunkHandle LOCAL LMemCopyToChunk(MemHandle dstMem, ChunkHandle dstArray, optr a
     return 0;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_PRINT_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_PRINT_TEXT")
+#endif
 
 /********************************************************************
  *              MSG_PRINT_NOTIFY_PRINT_DB
@@ -1648,10 +1667,14 @@ ChunkHandle LOCAL LMemCopyToChunk(MemHandle dstMem, ChunkHandle dstArray, optr a
     }
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_TEXT
-
-/* restore strings in code segment */
+/* "-dc" causes vptrs for text constants if different code segments are used */
 #pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_TEXT")
+#endif
 
 @method HTMLTextClass, MSG_VIS_TEXT_SCREEN_UPDATE
 {
@@ -2477,10 +2500,14 @@ typedef struct {
     return didAdd ;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_FREE_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_FREE_TEXT")
+#endif
 
 /* Remove from the list any images that have had their cell calculated.  This frees up */
 /* the list of items that are no longer needed. */
@@ -2589,10 +2616,14 @@ NEC(     memset(p_block, 0x00, sizeof(*p_block)) ;  )
     }
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLAS_TEXT
-
-/* restore strings in code segment */
+/* "-dc" causes vptrs for text constants if different code segments are used */
 #pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLAS_TEXT")
+#endif
 
 /* Get rid of the block associate with waiting images */
 @method HTMLTextClass, MSG_HTML_TEXT_WAITING_IMAGES_DESTROY

--- a/Library/Breadbox/Html4Par/htmlclas/htmlclrt.goc
+++ b/Library/Breadbox/Html4Par/htmlclas/htmlclrt.goc
@@ -42,7 +42,14 @@ extern void FormElementEditSelectList(
          optr formArray,
          word selectElement) ;
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLRT_HOTSPOT_TEXT
+/* "-dc" causes vptrs for text constants if different code segments are used */
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLRT_HOTSPOT_TEXT")
+#endif
 
 /* "-dc" causes vptrs for text constants if different code segments are used */
 #pragma option -dc-
@@ -145,7 +152,14 @@ extern void FormElementEditSelectList(
     return found ;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLRT_TEXT
+/* "-dc" causes vptrs for text constants if different code segments are used */
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLRT_TEXT")
+#endif
 
 /* restore strings in code segment */
 #pragma option -dc
@@ -486,10 +500,14 @@ extern void FormElementEditSelectList(
     return link;                        /* return whatever we have found */
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLRT_SELECT_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLRT_SELECT_TEXT")
+#endif
 
 @extern method HTMLTextClass, MSG_HTML_TEXT_SELECT_LINK
 {
@@ -578,10 +596,14 @@ void FormElementRemoveTextEntry(optr urlTextObj);
     }
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLRT_HOTSPOT_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLRT_HOTSPOT_TEXT")
+#endif
 
 @extern method HTMLTextClass, MSG_HTML_TEXT_NEXT_HOTSPOT
 {
@@ -749,10 +771,14 @@ void FormElementRemoveTextEntry(optr urlTextObj);
   };
 @end PointerResource;
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLRT_SELECT_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLRT_SELECT_TEXT")
+#endif
 
 @extern method HTMLTextClass, MSG_META_LARGE_START_SELECT,
                               MSG_META_LARGE_PTR
@@ -1081,10 +1107,14 @@ void FormElementRemoveTextEntry(optr urlTextObj);
 }
 @endif
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLCLRT_TEXT
-
-/* restore strings in code segment */
+/* "-dc" causes vptrs for text constants if different code segments are used */
 #pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLCLRT_TEXT")
+#endif
 
 @ifdef JAVASCRIPT_SUPPORT
 @extern method HTMLTextClass, MSG_HTML_TEXT_FOCUS_FORM_ELEMENT

--- a/Library/Breadbox/Html4Par/htmlclas/htmlform.goc
+++ b/Library/Breadbox/Html4Par/htmlclas/htmlform.goc
@@ -594,10 +594,14 @@ void FormStringAppendNull(MemHandle mem)
     
 /*------------------------------------------------------------------------*/
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLFORM_UPLOAD
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLFORM_UPLOAD")
+#endif
 
 void AddBoundaryString(MemHandle formString)
 {

--- a/Library/Breadbox/Html4Par/htmlclas/htmltcel.goc
+++ b/Library/Breadbox/Html4Par/htmlclas/htmltcel.goc
@@ -32,10 +32,14 @@
 #include "errors.h"
 #include "tableint.h"
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLTCEL_INIT_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLTCEL_INIT_TEXT")
+#endif
 
 void ISetupRegionLinks(T_cellArrayHandle cellArray, T_regionArrayHandle regionArray) ;
 
@@ -551,10 +555,14 @@ word RegionGetPathTopBound(
     return height ;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLTCEL_LAYOUT_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLTCEL_LAYOUT_TEXT")
+#endif
 
 /**************************************************************************
  * Routine:  IRegionRepositionResizeAndReflow
@@ -1815,10 +1823,14 @@ EC( ECCheckStack(); )
     ProfPoint("ILayoutCellStart") ;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLTCEL_LAYOUT2_TEXT
-
 /* "-dc" causes vptrs for text constants if different code segments are used */
-#pragma option -dc-
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLTCEL_LAYOUT2_TEXT")
+#endif
 
 /**************************************************************************
  * Routine:  ILayoutCellRegions

--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -1114,8 +1114,14 @@ void InsertHRule(word size, VisTextParaAttrAttributes align)
  *              Utility functions
  ***************************************************************************/
 
+#ifdef __BORLANDC__
 #pragma codeseg HTMLPARS2_TEXT
-#pragma option -dc-
+/* "-dc" causes vptrs for text constants if different code segments are used */
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HTMLPARS2_TEXT")
+#endif
 
 int LOCAL TranslateCharNum(unsigned int num)
 {

--- a/Library/Breadbox/Html4Par/local.mk
+++ b/Library/Breadbox/Html4Par/local.mk
@@ -16,7 +16,8 @@ GOCFLAGS += $(COMPILE_OPTIONS)
 # -Z:   Suppress register reloads
 # JavaScript code uses #if rather than #ifdef
 #XCCOMFLAGS = -d -O -Z -WDE $(COMPILE_OPTIONS:S|JAVASCRIPT_SUPPORT|JAVASCRIPT_SUPPORT=1|g)
-XCCOMFLAGS = -zc -zu $(COMPILE_OPTIONS:S|JAVASCRIPT_SUPPORT|JAVASCRIPT_SUPPORT=1|g)
+XCCOMFLAGS = -zu $(COMPILE_OPTIONS:S|JAVASCRIPT_SUPPORT|JAVASCRIPT_SUPPORT=1|g)
+# removed -zc because it is not compatible with code_seg() pragma
 #if $(PRODUCT) != "NDO2000"
 # -dc: Breaks mkmf...  Removed from NDO2000 build.
 ##XCCOMFLAGS += -dc 

--- a/Library/Breadbox/UrlDrv/Wmg3Http/WMG3HTTP.goc
+++ b/Library/Breadbox/UrlDrv/Wmg3Http/WMG3HTTP.goc
@@ -1148,9 +1148,13 @@ long header(HTTPConnectionHandle conn, long *clret, word *responseCode)
 	    }
 	}
 	/* detected chunked encodings */
-	else if (LocalCmpStringsNoCaseSBCS(p, strn("Transfer-Encoding: chunked")) == 0) {
-	    p_conn->chunked = TRUE;
-	    p_conn->chunkSize = 0;  /* ready for first chunk */
+	else if (LocalCmpStringsNoCaseSBCS(p, strn("Transfer-Encoding:")) == 0) {
+	    char *q;
+	    q = strstrsbcs(s, "chunked");
+	    if (q) {
+		p_conn->chunked = TRUE;
+		p_conn->chunkSize = 0;  /* ready for first chunk */
+	    }
 	}
 #endif
 #ifdef CACHE_VALIDATION

--- a/Library/Breadbox/UrlDrv/Wmg3Http/WMG3HTTP.goc
+++ b/Library/Breadbox/UrlDrv/Wmg3Http/WMG3HTTP.goc
@@ -648,9 +648,14 @@ void SocketMyClose(Socket sock)
 /* a glue bug presents us from putting the above include in the AuthCode
    segment */
 
+#ifdef __BORLANDC__
 #pragma codeseg AuthCode
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("AuthCode")
+#endif
 
-    void base64encode(TCHAR *in, char *out)
+void base64encode(TCHAR *in, char *out)
 {
     const char basis_64[] =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -696,7 +701,13 @@ void SocketMyClose(Socket sock)
     *out = '\0';
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg()
+#endif
 
 int sock_getline(HTTPConnectionHandle conn, T_HTTPConnection **retptr)
 {
@@ -781,7 +792,13 @@ word sock_printf(T_HTTPConnection *p_conn, char *buffer, char *fmt, ...)
     return SOCK_SEND_NO_ERR;
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg HeaderCode
+#pragma option -dc
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("HeaderCode")
+#endif
 
 /* rarely called from main code resource */
 Boolean HeaderlessHTML(T_HTTPConnection *p_conn)
@@ -1234,9 +1251,12 @@ long header(HTTPConnectionHandle conn, long *clret, word *responseCode)
     return URLRequestMakeRet(URL_RET_FILE) | (noCache ? URB_RF_NOCACHE : 0);
 }
 
-#pragma codeseg
-
+#ifdef __BORLANDC__
 #pragma codeseg COOKIES_TEXT
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("COOKIES_TEXT")
+#endif
 
 #ifdef COOKIE_ENABLE
 /*
@@ -1285,9 +1305,12 @@ word SendCookies(T_HTTPConnection *p_conn)
 }
 #endif
 
-#pragma codeseg
-
+#ifdef __BORLANDC__
 #pragma codeseg CacheCode
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("CacheCode")
+#endif
 
 #ifdef PERSISTANT_CONNECTIONS
 Boolean FindAndUseSocket(T_HTTPConnection *p_conn)
@@ -1399,7 +1422,12 @@ Boolean PutSocketInCache(T_HTTPConnection *p_conn)
 }
 #endif
 
+#ifdef __BORLANDC__
 #pragma codeseg
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg()
+#endif
 
 #ifdef PERSISTANT_CONNECTIONS
 void HandleErrorFunc(T_HTTPConnection *p_conn, Boolean *retry)
@@ -2875,7 +2903,12 @@ word _pascal _export URLDrvMain(_URLMainParams_)
     return rcode;                       /* pass back return data type */
 }
 
+#ifdef __BORLANDC__
 #pragma codeseg MiscCode
+#endif
+#ifdef __WATCOMC__
+#pragma code_seg("MiscCode")
+#endif
 
 /* entry_URLDrvAbort URLDrvAbort */
 void _pascal _export URLDrvAbort(_URLAbortParams_)
@@ -3112,5 +3145,3 @@ Boolean _pascal _export WMG3HTTPEntry(LibraryCallType ty, GeodeHandle client)
 
     return FALSE;
 }
-
-#pragma codeseg

--- a/Library/Breadbox/UrlDrv/Wmg3Http/WMG3HTTP.goc
+++ b/Library/Breadbox/UrlDrv/Wmg3Http/WMG3HTTP.goc
@@ -1040,16 +1040,19 @@ long header(HTTPConnectionHandle conn, long *clret, word *responseCode)
                 contentlength = CL_UNKNOWN;
 #endif
         } else if (LocalCmpStringsNoCaseSBCS(p, strn("Content-Type:")) == 0) {
-            ChunkStrcpySBCS(p_conn->heap, &(p_conn->mimeTypeChunk), s);
+            /* ignore content type for "Not Modified" (WebOne proxy) */
+	    if (*responseCode != 304) {
+              ChunkStrcpySBCS(p_conn->heap, &(p_conn->mimeTypeChunk), s);
 #if PROGRESS_DISPLAY
-            /* get mime type from HTTP header */
-            if (p_conn->loadProgressDataP)
+              /* get mime type from HTTP header */
+              if (p_conn->loadProgressDataP)
 @ifdef DO_DBCS
-                xstrncpysbcstodbcs(p_conn->loadProgressDataP->LPD_mimeType, s, sizeof(p_conn->loadProgressDataP->LPD_mimeType)/sizeof(TCHAR));
+                  xstrncpysbcstodbcs(p_conn->loadProgressDataP->LPD_mimeType, s, sizeof(p_conn->loadProgressDataP->LPD_mimeType)/sizeof(TCHAR));
 @else
-                xstrncpy(p_conn->loadProgressDataP->LPD_mimeType, s, sizeof(p_conn->loadProgressDataP->LPD_mimeType));
+                  xstrncpy(p_conn->loadProgressDataP->LPD_mimeType, s, sizeof(p_conn->loadProgressDataP->LPD_mimeType));
 @endif
 #endif
+	    }
         } else if (LocalCmpStringsNoCaseSBCS(p, strn("Location:")) == 0) {
             if (*responseCode == 301 || *responseCode == 302) {
                 ChunkStrcpySBCS(p_conn->heap, &(p_conn->urlChunk), s);


### PR DESCRIPTION
Due to my branch setup, this is now becoming more of an "omnibus" PR for multiple changes to the browser that I am pushing to my branch:

- Adapt code segment splitting to Watcom (mostly already done independently by Falk, but adding a few more cases
- Make detection of HTTP chunked encoding more robust. This works around a case where there is an extra blank between "Transfer-Encoding:" and "chunked" (seen recently on zdf.de, tagesschau.de, ndr.de)
- Ignore Content-Type when server returns 304 (Not Modified) - bluewaysw#497