### PR TITLE
707 ttf driver create ini key to activate deactivate bytecode interpreter

### DIFF
--- a/Driver/Font/TrueType/Adapter/ttadapter.h
+++ b/Driver/Font/TrueType/Adapter/ttadapter.h
@@ -507,6 +507,7 @@ typedef enum {
 #define MUL_100_WWFIXED( factor, percentage )   \
         GrMulWWFixed( factor, GrUDivWWFixed( ((long)percentage ) << 16, 100L << 16))
 
+
 /***********************************************************************
  *      functions
  ***********************************************************************/

--- a/Driver/Font/TrueType/Adapter/ttinit.c
+++ b/Driver/Font/TrueType/Adapter/ttinit.c
@@ -1086,10 +1086,40 @@ static char GetDefaultChar( TRUETYPE_VARS, char firstChar )
 }
 
 
+/********************************************************************
+ *                      activateBytecodeInterpreter
+ ********************************************************************
+ * SYNOPSIS:       Activates or determines if the bytecode interpreter 
+ *                 should be active for the TrueType font driver. Reads 
+ *                 the configuration setting from geos.ini.
+ * 
+ * PARAMETERS:     None
+ * 
+ * RETURNS:        Boolean
+ *                    TRUE if the bytecode interpreter should be active 
+ *                    (default behavior) or the value retrieved from the 
+ *                    initialization file if it is successfully read.
+ * 
+ * STRATEGY:       - Attempt to read the BYTECODEINTERPRETER_KEY from the 
+ *                   initialization file under the TTFDRIVER_CATEGORY.
+ *                 - If the key is successfully read, return the retrieved value.
+ *                 - If reading fails, return TRUE as the default behavior.
+ * 
+ * REVISION HISTORY:
+ *      Date      Name      Description
+ *      ----      ----      -----------
+ *      17.11.24  jk        Initial Revision
+ *******************************************************************/
+
 static Boolean activateBytecodeInterpreter()
 {
-        return TRUE;
+        Boolean  bytecodeInterpreterActive;
 
+
+        if( InitFileReadBoolean( TTFDRIVER_CATEGORY, BYTECODEINTERPRETER_KEY, &bytecodeInterpreterActive ) )
+                return bytecodeInterpreterActive;
+
+        return TRUE;
 }
 
 

--- a/Driver/Font/TrueType/Adapter/ttinit.c
+++ b/Driver/Font/TrueType/Adapter/ttinit.c
@@ -73,6 +73,8 @@ static void strcpyname( char* dest, const char* source );
 
 static int strcmp( const char* s1, const char* s2 );
 
+static Boolean activateBytecodeInterpreter();
+
 
 /********************************************************************
  *                      Init_FreeType
@@ -105,6 +107,8 @@ TT_Error _pascal Init_FreeType()
         error = TT_Init_FreeType();
         if ( error != TT_Err_Ok )
                 return error;
+
+        engineInstance.interpreterActiv = activateBytecodeInterpreter();
 
         return TT_Err_Ok;
 }
@@ -1079,6 +1083,13 @@ static char GetDefaultChar( TRUETYPE_VARS, char firstChar )
                 return firstChar;  
 
         return DEFAULT_DEFAULT_CHAR; 
+}
+
+
+static Boolean activateBytecodeInterpreter()
+{
+        return TRUE;
+
 }
 
 

--- a/Driver/Font/TrueType/Adapter/ttinit.c
+++ b/Driver/Font/TrueType/Adapter/ttinit.c
@@ -1116,7 +1116,7 @@ static Boolean activateBytecodeInterpreter()
         Boolean  bytecodeInterpreterActive;
 
 
-        if( InitFileReadBoolean( TTFDRIVER_CATEGORY, BYTECODEINTERPRETER_KEY, &bytecodeInterpreterActive ) )
+        if( !InitFileReadBoolean( TTFDRIVER_CATEGORY, BYTECODEINTERPRETER_KEY, &bytecodeInterpreterActive ) )
                 return bytecodeInterpreterActive;
 
         return TRUE;

--- a/Driver/Font/TrueType/Adapter/ttinit.c
+++ b/Driver/Font/TrueType/Adapter/ttinit.c
@@ -108,7 +108,7 @@ TT_Error _pascal Init_FreeType()
         if ( error != TT_Err_Ok )
                 return error;
 
-        engineInstance.interpreterActiv = activateBytecodeInterpreter();
+        engineInstance.interpreterActive = activateBytecodeInterpreter();
 
         return TT_Err_Ok;
 }

--- a/Driver/Font/TrueType/Adapter/ttinit.h
+++ b/Driver/Font/TrueType/Adapter/ttinit.h
@@ -33,7 +33,8 @@
  ***********************************************************************/
 
 #define FONTMAPPING_CATEGORY            "FontMapping" 
