### PR TITLE
Some documentation improvements

### DIFF
--- a/TechDocs/Markdown/Asmref/asmstrgg.md
+++ b/TechDocs/Markdown/Asmref/asmstrgg.md
@@ -1651,7 +1651,7 @@ In OSF/Motif, the following table shows the standard triggers that will be
 provided with various hints (given a GIT_PROPERTIES GenInteraction that 
 is built as a dialog box):
 
-**Table 12-1** *Default Triggers supplied with a GIT_PROPERTIES dialog box.*
+**Table 12-1** Default Triggers supplied with a GIT_PROPERTIES dialog box.
 
 	Hint									Triggers Supplied
 

--- a/TechDocs/Markdown/Concepts/ccoding.md
+++ b/TechDocs/Markdown/Concepts/ccoding.md
@@ -17,7 +17,8 @@ handles several other types specific to GEOS. These are all defined in the file
 geos.h. Some of these types were carried over from the world of assembly 
 language and (along with the standard C types) are shown in Table 5-1.
 
-**Table 5-1** Basic Data Types  
+**Table 5-1** Basic Data Types
+
 |Type Name    |Description                                 |
 |-------------|--------------------------------------------|
 |byte         |An unsigned, 8-bit field.                   |
@@ -59,7 +60,8 @@ supported by your C compiler uses word-sized values. GEOS also allows
 byte-sized enumerated types with the **ByteEnum** type. Use of this type is 
 shown in Code Display 5-1.
 
-**Table 5-2** Flag Records and ByteEnum  
+**Table 5-2** Flag Records and ByteEnum
+
 |Type Name   |Description                   |
 |------------|------------------------------|
 |ByteFlags   |An 8-bit record of bit flags. |
@@ -172,7 +174,8 @@ There are over a dozen different types of handles that can be used by any sort
 of geode. These are listed in Table 5-3, along with a brief description of each. 
 All are 16-bit unsigned integers.
 
-**Table 5-3** Handle Types  
+**Table 5-3** Handle Types
+
 |Type Name       |Description                                       |
 |----------------|--------------------------------------------------|
 |Handle          |All-purpose handle.                               |

--- a/TechDocs/Markdown/Concepts/cmath.md
+++ b/TechDocs/Markdown/Concepts/cmath.md
@@ -118,7 +118,8 @@ function names and the operations they perform.
 |FloatInt()       |(int) X     |returns integer of X, rounded down|
 |FloatIntFrac()   |            |separates X into integer and fraction|
 |FloatRound()     |            |rounds X to a given decimal places|
-**Table D-1** Basic FP Functions and corresponding C operations (if any)
+
+**Table 4-1** Basic FP Functions and corresponding C operations (if any)
 
 If you wish to call these routines directly rather than rely on the C 
 operations, you may manipulate the floating point stack directly. To add 
@@ -205,6 +206,7 @@ for more details on using these functions.
 |FloatLn1plusX()   |               |natural log of (1 + X)       |
 |FloatSqr()        |               |square of X                  |
 |FloatSqrt()       |sqrt()         |square root                  |
+
 **Table 4-2** Transcendental Floating Point Functions
 
 #### D.1.3 Random Number Generation

--- a/TechDocs/Markdown/Concepts/cparse.md
+++ b/TechDocs/Markdown/Concepts/cparse.md
@@ -244,6 +244,7 @@ Operators of the same precedence level are grouped from left to right; that is,
 |<=       |Boolean or string less-than-or-equal-to
 |>        |Boolean or string greater-than
 |>=       |Boolean or string greater-than-or-equal-to
+
 **Table 20-1** Parse Library Operators
 
  **:** This is a range separator. The range separator is a binary infix 

--- a/TechDocs/Markdown/Concepts/cshapes.md
+++ b/TechDocs/Markdown/Concepts/cshapes.md
@@ -1014,7 +1014,8 @@ the color values and flags stored with the GState.
 |C_LIGHT_VIOLET|0x0D  |0xFF  |0x55  |0xFF  |
 |C_YELLOW      |0x0E  |0xFF  |0xFF  |0x55  |
 |C_WHITE       |0x0F  |0xFF  |0xFF  |0xFF  |
