### PR TITLE
Ttf driver remove big glyph metrics

### DIFF
--- a/Driver/Font/TrueType/FreeType/freetype.h
+++ b/Driver/Font/TrueType/FreeType/freetype.h
@@ -229,47 +229,6 @@
   typedef struct TT_Glyph_Metrics_  TT_Glyph_Metrics;
 
 
-  /* A structure used to return horizontal _and_ vertical glyph         */
-  /* metrics.                                                           */
-  /*                                                                    */
-  /* A glyph can be used either in a horizontal or vertical layout.     */
-  /* Its glyph metrics vary with orientation.  The TT_Big_Glyph_Metrics */
-  /* structure is used to return _all_ metrics in one call.             */
-
-  struct TT_Big_Glyph_Metrics_
-  {
-    TT_BBox  bbox;          /* glyph bounding box */
-
-    TT_Pos   horiBearingX;  /* left side bearing in horizontal layouts */
-    TT_Pos   horiBearingY;  /* top side bearing in horizontal layouts  */
-
-    TT_Pos   vertBearingX;  /* left side bearing in vertical layouts */
-    TT_Pos   vertBearingY;  /* top side bearing in vertical layouts  */
-
-    TT_Pos   horiAdvance;   /* advance width for horizontal layout */
-    TT_Pos   vertAdvance;   /* advance height for vertical layout  */
-
-    /* The following fields represent unhinted scaled metrics values. */
-    /* They can be useful for applications needing to do some device  */
-    /* independent placement of glyphs.                               */
-    /*                                                                */
-    /* Applying these metrics to hinted glyphs will most surely ruin  */
-    /* the grid fitting performed by the bytecode interpreter.  These */
-    /* values are better used to compute accumulated positioning      */
-    /* distances.                                                     */
-
-  #ifdef TT_CONFIG_OPTION_SUPPORT_OPTIONAL_FIELDS
-    TT_Pos   linearHoriBearingX;  /* linearly scaled horizontal lsb     */
-    TT_Pos   linearHoriAdvance;   /* linearly scaled horizontal advance */
-
-    TT_Pos   linearVertBearingY;  /* linearly scaled vertical tsb     */
-    TT_Pos   linearVertAdvance;   /* linearly scaled vertical advance */
-  #endif
-  };
-
-  typedef struct TT_Big_Glyph_Metrics_  TT_Big_Glyph_Metrics;
-
-
   /* A structure used to return instance metrics. */
 
   struct  TT_Instance_Metrics_
@@ -491,7 +450,7 @@
     TT_FWord   xAvgCharWidth;
     TT_UShort  usWeightClass;
 
-    #ifdef TT_CONFIG_OPTION_SUPPORT_OPTIONAL_FIELDS
+#ifdef TT_CONFIG_OPTION_SUPPORT_OPTIONAL_FIELDS
     TT_UShort  usWidthClass;
     TT_Short   fsType;
     TT_FWord   ySubscriptXSize;

--- a/Driver/Font/TrueType/FreeType/ttapi.c
+++ b/Driver/Font/TrueType/FreeType/ttapi.c
@@ -713,10 +713,7 @@ extern TEngine_Instance engineInstance;
     if ( !_glyph )
       return TT_Err_Invalid_Glyph_Handle;
 
-    metrics->bbox     = _glyph->metrics.bbox;
-    metrics->bearingX = _glyph->metrics.horiBearingX;
-    metrics->bearingY = _glyph->metrics.horiBearingY;
-    metrics->advance  = _glyph->metrics.horiAdvance;
+    *metrics = _glyph->metrics;
 
     return TT_Err_Ok;
   }

--- a/Driver/Font/TrueType/FreeType/ttconfig.h
+++ b/Driver/Font/TrueType/FreeType/ttconfig.h
@@ -36,14 +36,6 @@
 #include "ft_conf.h"
 
 
