### PR TITLE
Browser list adjustments

### DIFF
--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -1054,7 +1054,7 @@ void AddParaCond(void)
         STRCPYSB(insertPrepend,"\t");     /* make sure it's indented */
 
       if(*insertPrepend)                /* prepend text to paragraph? */
-        AddText(&vcaBase, insertPrepend);
+        AddText(&currentCS, insertPrepend);
 
       FixupStartPos(pos);               /* fixup tag starting positions on
                                            stack to after prepended text */

--- a/Library/Breadbox/Html4Par/htmlsty.goh
+++ b/Library/Breadbox/Html4Par/htmlsty.goh
@@ -54,9 +54,9 @@
                                        5*PIXELS_PER_INCH,0,0,0};
 @chunk ParaStyleDelta vpdList       = {PSD_MARGINS_ADD | PSD_SPACING,
                                        5*PIXELS_PER_INCH,0,
-                                       -2*PIXELS_PER_INCH,0};
+                                       -3*PIXELS_PER_INCH,0};
 @chunk ParaStyleDelta vpdUList      = {PSD_MARGINS_ADD | PSD_SPACING,
-                                       5*PIXELS_PER_INCH,0,-2*PIXELS_PER_INCH,0};
+                                       5*PIXELS_PER_INCH,0,-3*PIXELS_PER_INCH,0};
 
 /******************************************************************************/
 


### PR DESCRIPTION
This makes two small changes to the formatting of numbered lists:

- Make the list numbering (or bullet) uses the same style as the rest of the list
- Increased the hanging indent a little bit to leave room for numbers greater than 9

The first change is based on an idea by @HubertHuckevoll. Unlike the proposal in c452039a08ef03dcb3444add3c012bddb74e7220 I have eventually used `currentCS` (the style for the text that is about to be written) rather than `insertParagraphCS` (the style for the pending paragraph just before the list item), because otherwise the first item of a list may be styled incorrectly.