-**Table 24-1** Convenient Color Indexes
+
+**Table 24-1** Convenient Color Indexes  
 _These are the first 16 members of the Color enumerated type. For a full list 
 of available Color values, see the Routines reference or color.h._
 
@@ -1461,6 +1462,7 @@ whole is stored in a **DashPairArray**. Dash lengths will scale with the line wi
 |LS_DOTTED   |1      |1 2          |
 |LS_DASHDOT	 |2      |4 4 1 4      |
 |LS_DASHDDOT |3      |4 4 1 4 1 4  |
+
 **Table 24-2** Arrays for System Line Styles
 
 Line joins govern the behavior of angles and corners. Using the appropriate 

--- a/TechDocs/Markdown/Esp/ebasics.md
+++ b/TechDocs/Markdown/Esp/ebasics.md
@@ -234,6 +234,7 @@ structures. The types are listed in Table 2-1.
 |lptr      |2    |Chunk handle (i.e. near pointer to a near pointer)     |
 |optr      |4    |object descriptor; high word is hptr, low word is lptr |
 |sptr      |2    |Segment address (or descriptor).                       |
+
 **Table 2-1** Major Esp Data Types  
 _These are the main Esp data types, with their size in bytes._
 
@@ -1102,6 +1103,7 @@ passing the "-m" flag to Esp.
 |\"                 |Double-quote             |
 |\000               |ASCII code in octal      |
 |\x00               |ASCII code in hexadecimal|
+
 **Table 2-2** Esp Escape Sequences
 
 ##### 2.3.4.1 Pseudo-Ops and Directives
@@ -1170,6 +1172,7 @@ If you use .TYPE with a code-related expression, the high byte is set thus:
 |13       |Procedure is a private static method    |
 |14       |Procedure is a dynamic method           |
 |15       |Procedure is a method                   |
+
 **Table 2-3** .TYPE high-byte return values
 
 **LENGTH and SIZE**

--- a/TechDocs/Markdown/Gemfile
+++ b/TechDocs/Markdown/Gemfile
@@ -1,15 +1,13 @@
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 4.3.2" # installed by `gem jekyll`
-# gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
+gem "jekyll", "~> 4.4.1" # installed by `gem jekyll`
 
-gem "just-the-docs", "0.7.0" # pinned to the current release
-# gem "just-the-docs"        # always download the latest release
+gem "just-the-docs", github: "mgroeber9110/just-the-docs", branch: "1210-index-on-web-worker"
 
 group :jekyll_plugins do
   gem "jekyll-github-metadata"
   gem "jekyll-relative-links"
-  gem "jekyll-optional-front-matter"
+  gem "jekyll-optional-front-matter", github: "mgroeber9110/jekyll-optional-front-matter", branch: "42-keep-pages-sorted-after-adding"
   gem "jekyll-titles-from-headings"
   gem "jekyll-default-layout"
 end

--- a/TechDocs/Markdown/Gemfile.lock
+++ b/TechDocs/Markdown/Gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: https://github.com/mgroeber9110/jekyll-optional-front-matter.git
+  revision: adf26b2d7a41a87bfee2fa0d05ea1652c96bd916
+  branch: 42-keep-pages-sorted-after-adding
+  specs:
+    jekyll-optional-front-matter (0.3.2)
+      jekyll (>= 3.0, < 5.0)
+
+GIT
+  remote: https://github.com/mgroeber9110/just-the-docs.git
+  revision: cee67f5dd5aff4e1606764506adee0f359af1909
+  branch: 1210-index-on-web-worker
+  specs:
+    just-the-docs (0.10.1)
+      jekyll (>= 3.8.5)
+      jekyll-include-cache
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -5,7 +24,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -15,26 +35,25 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.15.5)
-    ffi (1.15.5-x64-mingw-ucrt)
+    ffi (1.17.2)
     forwardable-extended (2.6.0)
-    google-protobuf (3.24.3-arm64-darwin)
-    google-protobuf (3.24.3-x64-mingw-ucrt)
-    google-protobuf (3.24.3-x86_64-linux)
     http_parser.rb (0.8.0)