-/**************************************************************************/
-/* Define TT_CONFIG_THREAD_SAFE if you want to build a thread-safe        */
-/* version of the library.                                                */
-
-/* #define TT_CONFIG_OPTION_THREAD_SAFE */
-
-
-
 /* ------------ general debugging -------------------------------------- */
 
 

--- a/Driver/Font/TrueType/FreeType/ttfile.c
+++ b/Driver/Font/TrueType/FreeType/ttfile.c
@@ -95,7 +95,6 @@
   {
     Long        position;                /* current position within the file */
     FileHandle  file;                    /* file handle                      */
-    Long        base;                    /* stream base in file              */
     Long        size;                    /* stream size in file              */
   };
 
@@ -780,7 +779,6 @@
 
     stream_rec->file     = file;
     stream_rec->size     = -1L;
-    stream_rec->base     = 0;
     stream_rec->position = 0;
 
     error = Stream_Activate( stream_rec );
@@ -875,8 +873,6 @@
   EXPORT_FUNC
   TT_Error  TT_Seek_File( STREAM_ARGS Long  position )
   {
-    position += CUR_Stream->base;
-
     FilePos( CUR_Stream->file, position, FILE_POS_START );
     if ( ThreadGetError() != NO_ERROR_RETURNED )  
       return TT_Err_Invalid_File_Offset;
@@ -900,8 +896,8 @@
   EXPORT_FUNC
   TT_Error  TT_Skip_File( STREAM_ARGS Long  distance )
   {
-    return TT_Seek_File( STREAM_VARS FilePos( CUR_Stream->file, 0, FILE_POS_RELATIVE ) -
-                                    CUR_Stream->base + distance );
+    return TT_Seek_File( STREAM_VARS FilePos( CUR_Stream->file, 0, FILE_POS_RELATIVE ) +
+                                    distance );
   }
 
 
@@ -973,7 +969,7 @@
   EXPORT_FUNC
   Long  TT_File_Pos( STREAM_ARG )
   {
-    return FilePos( CUR_Stream->file, 0, FILE_POS_RELATIVE ) - CUR_Stream->base;
+    return FilePos( CUR_Stream->file, 0, FILE_POS_RELATIVE );
   }
 
 

--- a/Driver/Font/TrueType/FreeType/ttgload.c
+++ b/Driver/Font/TrueType/FreeType/ttgload.c
@@ -353,11 +353,11 @@
     /* We need the left side bearing and advance width. */
 
     /* pp1 = xMin - lsb */
-    vec[n_points].x = subg->metrics.bbox.xMin - subg->metrics.horiBearingX;
+    vec[n_points].x = subg->metrics.bbox.xMin - subg->metrics.bearingX;
     vec[n_points].y = 0;
 
     /* pp2 = pp1 + aw */
-    vec[n_points+1].x = vec[n_points].x + subg->metrics.horiAdvance;
+    vec[n_points+1].x = vec[n_points].x + subg->metrics.advance;
     vec[n_points+1].y = 0;
 
     /* clear the touch flags */
@@ -569,8 +569,8 @@
     element->transform.ox = 0;
     element->transform.oy = 0;
 
-    element->metrics.horiBearingX = 0;
-    element->metrics.horiAdvance  = 0;
+    element->metrics.bearingX = 0;
+    element->metrics.advance  = 0;
   }
 
 
@@ -746,8 +746,8 @@
           if ( (!(load_flags & TTLOAD_IGNORE_GLOBAL_ADVANCE_WIDTH)) && face->postscript.isFixedPitch )
             advance_width = face->horizontalHeader.advance_Width_Max;
 
-          subglyph->metrics.horiBearingX = left_bearing;
-          subglyph->metrics.horiAdvance  = advance_width;
+          subglyph->metrics.bearingX = left_bearing;
+          subglyph->metrics.advance  = advance_width;
         }
 
         phase = Load_Header;
@@ -784,7 +784,7 @@
           subglyph->metrics.bbox.yMax = 0;
 
           subglyph->pp1.x = 0;
