### PR TITLE
Adjust kerning value treshold #764

### DIFF
--- a/Driver/Font/TrueType/Adapter/ttadapter.h
+++ b/Driver/Font/TrueType/Adapter/ttadapter.h
@@ -66,7 +66,7 @@ extern TEngine_Instance engineInstance;
 #define FAMILY_NAME_LENGTH                  20
 #define STYLE_NAME_LENGTH                   16
 
-#define KERN_VALUE_DIVIDENT                 100
+#define KERN_VALUE_DIVIDENT                 30
 
 #define STANDARD_GRIDSIZE                   1000
 #define MAX_NUM_GLYPHS                      2000


### PR DESCRIPTION
Use a limit that is significant and still keeps the kern table size so that PC/GEOS can deal with it.