### PR TITLE
Simplify parallel development with separate EC and NC target builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,24 @@ Build the target environment:
   - the answers to the questions from the above perl-script are:
     - nt (for the platform)
     - y (for the EC version)
-    - n (for the DBCS)
+      - Alternatively, reply "n" for the NC ("release") version that is faster and corresponds to the actual release
+      - The EC ("debug") version has stricter error checking and is better suited for debugging
+    - n (as the build for Double-Byte Character Sets is not yet fully functional)
     - y (for the geodes)
     - n (for the VM files)
-    - and then you'll have to enter the path to a "gbuild"-folder in your LOCAL_ROOT-folder.
+    - and then you'll have to enter the path to a "gbuild.ec"-folder in your LOCAL_ROOT-folder (or accept the default).
   - BTW: It's expected that the current version of the perl-script creates several "Could not find file _name_ in any of the source trees."-messages.
 
 Launch the target environment in dosbox:
 - make sure dosbox is added to your path variable, or [pcgeos-basebox](https://github.com/bluewaysw/pcgeos-basebox/tags) is installed and configured using BASEBOX environmental variable
-- `%ROOT_DIR%/bin/target`
+- `%ROOT_DIR%/bin/target` to launch the EC ("debug") version
   - the "swat" debugger stops immediately after the first stage of the boot process
   - enter `quit` at the "=>" prompt to detach the debugger and launch PC/GEOS stand-alone
     - or: enter `c` to launch with the debugger running in the background (slower)
-
+- Alternatively, adding the `-n` option to the `target` command launches the NC ("release") version
 
 ## Customize target environment
-If you want to customize the target environment settings only for yourself, you should not change the file %ROOT_DIR%/bin/basebox.conf.
+If you want to customize the target environment settings only for yourself, you should not change the file `%ROOT_DIR%/bin/basebox.conf`.
 - Create a file called basebox_user.conf in %LOCAL_ROOT% folder.
 - Enter the new settings here. These settings overwrite those from basebox.conf. Example:
   - [cpu]

--- a/Tools/build/product/bbxensem/Scripts/buildbbx.cmd
+++ b/Tools/build/product/bbxensem/Scripts/buildbbx.cmd
@@ -1,9 +1,0 @@
-@echo off
-rem
-rem	Call interactive script to make Ark images
-rem
-rem	$Id:$
-rem
-@echo on
-perl %ROOT_DIR%\tools\build\product\bbxensem\scripts\buildbbx.pl %*
-

--- a/Tools/build/product/bbxensem/Scripts/buildbbx.pl
+++ b/Tools/build/product/bbxensem/Scripts/buildbbx.pl
@@ -144,7 +144,8 @@ $CommonConfigFile = "$LocalDir/$CONFIG_FILE_ROOT/$CONFIG_FILE_ROOT";
 		"dbcs" => "n",
 		"mapblock" => "e8000",
 		"romwindows" => "c8000 128k",
-		"destdir" => "$LocalDir/$DEST_SUB_DIRECTORY",
+		"destdirnc" => "$LocalDir/$DEST_SUB_DIRECTORY.nc",
+		"destdirec" => "$LocalDir/$DEST_SUB_DIRECTORY.ec",
 		"shipfiles" => "y",
 		"vm" => "n",
 		"patching" => "n",
@@ -478,9 +479,14 @@ ReadTargetInputFromCache();
 # Since we are not making xip images, this is not the temporary directory, 
 # it is the destination directory for the demo.
 #
-print "Directory to put target files in (default = $DefaultInfo{destdir}): ";
-$RealInfo{destdir} = FormatPath( ReadUserInput( $DefaultInfo{destdir} ), 0 );
+if ( $RealInfo{ec} eq "y" ) {
+    $DefaultDestDir = $DefaultInfo{destdirec}
+} else {
+    $DefaultDestDir = $DefaultInfo{destdirnc}
+}
 
+print "Directory to put target files in (default = $DefaultDestDir): ";
+$RealInfo{destdir} = FormatPath( ReadUserInput( $DefaultDestDir ), 0 );
 AddGbuildArg( "desttree", $RealInfo{destdir} );
 
 ##############################################################################

--- a/bin/buildbbx.cmd
+++ b/bin/buildbbx.cmd
@@ -1,0 +1,9 @@
+@echo off
+rem
+rem	Call interactive script to make Ark images
+rem
+rem	$Id:$
+rem
+@echo on
+perl %ROOT_DIR%\tools\build\product\bbxensem\scripts\buildbbx.pl %*
+

--- a/bin/target
+++ b/bin/target
@@ -14,23 +14,32 @@
 #	fr	26/10/20	Initial Revision
 #
 # DESCRIPTION:
-#	A script to start the target basebox and optionally
-#       connect swat.
+#	A script to start the target basebox and connect swat.
 #
-#	Usage: target [path] [-swat]
+#	Usage: target [-n]
 #
-#	If you give the argument "no", then the things that would be
-#	removed will be printed, but not removed.
+#	If you give the argument "-n", the target in gbuild.nc is launched,
+#  otherwise the target in gbuild.
 #
 #	$Id: clean,v 1.18 97/02/12 17:08:40 stevey Exp $
 #
 ###############################################################################
+# Parse command line arguments
+TARGET=gbuild.ec
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -n)
+      TARGET=gbuild.nc
+      ;;
+  esac
+  shift
+done
 if [ "$BASEBOX" = "" ]; then
     BASEBOX=dosbox
 fi
 OLD_PATH=$PWD
