### PR TITLE
Browser: use character style from enclosing element for list bullets

### DIFF
--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -80,6 +80,7 @@ dword textpos;
 
 word            currentFlags;
 VisTextCharAttr currentCS;
+VisTextCharAttr parentCS;
 VisTextParaAttr currentS;
 sword           currentBaseFont;
 
@@ -1056,7 +1057,7 @@ void AddParaCond(void)
         *insertPrepend = 0;
 
       if(*insertPrepend)                /* prepend text to paragraph? */
-        AddText(&currentCS, insertPrepend);
+        AddText(&parentCS, insertPrepend);
 
       FixupStartPos(pos);               /* fixup tag starting positions on
                                            stack to after prepended text */

--- a/Library/Breadbox/Html4Par/htmlpars/parstags.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/parstags.goc
@@ -161,6 +161,7 @@ void GetCurrentStyles(void)
       if((HTMLext->HE_options & HTML_READ_FAST) && (tagStack->spec != SPEC_A))
         continue;                       /* fast: ignore everything but links */
 
+      parentCS = currentCS;
       ApplyCharacterDelta( &currentCS, &(tagStack->charDelta) );
 
       if(tagStack->delta.PSD_which & PSD_RESET)

--- a/Library/Breadbox/Html4Par/internal.h
+++ b/Library/Breadbox/Html4Par/internal.h
@@ -278,6 +278,7 @@ extern dword textpos;
 
 extern word            currentFlags;
 extern VisTextCharAttr currentCS;
+extern VisTextCharAttr parentCS;
 extern VisTextParaAttr currentS;
 extern sword           currentBaseFont;
 


### PR DESCRIPTION
This fixes the issue described in https://www.geos-infobase.de/WBB_317/forum/index.php?thread/3091-webmagick/&postID=22802#post22802 where the bullet points (or numbers) of a list take over the character style of the first character in the item, rather than that of the enclosing list, as in other browsers.

We had already fixed this last year to not use the default style, but from looking at examples in another browser, using the style of the parent element looks more correct.