-    i18n (1.14.1)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.2)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
+      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
@@ -47,29 +66,23 @@ GEM
       octokit (>= 4, < 7, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-optional-front-matter (0.3.2)
-      jekyll (>= 3.0, < 5.0)
     jekyll-relative-links (0.7.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-titles-from-headings (0.5.3)
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.7.0)
-      jekyll (>= 3.8.5)
-      jekyll-include-cache
-      jekyll-seo-tag (>= 2.0)
-      rake (>= 12.3.1)
-    kramdown (2.4.0)
-      rexml
+    json (2.12.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
@@ -79,27 +92,23 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.3)
-    rake (13.0.6)
+    rake (13.3.0)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
-    rouge (4.1.3)
+    rexml (3.4.1)
+    rouge (4.5.2)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.67.0-arm64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.67.0-x64-mingw-ucrt)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.67.0-x86_64-linux-gnu)
-      google-protobuf (~> 3.23)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.4.2)
-    webrick (1.8.1)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
 
 PLATFORMS
   arm64-darwin-23
@@ -107,13 +116,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll (~> 4.3.2)
+  jekyll (~> 4.4.1)
   jekyll-default-layout
   jekyll-github-metadata
-  jekyll-optional-front-matter
+  jekyll-optional-front-matter!
   jekyll-relative-links
   jekyll-titles-from-headings
-  just-the-docs (= 0.7.0)
+  just-the-docs!
 
 BUNDLED WITH
    2.3.26

--- a/TechDocs/Markdown/Objects/ogen.md
+++ b/TechDocs/Markdown/Objects/ogen.md
@@ -1289,9 +1289,9 @@ modified keystrokes, which may confuse the user. In general, it is good
 practice to use the "control" key exclusively for keyboard accelerators to 
 prevent overlapping with GEOS keyboard acclelators and mnemonics.
 
-**Table 2-1** *Valid Action Keys for Keyboard Accelerators*  
-*These keys are only valid using the specific UI keyword. These Action Keys 
-must also be combined with valid Modifiers (alt, shift, or ctrl)*.  
+**Table 2-1** Valid Action Keys for Keyboard Accelerators.  
+_These keys are only valid using the specific UI keyword. These Action Keys 
+must also be combined with valid Modifiers (alt, shift, or ctrl)_
 
 	NUMPAD_0				SPACE		UP
 	NUMPAD_1				TAB			DOWN

--- a/TechDocs/Markdown/Objects/ogenint.md
+++ b/TechDocs/Markdown/Objects/ogenint.md
@@ -2741,7 +2741,7 @@ moniker chosen by the Specific UI.
 The standard response triggers (and their visual monikers under OSF/Motif) 
 for each *GII_type* are shown in Table 7-1.
 
-**Table 7-1** *Standard Response Triggers*
+**Table 7-1** Standard Response Triggers
 
 	Interaction Type	Trigger Type	Moniker
 

--- a/TechDocs/Markdown/Objects/ogenval.md
+++ b/TechDocs/Markdown/Objects/ogenval.md
@@ -861,7 +861,7 @@ inch) respectively. This is necessary because the system expects these values
 to be in Points for other system operations. A conversion table is provided in 
 Table 8-1 for setting up these initial values.
 
-**Table 8-1** *Conversions to US Points*
+**Table 8-1** Conversions to US Points
 
 	Distance Unit		Multiplier  
 	Inches				72  

--- a/TechDocs/Markdown/Objects/open.md
+++ b/TechDocs/Markdown/Objects/open.md
@@ -317,7 +317,7 @@ bitstream. Coordinates may be recorded either as absolute positions or as
 offsets from the last coordinate. See Table 21-1 for a list of components of this 
 bitstream. 
 
-**Table 21-1** *Components of the Ink's Bitstream*
+**Table 21-1** Components of the Ink's Bitstream
 
 	Bit Pattern					Meaning						Total Bits
 	00							0 offset							2

--- a/TechDocs/Markdown/Tools/tswatcm.md
+++ b/TechDocs/Markdown/Tools/tswatcm.md
@@ -179,7 +179,7 @@ Another important way of representing the symbol is as a *segment:offset* pair. 
 Some examples of address expressions are shown in Table 3-1.
 
 ----------
-**Table 3-1 Address Expressions**
+**Table 3-1** Address Expressions
 
 	Type							Example
 