-cd ${LOCAL_ROOT}/gbuild/localpc
-rm $LOCAL_ROOT/gbuild/localpc/IPX_STAT.TXT
+cd ${LOCAL_ROOT}/${TARGET}/localpc
+rm $LOCAL_ROOT/${TARGET}/localpc/IPX_STAT.TXT
 rm ensemble/init.bat
 if [ "$GEOS_CENTRAL_STORAGE" != "" ]; then
    echo mount s: %GEOS_CENTRAL_STORAGE% >> ensemble/init.bat
@@ -51,6 +60,6 @@ set +m
 cd $OLD_PATH
 
 clear
-while [ ! -f $LOCAL_ROOT/gbuild/localpc/IPX_STAT.TXT ]; do sleep 1; printf "."; done
-IPX_PORT=$(grep "127.0.0.1 from port" $LOCAL_ROOT/gbuild/localpc/IPX_STAT.TXT | perl -e 'my $status = <>; $status =~  m/(\d+)\r/; printf("%04X", $1);')
+while [ ! -f $LOCAL_ROOT/${TARGET}/localpc/IPX_STAT.TXT ]; do sleep 1; printf "."; done
+IPX_PORT=$(grep "127.0.0.1 from port" $LOCAL_ROOT/${TARGET}/localpc/IPX_STAT.TXT | perl -e 'my $status = <>; $status =~  m/(\d+)\r/; printf("%04X", $1);')
 swat -net 00000000:7F000001${IPX_PORT}:003F

--- a/bin/target.cmd
+++ b/bin/target.cmd
@@ -4,10 +4,15 @@ if "%~1"=="-fcc" (
    CALL <NUL %0 -fcc %*
    GOTO :EOF
 )
+if "%1"=="-n" (
+   set TARGET=gbuild.nc
+) ELSE (
+   set TARGET=gbuild.ec
+)
 IF NOT DEFINED BASEBOX (SET BASEBOX=dosbox)
 set OLD_PATH=%cd%
-cd /D %LOCAL_ROOT%\gbuild\localpc 
-del /F %LOCAL_ROOT%\gbuild\localpc\IPX_STAT.txt
+cd /D %LOCAL_ROOT%\%TARGET%\localpc 
+del /F %LOCAL_ROOT%\%TARGET%\localpc\IPX_STAT.txt
 del /F ensemble\init.bat
 IF DEFINED GEOS_CENTRAL_STORAGE (
    echo mount s: %GEOS_CENTRAL_STORAGE% >> ensemble\init.bat
@@ -26,13 +31,13 @@ start /B %BASEBOX% -conf %ROOT_DIR%\bin\basebox.conf -conf %LOCAL_ROOT%\basebox_
 cd %OLD_PATH%
 @cls
 :waitForFile
-@IF EXIST %LOCAL_ROOT%\gbuild\localpc\IPX_STAT.txt GOTO foundFile
+@IF EXIST %LOCAL_ROOT%\%TARGET%\localpc\IPX_STAT.txt GOTO foundFile
 @sleep 1s
 @echo|set /p="."
 @GOTO waitForFile
 :foundFile
-FINDSTR /r /c:"127.0.0.1 from port" %LOCAL_ROOT%\gbuild\localpc\IPX_STAT.txt | perl -e "my $status = <>; $status =~  m/(\d+)$/; printf('%%04X', $1);" > %LOCAL_ROOT%\gbuild\localpc\IPX_PORT.txt
-set /p IPX_PORT=<%LOCAL_ROOT%\gbuild\localpc\IPX_PORT.txt
+FINDSTR /r /c:"127.0.0.1 from port" %LOCAL_ROOT%\%TARGET%\localpc\IPX_STAT.txt | perl -e "my $status = <>; $status =~  m/(\d+)$/; printf('%%04X', $1);" > %LOCAL_ROOT%\%TARGET%\localpc\IPX_PORT.txt
+set /p IPX_PORT=<%LOCAL_ROOT%\%TARGET%\localpc\IPX_PORT.txt
 cls
 rem mode 120,50
 IF EXIST "%USERPROFILE%\swat.rc" (


### PR DESCRIPTION
This modifies the `buildbbx.pl` script so that it uses separate default paths for the EC and NC build (`gbuild.ec` and `gbuild.nc`, respectively). As it already remembers the paths for the two separately, this means that the defaults will usually work fine to maintain two separate targets under `local`, similar to the directory layout of old Geos SDKs.

The `target` command now launches the EC target by default, and can be modified with the `-n` switch to launch the NC target instead (analogous to `pmake -n`), assuming that the default paths are used.

Note: I do not have a Linux environment for Geos development, so I was not fully able to test the change to the Linux version of `target`.

Closes #700.