### PR TITLE
TTF driver: Style detection, width rounding, and char-mapping fixes

### DIFF
--- a/Driver/Font/TrueType/Adapter/ttcharmapper.c
+++ b/Driver/Font/TrueType/Adapter/ttcharmapper.c
@@ -251,7 +251,7 @@ word geosCharMap[] =
         C_LATIN_CAPITAL_LETTER_I_GRAVE, 
         C_LATIN_CAPITAL_LETTER_O_ACUTE, 
         C_LATIN_CAPITAL_LETTER_O_CIRCUMFLEX,  
-        //no character
+        0,  //no character
         C_LATIN_CAPITAL_LETTER_O_GRAVE, 
         C_LATIN_CAPITAL_LETTER_U_ACUTE, 
         C_LATIN_CAPITAL_LETTER_U_CIRCUMFLEX, 

--- a/Driver/Font/TrueType/Adapter/ttinit.c
+++ b/Driver/Font/TrueType/Adapter/ttinit.c
@@ -687,7 +687,7 @@ static AdjustedWeight mapFontWeight( TT_Short weightClass )
 
 static TextStyle mapTextStyle( const char* subfamily )
 {
-        if ( strcmp( subfamily, "Regular" ) == 0 || strcmp( subfamily, "Medium" ) == 0 )
+        if ( strcmp( subfamily, "Regular" ) == 0 || strcmp( subfamily, "Medium" ) == 0 || strcmp( subfamily, "Roman" ) == 0 )
                 return 0x00;
         if ( strcmp( subfamily, "Bold" ) == 0 )
                 return TS_BOLD;

--- a/Driver/Font/TrueType/Adapter/ttwidths.c
+++ b/Driver/Font/TrueType/Adapter/ttwidths.c
@@ -330,8 +330,11 @@ EC(             ECCheckBounds( (void*)charTableEntry ) );
                         /* load metrics */
                         TT_Get_Index_Metrics( FACE, charIndex, &GLYPH_METRICS );
 
-                        /* fill CharTableEntry */
+                        /* compute scaled advance width for glyph and round it to neares 1/4 pixel */
                         scaledWidth = GrMulWWFixed( MakeWWFixed( GLYPH_METRICS.advance), SCALE_WIDTH );
+                        scaledWidth += 0x2000;
+
+                        /* fill CharTableEntry */
                         charTableEntry->CTE_width.WBF_int  = INTEGER_OF_WWFIXEDASDWORD( scaledWidth );
                         charTableEntry->CTE_width.WBF_frac = FRACTION_OF_WWFIXEDASDWORD( scaledWidth );
                         charTableEntry->CTE_dataOffset     = CHAR_NOT_BUILT;


### PR DESCRIPTION
This pull request introduces several improvements to the TTF driver:
- The subfamily name "Roman" is now correctly recognized as Regular style.
- The extended glyph width is now rounded to 1/4 pixel for improved rendering consistency.
- Fixed an issue in character mapping that caused incorrect glyph lookup in certain cases.