### PR TITLE
Browser: default to ISO encoding again, avoid DBCS error in EC

### DIFF
--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -1759,7 +1759,7 @@ int LOCAL HandleScript(int c, Boolean accept)
         n = 0;                          // characters have been dealt with
       }
       
-      while ((c != EOF) && (toupper(c)==endScript[n]))
+      while (c!=EOF && c<128 && (toupper(c)==endScript[n]))
       {
         buf[n++] = (char)c;
 	pbuf[0] = pbuf[1]; pbuf[1] = pbuf[2]; pbuf[2] = p = c;
@@ -2201,7 +2201,7 @@ int EXPORT ParseHTMLFile(ReadHTML_getc *p_gc, dword p_data, HTMLextra *ext,
 #ifdef DO_DBCS
     G_htmlCodePage = HTMLext->HE_codePage;
 #else
-    G_decodeUtf8 = TRUE;
+    G_decodeUtf8 = HTMLext->HE_decodeUtf8;
 #endif
     *item = InitTransferItem();         /* initialize & return transfer item */
     InitTagStacks(localHeap);           /* set up tag stacks */
@@ -2416,7 +2416,7 @@ int EXPORT ParsePlainFile(ReadHTML_getc *p_gc, dword p_data, HTMLextra *ext,
 #ifdef DO_DBCS
     G_htmlCodePage = HTMLext->HE_codePage;
 #else
-    G_decodeUtf8 = TRUE;
+    G_decodeUtf8 = HTMLext->HE_decodeUtf8;
 #endif
     *item = InitTransferItem();         /* initialize & return transfer item */
     InitTagStacks(localHeap);           /* set up tag stacks */


### PR DESCRIPTION
This should fix ISO Latin pages showing "?" for non-ASCII characters after merging the initial UTF-8 support.

Additionally, I noticed and fixed an issue where a DBCS error was triggered by a script containing a Unicode character above 256 (only for EC builds). I saw this on www.bild.de.