-          subglyph->pp2.x = subglyph->metrics.horiAdvance;
+          subglyph->pp2.x = subglyph->metrics.advance;
           if (load_flags & TTLOAD_SCALE_GLYPH)
             subglyph->pp2.x = Scale_X( &exec->metrics, subglyph->pp2.x );
 
@@ -818,9 +818,9 @@
         }
 
         subglyph->pp1.x = subglyph->metrics.bbox.xMin -
-                          subglyph->metrics.horiBearingX;
+                          subglyph->metrics.bearingX;
         subglyph->pp1.y = 0;
-        subglyph->pp2.x = subglyph->pp1.x + subglyph->metrics.horiAdvance;
+        subglyph->pp2.x = subglyph->pp1.x + subglyph->metrics.advance;
         if (load_flags & TTLOAD_SCALE_GLYPH)
         {
           subglyph->pp1.x = Scale_X( &exec->metrics, subglyph->pp1.x );
@@ -1017,8 +1017,8 @@
           if ( !subglyph->preserve_pps &&
                subglyph->element_flag & USE_MY_METRICS )
           {
-            subglyph->metrics.horiBearingX = subglyph2->metrics.horiBearingX;
-            subglyph->metrics.horiAdvance  = subglyph2->metrics.horiAdvance;
+            subglyph->metrics.bearingX = subglyph2->metrics.bearingX;
+            subglyph->metrics.advance  = subglyph2->metrics.advance;
 
             subglyph->pp1 = subglyph2->pp1;
             subglyph->pp2 = subglyph2->pp2;
@@ -1169,8 +1169,8 @@
       TT_Pos  advance;
 
 
-      left_bearing = subglyph->metrics.horiBearingX;
-      advance      = subglyph->metrics.horiAdvance;
+      left_bearing = subglyph->metrics.bearingX;
+      advance      = subglyph->metrics.advance;
 
       if ( face->postscript.isFixedPitch )
         advance = face->horizontalHeader.advance_Width_Max;
@@ -1180,30 +1180,15 @@
         left_bearing = Scale_X( &exec->metrics, left_bearing );
         advance      = Scale_X( &exec->metrics, advance      );
       }
-
-#ifdef TT_CONFIG_OPTION_SUPPORT_OPTIONAL_FIELDS
-      glyph->metrics.linearHoriBearingX = left_bearing;
-      glyph->metrics.linearHoriAdvance  = advance;
-#endif
     }
 
-    glyph->metrics.horiBearingX = glyph->metrics.bbox.xMin;
-    glyph->metrics.horiBearingY = glyph->metrics.bbox.yMax;
-    glyph->metrics.horiAdvance  = subglyph->pp2.x - subglyph->pp1.x;
+    glyph->metrics.bearingX = glyph->metrics.bbox.xMin;
+    glyph->metrics.bearingY = glyph->metrics.bbox.yMax;
+    glyph->metrics.advance  = subglyph->pp2.x - subglyph->pp1.x;
 
     /* Now take care of vertical metrics.  In the case where there is    */
     /* no vertical information within the font (relatively common), make */
     /* up some metrics `by hand' ...                                     */
-
-    {
-      Short   top_bearing;    /* vertical top side bearing (EM units) */
-      UShort  advance_height; /* vertical advance height (EM units)   */
-
-      TT_Pos  left;     /* scaled vertical left side bearing          */
-      TT_Pos  Top;      /* scaled original vertical top side bearing  */
-      TT_Pos  top;      /* scaled vertical top side bearing           */
-      TT_Pos  advance;  /* scaled vertical advance height             */
-
 
 #ifdef TT_CONFIG_OPTION_PROCESS_VMTX
       /* Get the unscaled `tsb' and `ah' values */
@@ -1218,69 +1203,8 @@
                         &top_bearing,
                         &advance_height );
       }
-      else
 #endif
