### PR TITLE
Fix KR-09 when reflowing table layout after loading images

### DIFF
--- a/Library/Breadbox/Html4Par/htmlclas/htmltcel.goc
+++ b/Library/Breadbox/Html4Par/htmlclas/htmltcel.goc
@@ -626,7 +626,7 @@ word IRegionRepositionResizeAndReflow(
 
     RegionPurgeCache(oself) ;
     if (width < REGION_MINIMUM_WIDTH)
-	width = REGION_MINIMUM_WIDTH ;
+        width = REGION_MINIMUM_WIDTH ;
     if (width>MAXIMUM_COLUMN_WIDTH) {
         width = MAXIMUM_COLUMN_WIDTH ;
     }
@@ -713,11 +713,11 @@ word IRegionRepositionResizeAndReflow(
         }
         oldWidth = p_region->VLTRAE_size.XYS_width ;
         p_region->VLTRAE_size.XYS_width = width ;
-	lineCount = p_region->VLTRAE_lineCount;
-	charCount = p_region->VLTRAE_charCount;
-	/* Don't want to keep it in memory if we are going to move */
-	/* things around. */
-	RegionUnlock(p_region) ;
+        lineCount = p_region->VLTRAE_lineCount;
+        charCount = p_region->VLTRAE_charCount;
+        /* Don't want to keep it in memory if we are going to move */
+        /* things around. */
+        RegionUnlock(p_region) ;
 
         if (charCount)  {
             ProfPoint("IRegionRepositionResizeAndReflow--Pre") ;
@@ -741,12 +741,12 @@ word IRegionRepositionResizeAndReflow(
                         width))  {
                     /* Adjust failed.  Let's do the old fashion way */
                     @call oself::MSG_VIS_TEXT_INVALIDATE_RANGE(&range);
-		}
+                }
             }
             ProfPoint("IRegionRepositionResizeAndReflow--Post") ;
             RegionPurgeCache(oself) ;
-	    /* Purge seek cache: overflow regions may have been inserted */
-	    p_stack->LS_lastSeekedRegion = 0xFFFF ;
+            /* Purge seek cache: overflow regions may have been inserted */
+            p_stack->LS_lastSeekedRegion = 0xFFFF ;
         }
 
         /* We are now back.  All lines have been reformatted. */


### PR DESCRIPTION
This fixes the crash observed on the guestbook of theoldnet.com, which was caused by the overflowing of some regions after loading graphics. This caused new regions to be inserted into the region array in the middle of a layout update, making the cached position in the region array invalid.

While looking at this code, I also noticed that the unlocking/re-locking of the region around a reflow could be made a bit more readable.

Close #1020.