### PR TITLE
Prevent GrCharMetrics to prevent font mapping #843

### DIFF
--- a/Driver/Font/TrueType/Adapter/ttchars.c
+++ b/Driver/Font/TrueType/Adapter/ttchars.c
@@ -138,8 +138,8 @@ EC(     ECCheckBounds( (void*)transformMatrix ) );
                 TT_Matrix         flipmatrix = HORIZONTAL_FLIP_MATRIX;
 
 
-                /* We calculate with an average of 4 on/off points, line number and line end code. */
-                size = height * 6 * sizeof( word ) + REGION_SAFETY + SIZE_REGION_HEADER; 
+                /* We calculate with an average of 6 on/off points, line number and line end code. */
+                size = height * 8 * sizeof( word ) + REGION_SAFETY + SIZE_REGION_HEADER; 
 
                 /* get pointer to bitmapBlock */
                 charData = EnsureBitmapBlock( bitmapHandle, size );

--- a/Driver/Font/TrueType/Main/truetypeMetrics.asm
+++ b/Driver/Font/TrueType/Main/truetypeMetrics.asm
@@ -58,18 +58,14 @@ REVISION HISTORY:
 TrueTypeCharMetrics	proc	far
 	uses	cx, si, ds
 
-resultDXAX	local	dword
-
 	push	bx, di
 	mov	di, FONT_C_CODE_STACK_SPACE
 	call	ThreadBorrowStackSpace
 	push	di
 
-	.enter
+resultDXAX	local	dword
 
-	mov	di, FONT_C_CODE_STACK_SPACE
-	call 	ThreadBorrowStackSpace
-	push	di
+	.enter
 
 	mov	si, cx
 	push	dx		; pass character code
@@ -114,8 +110,6 @@ resultDXAX	local	dword
 	jnz	roundToInt
 	rndwwbf dxax
 
-	pop	di
-	call 	ThreadReturnStackSpace
 done:
 	clc
 	.leave

--- a/Library/Kernel/Graphics/graphicsFont.asm
+++ b/Library/Kernel/Graphics/graphicsFont.asm
@@ -831,19 +831,14 @@ endif
 	call	MemLock
 	mov	es, ax				;es <- seg addr of GState
 	;
-	; See if the font is even available
-	;
-	mov	cx, es:GS_fontAttr.FCA_fontID	;cx <- current font
-	mov	dl, mask FEF_OUTLINES		;dl <- FontEnumFlags
-	call	GrCheckFontAvail			;font available?
-	jcxz	notAvailable			;branch if not available
-	;
 	; Call the corresponding driver
 	;
 	pop	dx				;dx <- character (Chars)
 	mov	cx, si				;cx <- GCM_info
 	mov	ax, DR_FONT_CHAR_METRICS	;ax <- FontFunction
 	call	GrCallFontDriver
+	jnc	done
+	clr	ax, dx				;dx:ax <- font not available
 done:
 	;
 	; Unlock the GState
@@ -854,11 +849,6 @@ done:
 	.leave
 	ret
 
-notAvailable:
-	pop	ax
-	clr	ax, dx				;dx:ax <- font not available
-	stc					;carry <- error
-	jmp	done
 GrCharMetrics	endp
 
 


### PR DESCRIPTION
Fix metrics stack allocation in ttf driver
make region buffer fit for 'W'