--- a/TechDocs/Markdown/Tools/tswtj_z.md
+++ b/TechDocs/Markdown/Tools/tswtj_z.md
@@ -1004,7 +1004,7 @@ which comes from the following command set: (see Table 4-2)
 
 ----------
 
-**Table 4-2 Patch Command Set**
+**Table 4-2** Patch Command Set
 
 	Form					Meaning					Example
 

--- a/TechDocs/Markdown/Tools/ttcl.md
+++ b/TechDocs/Markdown/Tools/ttcl.md
@@ -294,7 +294,7 @@ the next character. For example, in the command:
 the first argument will be \\*a and the second \\{test.
 
 
-**Table 5-1 *Backslash Sequences***
+**Table 5-1** Backslash Sequences
 
 ----------
 
@@ -345,9 +345,7 @@ in octal (if the first character of the value of the first character is 0 (zero)
 in hexadecimal (if the first two characters of the value are 0x). The valid 
 operators are listed in Table 5-2 grouped in decreasing order of precedence.
 
-**Table 5-2 Valid Operators**
-
-----------
+**Table 5-2** Valid Operators
 
 	Operators			Description  
 	-   ~   !			Unary minus, bit-wise NOT, logical NOT  
@@ -2247,9 +2245,7 @@ automatically deleted.
 integer is a mask of bits that mean different things:
 
 
-**Table 5-3** *The State Subcommand: Block Information*
-
-----------
+**Table 5-3** The State Subcommand: Block Information
 
 	Mask		State			Mask		State  
 	0xf8000		Type			0x00200		Attached  
@@ -2263,9 +2259,7 @@ integer is a mask of bits that mean different things:
 When the integer is AND-ed with the mask for Type (0xf8000), the following 
 values indicate the following types of handles:
 
-**Table 5-4** *The State Subcommand: Block Type*
-
-----------
+**Table 5-4** The State Subcommand: Block Type
 
 	Mask		State  
 	0xe0000		Thread  

--- a/TechDocs/Markdown/Tools/ttools.md
+++ b/TechDocs/Markdown/Tools/ttools.md
@@ -1311,9 +1311,7 @@ would send the file DRIVER\VIDEO\DUMB\HGC\HGCEC.GEO (HGC.GEO if
 sending non-EC). Typing "pcs -S pcb" would send that file, and also 
 DRIVER\MOUSE\LOGIBUS\LOGIBUSE.GEO (or LOGIBUS.GEO). 
 
-**Table 10-1** *Destination of Files Sent by Pcs*
-
-----------
+**Table 10-1** Destination of Files Sent by Pcs
 
 	Development Directory 				Suffix 		Target Directory
 

--- a/TechDocs/Markdown/_config.yml
+++ b/TechDocs/Markdown/_config.yml
@@ -19,6 +19,25 @@ plugins:
 
 github: [metadata]
 
+search:
+  # Split pages into sections that can be searched individually
+  # Supports 1 - 6, default: 4
+  heading_level: 4
+  # Maximum amount of previews per search result
+  # Default: 3
+  previews: 2
+  # Maximum amount of words to display before a matched word in the preview
+  # Default: 5
+  preview_words_before: 3
+  # Maximum amount of words to display after a matched word in the preview
+  # Default: 10
+  preview_words_after: 3
+  # Focus the search input by pressing `ctrl + focus_shortcut_key` (or `cmd + focus_shortcut_key` on macOS)
+  focus_shortcut_key: "k"
+
+optional_front_matter:
+  remove_originals: true
+
 defaults:
   -
     scope:


### PR DESCRIPTION
Updates to the latest Jekyll version for generating the documentation website.

This process now uses fixed versions of the `just-the-docs` theme and the `jekyll-optional-front-matter` plugin that improve the quality of the index, and run indexing in the background, so that page layout and scrolling does not freeze. These fixes are currently just on my private branches of these plugins, but submitted to upstream.

Also, I fixed a few table captions to make sure the Markdown parser of Jekyll renders the tables correctly.

One simple, but wide-ranging change that I will do separately (to keep the diffs more readable) is to switch the assumed tab size from 4 to 8 in the documentation, as this is the default that browsers typically use.