-#define BYTECODEINTERPRETER_CATEGORY    "BytecodeInterpreter" 
+#define TTFDRIVER_CATEGORY              "TtfDriver"
+#define BYTECODEINTERPRETER_KEY         "bytecodeInterpreterActiv"
 
 
 /***********************************************************************

--- a/Driver/Font/TrueType/Adapter/ttinit.h
+++ b/Driver/Font/TrueType/Adapter/ttinit.h
@@ -34,7 +34,7 @@
 
 #define FONTMAPPING_CATEGORY            "FontMapping" 
 #define TTFDRIVER_CATEGORY              "TtfDriver"
-#define BYTECODEINTERPRETER_KEY         "bytecodeInterpreterActiv"
+#define BYTECODEINTERPRETER_KEY         "bytecodeInterpreterActive"
 
 
 /***********************************************************************

--- a/Driver/Font/TrueType/Adapter/ttinit.h
+++ b/Driver/Font/TrueType/Adapter/ttinit.h
@@ -32,7 +32,8 @@
  *      constants for font mapping
  ***********************************************************************/
 
-#define FONTMAPPING_CATEGORY            "FontMapping"   
+#define FONTMAPPING_CATEGORY            "FontMapping" 
+#define BYTECODEINTERPRETER_CATEGORY    "BytecodeInterpreter" 
 
 
 /***********************************************************************
@@ -77,6 +78,13 @@
  ***********************************************************************/
 
 #define MAKE_FONTID( fontGroup, familyName )   ( FM_TRUETYPE | fontGroup | ( 0x01ff & toHash ( familyName )))
+
+
+/***********************************************************************
+ *      drivers engineInstance
+ ***********************************************************************/
+
+extern TEngine_Instance engineInstance;
 
 
 /***********************************************************************

--- a/Driver/Font/TrueType/Adapter/ttinit.h
+++ b/Driver/Font/TrueType/Adapter/ttinit.h
@@ -29,11 +29,11 @@
 
 
 /***********************************************************************
- *      constants for font mapping
+ *      constants for access to geos.ini
  ***********************************************************************/
 
 #define FONTMAPPING_CATEGORY            "FontMapping" 
-#define TTFDRIVER_CATEGORY              "TtfDriver"
+#define TTFDRIVER_CATEGORY              "ttfDriver"
 #define BYTECODEINTERPRETER_KEY         "bytecodeInterpreterActive"
 
 

--- a/Driver/Font/TrueType/FreeType/ttengine.h
+++ b/Driver/Font/TrueType/FreeType/ttengine.h
@@ -55,11 +55,12 @@
      void*   objs_execution_class;  /* the context cache class  */
      void*   objs_glyph_class;      /* the glyph cache class    */
 
-     void*   objs_face_cache;  /* these caches are used to track */
-     void*   objs_exec_cache;  /* the current face and execution */
-                               /* context objects                */
+     void*   objs_face_cache;       /* these caches are used to track */
+     void*   objs_exec_cache;       /* the current face and execution */
+                                    /* context objects                */
 
-     void*   raster_component;     /* ttraster implementation depedent    */
+     void*   raster_component;      /* ttraster implementation depedent    */
+     Boolean interpreterActiv;      /* is bytecodeinterpreter aktiv?  */
   };
 
   /* NOTE : The raster's lock is only acquired by the Render_Glyph and     */

--- a/Driver/Font/TrueType/FreeType/ttengine.h
+++ b/Driver/Font/TrueType/FreeType/ttengine.h
@@ -60,7 +60,7 @@
                                     /* context objects                */
 
      void*   raster_component;      /* ttraster implementation depedent    */
-     Boolean interpreterActiv;      /* is bytecodeinterpreter aktiv?  */
+     Boolean interpreterActive;     /* is bytecodeinterpreter aktive?  */
   };
 
   /* NOTE : The raster's lock is only acquired by the Render_Glyph and     */

--- a/Driver/Font/TrueType/FreeType/ttobjs.c
+++ b/Driver/Font/TrueType/FreeType/ttobjs.c
@@ -579,7 +579,7 @@ extern TEngine_Instance engineInstance;
     exec->top     = 0;
     exec->callTop = 0;
 
-    return RunIns( exec );
+    return CALL_INTERPRETER;
   }
 
 
@@ -813,7 +813,7 @@ extern TEngine_Instance engineInstance;
       if ( error )
         goto Fin;
 
-      error = RunIns( exec );
+      error = CALL_INTERPRETER;
     }
     else
       error = TT_Err_Ok;
