### PR TITLE
re-enable jpeg size control in ImpGraph...

### DIFF
--- a/Library/Breadbox/ImpGraph/IMPBMP/impjpeg.goc
+++ b/Library/Breadbox/ImpGraph/IMPBMP/impjpeg.goc
@@ -192,9 +192,9 @@ JpegImport(TCHAR *file,
            XYSize *picsize,
            MimeRes resolution,
            AllocWatcherHandle watcher,
-           dword *usedMem, 
+           dword *usedMem,
 #if SCANLINE_COMPRESS
-           Boolean scanlineCompress, 
+           Boolean scanlineCompress,
 #endif
            Boolean *p_completeGraphic
 #if PROGRESS_DISPLAY
@@ -259,7 +259,7 @@ EC(dword cbSize = 0;)
   } else {
       filehan = FileOpen(file, FILE_ACCESS_R|FILE_DENY_W);
       if(filehan == 0) {
-        
+
         free(cinfo);
         return(0);
       }
@@ -306,7 +306,7 @@ EC(dword cbSize = 0;)
       if (status == FALSE) FileClose(filehan, TRUE);
   }
   if (status == FALSE) {
-      
+
       free(cinfo);
       return 0;
   }
@@ -399,10 +399,10 @@ EC(dword cbSize = 0;)
       /* More clean up */
 #if SCANLINE_COMPRESS
       if (scanlineCompress) {
-        if (cBuf) 
+        if (cBuf)
             MemFree(cBuf);
 #if LZG_COMPRESS
-        if (lzgCompress && lzgStack) 
+        if (lzgCompress && lzgStack)
             LZGFreeCompressStack(lzgStack);
 #endif /* LZG_COMPRESS */
       }
@@ -452,10 +452,10 @@ EC(dword cbSize = 0;)
   gotTempAlloc = AllocWatcherAllocate(watcher, requiredTempMemory) ;
 
   /* Don't do graphics bigger than 1024 x or 1024 y (either way) */
-  if (headerErr==FALSE && gotTempAlloc/* &&
+  if (headerErr==FALSE && gotTempAlloc &&
       ((picsize->XYS_width <= 2048) && (picsize->XYS_height <= 2048)) &&
       (((dword)(picsize->XYS_width) * (dword)(picsize->XYS_height)) <=
-       (1024L * 1024L))*/)  {
+       (1024L * 1024L)))  {
       /* Step 4: set parameters for decompression */
 
       cinfo->dct_method = JDCT_FASTEST;        /* fastest, but less acurate */
@@ -768,7 +768,7 @@ EC(dword cbSize = 0;)
 #if PROGRESS_DISPLAY
 	/* send out progress if desired number of scanlines have been seen */
 	if (importProgressDataP && importProgressDataP->IPD_callback &&
-	    (((cinfo->output_scanline % SLICE_HEIGHT) == 0) || 
+	    (((cinfo->output_scanline % SLICE_HEIGHT) == 0) ||
                  (cinfo->output_scanline == cinfo->output_height))) {
 	    importProgressDataP->IPD_bitmap = bmblock;
 	    importProgressDataP->IPD_iad.IAD_size.XYS_width = cinfo->output_width;
@@ -850,7 +850,7 @@ EC(dword cbSize = 0;)
   if(flag == FALSE)
         dataVMBlock = bmblock;
   else                        /* import failed: release bitmap right now */
-  {                           
+  {
         VMFreeVMChain(vmf, VMCHAIN_MAKE_FROM_VM_BLOCK(bmblock));
         dataVMBlock = 0;
   }


### PR DESCRIPTION
... for IjPGjPG - if fjpg failed to load, ijpg was still trying to load the image (and failed on big images), because the size check was disabled (why?)