-      {
-        /* Make up the distances from the horizontal header..     */
-
-        /* NOTE: The OS/2 values are the only `portable' ones,    */
-        /*       which is why we use them...                      */
-        /*                                                        */
-        /* NOTE2: The sTypoDescender is negative, which is why    */
-        /*        we compute the baseline-to-baseline distance    */
-        /*        here with :                                     */
-        /*             ascender - descender + linegap             */
-        /*                                                        */
-        top_bearing    = (Short) (face->os2.sTypoLineGap >> 1 );
-        advance_height = (UShort)(face->os2.sTypoAscender -
-                                  face->os2.sTypoDescender +
-                                  face->os2.sTypoLineGap);
-      }
-
-      /* We must adjust the top_bearing value from the bounding box given
-         in the glyph header to te bounding box calculated with
-         TT_Get_Outline_BBox()                                            */
-
-      /* scale the metrics */
-      if ( load_flags & TTLOAD_SCALE_GLYPH )
-      {
-        Top     = Scale_Y( &exec->metrics, top_bearing );
-        top     = Scale_Y( &exec->metrics,
-                           top_bearing + subglyph->metrics.bbox.yMax ) -
-                    glyph->metrics.bbox.yMax;
-        advance = Scale_Y( &exec->metrics, advance_height );
-      }
-      else
-      {
-        Top     = top_bearing;
-        top     = top_bearing + subglyph->metrics.bbox.yMax -
-                    glyph->metrics.bbox.yMax;
-        advance = advance_height;
-      }
-
-#ifdef TT_CONFIG_OPTION_SUPPORT_OPTIONAL_FIELDS
-      glyph->metrics.linearVertBearingY = Top;
-      glyph->metrics.linearVertAdvance  = advance;
-#endif
-
-      /* XXX : for now, we have no better algo for the lsb, but it should */
-      /*       work ok..                                                  */
-      /*                                                                  */
-      left = ( glyph->metrics.bbox.xMin - glyph->metrics.bbox.xMax ) >> 1;
-
-      /* grid-fit them if necessary */
-      if ( subglyph->is_hinted )
-      {
-        left   &= -64;
-        top     = (top + 63) & -64;
-        advance = (advance + 32) & -64;
-      }
-
-      glyph->metrics.vertBearingX = left;
-      glyph->metrics.vertBearingY = top;
-      glyph->metrics.vertAdvance  = advance;
-    }
-
+ 
 #ifdef TT_CONFIG_OPTION_PROCESS_HDMX
     /* Adjust advance width to the value contained in the hdmx table. */
     if ( !exec->face->postscript.isFixedPitch && instance &&
@@ -1289,7 +1213,7 @@
       widths = Get_Advance_Widths( exec->face,
                                    exec->instance->metrics.x_ppem );
       if ( widths )
-        glyph->metrics.horiAdvance = widths[glyph_index] << 6;
+        glyph->metrics.advance = widths[glyph_index] << 6;
     }
 #endif
 

--- a/Driver/Font/TrueType/FreeType/ttobjs.h
+++ b/Driver/Font/TrueType/FreeType/ttobjs.h
@@ -361,7 +361,7 @@
 
     Long         file_offset;
 
-    TT_Big_Glyph_Metrics  metrics;
+    TT_Glyph_Metrics  metrics;
 
     TGlyph_Zone  zone;
 
@@ -716,9 +716,9 @@
 
   struct TGlyph_
   {
-    PFace                 face;
-    TT_Big_Glyph_Metrics  metrics;
-    TT_Outline            outline;
+    PFace             face;
+    TT_Glyph_Metrics  metrics;
+    TT_Outline        outline;
   };
 
 


### PR DESCRIPTION
Changes to the TTF driver:

- TT_Big_Glyph_Metrics replaced by TT_Glyph_Metrics to save memory and improve performance when loading a glyph.
- Field base removed from TStream_Rec_ because it was never used.

These measures reduce the binary size of the driver by about 600 bytes.