@@ -934,7 +934,7 @@ extern TEngine_Instance engineInstance;
       if ( error )
         goto Fin;
 
-      error = RunIns( exec );
+      error = CALL_INTERPRETER;
     }
     else
       error = TT_Err_Ok;

--- a/Driver/Font/TrueType/FreeType/ttobjs.h
+++ b/Driver/Font/TrueType/FreeType/ttobjs.h
@@ -315,6 +315,8 @@
 
 #endif
 
+#define CALL_INTERPRETER  engineInstance.interpreterActive ? RunIns( exec ) : TT_Err_Ok
+
   /* Rounding function, as used by the interpreter */
   typedef TT_F26Dot6  TRound_Function( EXEC_OPS TT_F26Dot6 distance,
                                                 TT_F26Dot6 compensation );

--- a/Driver/Font/TrueType/FreeType/ttobjs.h
+++ b/Driver/Font/TrueType/FreeType/ttobjs.h
@@ -315,7 +315,7 @@
 
 #endif
 
-#define CALL_INTERPRETER  engineInstance.interpreterActive ? RunIns( exec ) : TT_Err_Ok
+#define CALL_INTERPRETER  ( engineInstance.interpreterActive ? RunIns( exec ) : TT_Err_Ok )
 
   /* Rounding function, as used by the interpreter */
   typedef TT_F26Dot6  TRound_Function( EXEC_OPS TT_F26Dot6 distance,

--- a/Driver/Font/TrueType/Main/truetypeVariable.def
+++ b/Driver/Font/TrueType/Main/truetypeVariable.def
@@ -83,7 +83,7 @@ TrueTypeEngineInstance	struct
 	objs_exec_cache			fptr	;the current face and execution
  									;context objects
 	raster_component		fptr	;ttraster implementation depedent
-	interpreterActiv		word
+	interpreterActive		word
 TrueTypeEngineInstance	ends
 
 ;------------------------------------------------------------------------------

--- a/Driver/Font/TrueType/Main/truetypeVariable.def
+++ b/Driver/Font/TrueType/Main/truetypeVariable.def
@@ -77,12 +77,13 @@ TrueTypeEngineInstance	struct
 	list_free_elements		fptr	
 	objs_face_class			fptr	;the face cache class
 	objs_instance_class		fptr	;the instance cache class
-	objs_execution_class		fptr	;the context cache class
-	objs_glyph_classfptr		fptr	;the glyph cache class
+	objs_execution_class	fptr	;the context cache class
+	objs_glyph_classfptr	fptr	;the glyph cache class
 	objs_face_cache			fptr	;these caches are used to track
 	objs_exec_cache			fptr	;the current face and execution
- 						;context objects
+ 									;context objects
 	raster_component		fptr	;ttraster implementation depedent
+	interpreterActiv		word
 TrueTypeEngineInstance	ends
 
 ;------------------------------------------------------------------------------

--- a/TechDocs/Markdown/Tools/tini.md
+++ b/TechDocs/Markdown/Tools/tini.md
@@ -2086,7 +2086,19 @@ application.
 
 ----------
 
-### 9.2.31 ui
+### 9.2.31 ttfDriver
+
+`bytecodeInterpreterActive = <Boolean>`
+
+If false, this key tells the ttf driver that the bytecode interpreter should not 
+be used. The default value is true.
+
+	bytecodeInterpreterActive = true
+	bytecodeInterpreterActive = false
+
+----------
+
+### 9.2.32 ui
 
 #### autosave
 
@@ -2400,7 +2412,7 @@ primarily when developing for small-screen platforms such as Zoomer.
 
 ----------
 
-### 9.2.32 *specific ui name*
+### 9.2.33 *specific ui name*
 
 Each specific UI may have a category with options; this category should be 
 named after the specific UI, e.g. [motif].
@@ -2421,7 +2433,7 @@ when drawing text monikers for gadgets such as menus and buttons.
 
 ----------
 
-### 9.2.33 ui features
+### 9.2.34 ui features
 
 The ui features category defines the UI configuration used by the 
 environment application (e.g. Welcome) and all applications on the 
@@ -2732,7 +2744,7 @@ is closed.
 
 ----------
 
-### 9.2.34 welcome
+### 9.2.35 welcome
 
 The welcome category defines configuration and usage characteristics of the 
 Welcome environment application. Its keys may be useful to you during 


### PR DESCRIPTION
- ini category created for configuration of the ttf driver
- boolean key bytecodeInterpreterActive created to activate/deactivate the bytecode interpreter
- by default, the bytecode interpreter is active
- Key and category documented in the tool book

fixes #707 