### PR TITLE
Techdocs: standardize heading levels

### DIFF
--- a/TechDocs/Markdown/Asmref/agp.md
+++ b/TechDocs/Markdown/Asmref/agp.md
@@ -5,7 +5,7 @@ alphabetical order in this section. These keywords
 define how the Glue linker will link the geode.
 
 ----------
-#### appobj
+### appobj
     appobj  <name>
 
 The **appobj** field indicates the name of the application object. All geodes with 
@@ -15,7 +15,7 @@ in the application's **.goc** file.
 
 ----------
 
-#### class
+### class
     class   <name>
 
 The **class** field specifies the name of the object class to be bound to the geode's 
@@ -26,7 +26,7 @@ of this connection). Note that this class binding will only be for the geode's f
 (primary) thread.
 
 ----------
-#### driver
+### driver
     driver  <name> [noload]
 
 This field specifies another driver that is used by this geode. The *noload* flag 
@@ -37,7 +37,7 @@ that access serial and parallel ports-those geodes will include the serial or
 parallel driver.)
 
 ----------
-#### entry
+### entry
     entry   <name>
 
 This field is used by library geodes. The *name* argument is the name of the 
@@ -45,7 +45,7 @@ library routine to be called by the kernel when the library is loaded or unloade
 and when a program using the library is loaded or unloaded.
 
 ----------
-#### exempt
+### exempt
     exempt  <library-name>
 
 If you wish to exempt a certain library from Glue's platform checking, call it 
@@ -54,7 +54,7 @@ the library not normally available with platforms named in your **platform**
 statement.
 
 ----------
-#### export
+### export
     export  <name> [as <name2>]
 
 This field identifies routines usable by geodes other than the one being 
@@ -69,7 +69,7 @@ This field is also used to export classes defined in a **.goc** or **.goh** file
 World for an example of this usage.
 
 ----------
-#### incminor
+### incminor
     incminor [<name>]
 
 The **incminor** directive is used at the end of a library's **.gp** file before new 
@@ -89,7 +89,7 @@ the **protominor** label should be associated with the revision represented by t
 **incminor** directive.
 
 ----------
-#### library
+### library
     library <name> [noload]
 
 This field specifies another library that is used by this geode. The *noload* flag 
@@ -106,7 +106,7 @@ included in the **.gp** file. Most will also have the following line:
 Any number of used libraries may be specified.
 
 ----------
-#### load
+### load
     load    <name> ["<class>"] as [<name2>] [<align>] [<combine>]\ ["<class2>"]
 
 The **load** field is used when you want to alter the way a segment is linked for 
@@ -165,7 +165,7 @@ Examples:
     load _NAME_ "CODE" as DATASEG para common "DATA"
 
 ----------
-#### longname
+### longname
     longname "<string>"
 
 The **longname** field designates a 32-character name for the geode. This name 
@@ -173,7 +173,7 @@ will be displayed with the geode's icon by GeoManager; all geodes should be
 given a long name.
 
 ----------
-#### name
+### name
     name    <pname>.<ext>
 
 The **name** field in the parameters file gives the geode a permanent name which 
@@ -186,7 +186,7 @@ When Glue is linking an error-checking geode, it drops the fourth character of
 *ext* and adds "ec" to the end of *pname*.
 
 ----------
-#### nosort
+### nosort
     nosort
 
 This keyword should appear before the list of resources. Normally glue will sort 
@@ -197,7 +197,7 @@ geode order their resources in the same way. If you won't generate .GYM files,
 you probably don't want to use this option.
 
 ----------
-#### platform
+### platform
     platform <name>
 
 The platform directive specifies that the Geode is compatible with the named 
@@ -222,7 +222,7 @@ If the new routine happens to be a "published" routine, glue will copy it into t
 geode in an effort to avoid the error.
 
 ----------
-#### publish
+### publish
     publish <name>
 
 Normally, If a geode is required to run (via platform specifications) with a 
@@ -257,7 +257,7 @@ output by glue:
     APPRESOURCE                         416     1
 
 ----------
-#### resource
+### resource
     resource <name> (read-only|preload|discardable|fixed|conforming|shared|\
              code|data|lmem|discard-only|swap-only|ui-object|object|\
              no-swap|no-discard)+
@@ -343,7 +343,7 @@ listed below:
         resource <name> code
 
 ----------
-#### stack
+### stack
     stack   <number>
 
 The **stack** field designates the size of the application's stack in bytes. The 
@@ -353,7 +353,7 @@ smaller stack size for example only). The **stack** field is valid only for geod
 with a process aspect.
 
 ----------
-#### tokenchars
+### tokenchars
     tokenchars "<string>"
 
 This is one of two fields that identifies a unique token in GeoManager's token 
@@ -362,7 +362,7 @@ four characters that identifies the geode's token. Note that these characters
 also appear in the geode file's extended attributes.
 
 ----------
-#### tokenid
+### tokenid
     tokenid <number>
 
 This is the other of two fields that identifies a unique token in GeoManager's 
@@ -371,7 +371,7 @@ corresponding to the programmer's manufacturer ID number. Note that this
 number also appears in the geode file's extended attributes.
 
 ----------
-#### type
+### type
     type    (process|driver|appl|library)+ [single] [system] [uses-coproc]\
             [needs-coproc] [has-gcm] [c-api]
 
@@ -416,7 +416,7 @@ to locate all GCM applications.
 so the kernel must call them with C calling conventions.
 
 ----------
-#### usernotes
+### usernotes
     usernotes "<string>"
 
 This field specifies text to be put in the **.geo** file's usernotes field. The text must 

--- a/TechDocs/Markdown/Asmref/asma_d.md
+++ b/TechDocs/Markdown/Asmref/asma_d.md
@@ -8,7 +8,7 @@ following chapter.
 ## 2.1 Routines A-D
 
 ----------
-#### ArrayQuickSort
+### ArrayQuickSort
 Sort the given array using a modified quicksort algorithm.
 
 **Pass:**  
@@ -27,7 +27,7 @@ ax, cx, dx
 **Library:** chunkarr.def
 
 ----------
-#### CellDirty
+### CellDirty
 Mark a cell as dirty.
 
 **Pass:**  
@@ -42,7 +42,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### CellGetDBItem
+### CellGetDBItem
 Get the group and item numbers of the database item associated with the 
 specified cell.
 
@@ -62,7 +62,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### CellGetExtent
+### CellGetExtent
 Get the extent (bounds) of the current sheet of spreadsheet cells.
 
 **Pass:**  
@@ -82,7 +82,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### CellLock
+### CellLock
 Lock a cell's data to examine or change it. The cell should not be locked while 
 also working with other cells; the caller should lock the cell, copy the data, 
 then unlock it with **CellUnlock**.
@@ -102,7 +102,7 @@ di, unless it is returned.
 **Library:** cell.def
 
 ----------
-#### CellReplace
+### CellReplace
 Replace a cell's data with new data.
 
 **Pass:**  
@@ -121,7 +121,7 @@ Possibly **es**, if it pointed to a database item in the same file.
 **Library:** cell.def
 
 ----------
-#### CellUnlock
+### CellUnlock
 Unlock a cell previously locked with **CellLock**.
 
 **Pass:**  
@@ -138,7 +138,7 @@ become unlocked, that register will be set to NULL_SEGMENT.
 **Library:** cell.def
 
 ----------
-#### CheckForDamagedES
+### CheckForDamagedES
 When using the error-checking version of the ui, this routine checks the ES 
 register to make sure it points to a valid LMem block. This comes in handy 
 in code where *es:xx should point to an object.
@@ -157,7 +157,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### ChunkArrayAppend
+### ChunkArrayAppend
 Append a new element to the end of a chunk array.
 
 **Pass:**  
@@ -176,7 +176,7 @@ Nothing.
 chunks or elements within it.
 
 ----------
-#### ChunkArrayCreate
+### ChunkArrayCreate
 Create a new general chunk array with no elements.
 
 **Pass:**  
@@ -204,7 +204,7 @@ Nothing.
 pointers to it.
 
 ----------
-#### ChunkArrayDelete
+### ChunkArrayDelete
 Delete a specified element from the given array.
 
 **Pass:**  
@@ -220,7 +220,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ChunkArrayDeleteRange
+### ChunkArrayDeleteRange
 Delete a range of elements from the given chunk array.
 
 **Pass:**  
@@ -238,7 +238,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ChunkArrayElementResize
+### ChunkArrayElementResize
 Resize an element in a variable-sized chunk array.
 
 **Pass:**  
@@ -259,7 +259,7 @@ the block are invalidated. If you are resizing the element smaller, the array
 is guaranteed not to move or cause other chunks to move.
 
 ----------
-#### ChunkArrayElementToPtr
+### ChunkArrayElementToPtr
 Return the address of a specified element in a chunk array.
 
 **Pass:**  
@@ -280,7 +280,7 @@ Nothing.
 **Warning:** The error-checking version fatal-errors if passed CA_NULL_ELEMENT in ax.
 
 ----------
-#### ChunkArrayEnum
+### ChunkArrayEnum
 Process all elements in a chunk array, calling a callback routine for each.
 
 **Pass:**  
@@ -311,7 +311,7 @@ cx, dx, bp, es - Data to pass to next enumeration.
 **Library:** chunkarr.def
 
 ----------
-#### ChunkArrayEnumRange
+### ChunkArrayEnumRange
 Process the specified elements in a chunk array, calling a callback routine for 
 each element.
 
@@ -346,7 +346,7 @@ cx, dx, bp, es - Data to pass to next enumeration.
 **Library:** chunkarr.def
 
 ----------
-#### ChunkArrayGetCount
+### ChunkArrayGetCount
 Return the number of elements in the given chunk array.
 
 **Pass:**  
@@ -361,7 +361,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ChunkArrayGetElement
+### ChunkArrayGetElement
 Get an element given its element number.
 
 **Pass:**  
@@ -382,7 +382,7 @@ Nothing.
 passed in ax or if **ax** is out of bounds.
 
 ----------
-#### ChunkArrayInsertAt
+### ChunkArrayInsertAt
 Insert the specified element at a given position in the array.
 
 **Pass:**  
@@ -402,7 +402,7 @@ Nothing.
 pointers to it.
 
 ----------
-#### ChunkArrayPtrToElement
+### ChunkArrayPtrToElement
 Return the element number of the element pointed to.
 
 **Pass:**  
@@ -418,7 +418,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ChunkArraySort
+### ChunkArraySort
 Sort the given chunk array in ascending order.
 
 **Pass:**  
@@ -461,7 +461,7 @@ ZF - clear
 **Library:** chunkarr.def
 
 ----------
-#### ChunkArrayZero
+### ChunkArrayZero
 Free all the elements of the given chunk array and resize it.
 
 **Pass:**  
@@ -476,7 +476,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ClipboardAbortQuickTransfer
+### ClipboardAbortQuickTransfer
 This routine aborts a quick-transfer. This routine is normally used if the 
 quick-transfer source object is about to be destroyed or if an error occurs 
 trying to register the quick-transfer item.
@@ -493,7 +493,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardAddToNotificationList
+### ClipboardAddToNotificationList
 Add the passed OD to the transfer notify list.
 
 **Pass:**  
@@ -508,7 +508,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardClearQuickTransferNotification
+### ClipboardClearQuickTransferNotification
 This routine removes the quick-transfer OD notification.
 
 **Pass:**  
@@ -523,7 +523,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardDoneWithItem
+### ClipboardDoneWithItem
 This routine must be called when you are finished using the requested 
 transfer item.
 
@@ -540,7 +540,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardEndQuickTransfer
+### ClipboardEndQuickTransfer
 
 End a quick-transfer. Reset the mouse pointer image, clear the 
 quick-transfer region (if any), and clear the quick-transfer item. Send out 
@@ -562,7 +562,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardEnumItemFormats
+### ClipboardEnumItemFormats
 This routine returns the list of all available formats 
 (**ClipboardItemFormatID** structures).
 
@@ -583,7 +583,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardFreeItem
+### ClipboardFreeItem
 Free the passed clipboard item.
 
 **Pass:**  
@@ -598,7 +598,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardFreeItemsNotInUse
+### ClipboardFreeItemsNotInUse
 Frees normal or quick transfer item if nobody's using it, nukes references to 
 it, sends proper GCN messages out.
 
@@ -618,7 +618,7 @@ item, as this routine just frees the data without updating any references in
 the map block.
 
 ----------
-#### ClipboardGetClipboardFile
+### ClipboardGetClipboardFile
 Return the VM file used to hold clipboard items.
 
 **Pass:**  
@@ -633,7 +633,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardGetItemInfo
+### ClipboardGetItemInfo
 
 Get more information about the passed transfer item.
 
@@ -650,7 +650,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardGetNormalItemInfo
+### ClipboardGetNormalItemInfo
 
 Return normal clipboard item information.
 
@@ -667,7 +667,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardGetQuickItemInfo
+### ClipboardGetQuickItemInfo
 
 Return quick clipboard item information.
 
@@ -684,7 +684,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardGetQuickTransferStatus
+### ClipboardGetQuickTransferStatus
 
 Check to see if a quick-transfer is in progress.
 
@@ -703,7 +703,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardGetUndoItemInfo
+### ClipboardGetUndoItemInfo
 
 Return undo clipboard item information.
 
@@ -720,7 +720,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardHandleEndMoveCopy
+### ClipboardHandleEndMoveCopy
 This routine handles a MSG_META_END_COPY, either preparing to finish the 
 quick-transfer and send a MSG_META_END_MOVE_COPY to the object with 
 the active grab or ending the quick-transfer and sending a 
@@ -743,7 +743,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardQueryItem
+### ClipboardQueryItem
 This routine registers the passed transfer item.
 
 **Pass:**  
@@ -764,7 +764,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardRegisterItem
+### ClipboardRegisterItem
 
 This routine registers the passed transfer item.
 
@@ -785,7 +785,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardRemoteReceive
+### ClipboardRemoteReceive
 Receive clipboard from remotely connected machine.
 
 **Pass:**  
@@ -800,7 +800,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardRemoteSend
+### ClipboardRemoteSend
 Send clipboard to remotely connected machine.
 
 **Pass:**  
@@ -815,7 +815,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardRemoveFromNotificationList
+### ClipboardRemoveFromNotificationList
 Remove the passed OD from the transfer notify list.
 
 **Pass:**  
@@ -831,7 +831,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardRequestItemFormat
+### ClipboardRequestItemFormat
 This routine requests the given transfer item, as stored in the given format 
 type.
 
@@ -852,7 +852,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardSetQuickTransferFeedback
+### ClipboardSetQuickTransferFeedback
 Set mouse cursor for quick-transfer.
 
 **Pass:**  
@@ -872,7 +872,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardStartQuickTransfer
+### ClipboardStartQuickTransfer
 Initiate a quick transfer (normally called from 
 MSG_META_START_MOVE_COPY).
 
@@ -925,7 +925,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardTestItemFormat
+### ClipboardTestItemFormat
 This routine determines whether the clipboard item supports the specified 
 format.
 
@@ -943,7 +943,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ClipboardUnregisterItem
+### ClipboardUnregisterItem
 
 This routine unregisters the passed clipboard item, restoring any transfer 
 which may have been disturbed by the last normal clipboard item.
@@ -961,7 +961,7 @@ Nothing.
 **Library:** clipbrd.def
 
 ----------
-#### ConfigBuildTitledMoniker
+### ConfigBuildTitledMoniker
 Global routine to build a titled moniker based on the passed moniker list
 
 **Pass:**  
@@ -976,7 +976,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### ConfigBuildTitledMonikerUsingToken
+### ConfigBuildTitledMonikerUsingToken
 Combine 2 vis monikers-placing the text moniker centered below the 
 picture moniker.
 
@@ -994,7 +994,7 @@ ax, bx, cx, di
 **Library:** config.def
 
 ----------
-#### DBAlloc
+### DBAlloc
 Allocate a new database item in a specified group.
 
 **Pass:**  
@@ -1017,7 +1017,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBCopyDBItem
+### DBCopyDBItem
 Copy an existing database item into a newly-allocated item.
 
 **Pass:**  
@@ -1041,7 +1041,7 @@ Nothing.
 pointers are invalidated by this routine.
 
 ----------
-#### DBDeleteAt
+### DBDeleteAt
 Delete a given number of bytes from within the specified database item.
 
 **Pass:**  
@@ -1060,7 +1060,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBDirty
+### DBDirty
 
 Mark a database item as dirty so it will be written to the database file with 
 its changes.
@@ -1077,7 +1077,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBFree
+### DBFree
 Remove the specified item from the database.
 
 **Pass:**  
@@ -1094,7 +1094,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBGetMap
+### DBGetMap
 Return the item that is set to be the database's map.
 
 **Pass:**  
@@ -1110,7 +1110,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBGroupAlloc
+### DBGroupAlloc
 Create a new database group.
 
 **Pass:**  
@@ -1125,7 +1125,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBGroupFree
+### DBGroupFree
 Remove all items in the specified group and delete the group.
 
 **Pass:**  
@@ -1141,7 +1141,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBInsertAt
+### DBInsertAt
 Insert a specified number of bytes within a given database item. The bytes 
 may be inserted at any offset, and the new bytes will be zeroed.
 
@@ -1168,7 +1168,7 @@ Nothing.
 all pointers are invalidated by this routine.
 
 ----------
-#### DBLock
+### DBLock
 Lock a database item for exclusive access. When you're done with the item, 
 unlock it with **DBUnlock**.
 
@@ -1186,7 +1186,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBLockMap
+### DBLockMap
 Lock the map item for the database file. This is a utility that is slightly 
 quicker than calling **DBGetMap** followed by **DBLock**. When finished with 
 the map item, you must call **DBUnlock** on it.
@@ -1204,7 +1204,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBReAlloc
+### DBReAlloc
 Change the size of an existing database item.
 
 **Pass:**  
@@ -1224,7 +1224,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBSetMap
+### DBSetMap
 Mark a database item as being the map item for the database file.
 
 **Pass:**  
@@ -1241,7 +1241,7 @@ Nothing.
 **Library:** dbase.def
 
 ----------
-#### DBUnlock
+### DBUnlock
 Unlocks a database item that had previously been locked with **DBLock**.
 
 **Pass:**  
@@ -1257,7 +1257,7 @@ NULL_SEGMENT to it, if it pointed to a block that had become unlocked.)
 **Library:** dbase.def
 
 ----------
-#### DiskCheckInUse
+### DiskCheckInUse
 Determine if the passed disk is actively being used, either by an open file or 
 by a thread having a directory on the disk in its directory stack.
 
@@ -1273,7 +1273,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskCheckUnnamed
+### DiskCheckUnnamed
 Check if the passed disk handle refers to an unnamed disk (i.e. a disk that 
 has no user-supplied volume name).
 
@@ -1289,7 +1289,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskCheckWritable
+### DiskCheckWritable
 See if the passed volume is writable.
 
 **Pass:**  
@@ -1304,7 +1304,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskCopy
+### DiskCopy
 Copies the contents of the source disk to the destination disk, prompting for 
 them as necessary.
 
@@ -1345,7 +1345,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskFind
+### DiskFind
 Search the list of registered disks and return the handle of that having the 
 passed volume name. An additional search is also made to ensure the match 
 is unique.
@@ -1367,7 +1367,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskForEach
+### DiskForEach
 Call a callback routine for each disk registered with the system, allowing the 
 callback to cancel the operation.
 
@@ -1397,7 +1397,7 @@ ax, cx, dx, bp
 **Library:**    disk.def
 
 ----------
-#### DiskFormat
+### DiskFormat
 Format the disk in the specified drive.
 
 **Pass:**  
@@ -1435,7 +1435,7 @@ CF - Return set to cancel format.
 **Warning:** All data on the destination disk is lost.
 
 ----------
-#### DiskGetDrive
+### DiskGetDrive
 Return the drive number of the drive in which the passed disk was 
 registered.
 
@@ -1451,7 +1451,7 @@ ah
 **Library:** disk.def
 
 ----------
-#### DiskGetVolumeFreeSpace
+### DiskGetVolumeFreeSpace
 Return the number of bytes free on a volume.
 
 **Pass:**  
@@ -1468,7 +1468,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskGetVolumeInfo
+### DiskGetVolumeInfo
 Return information about a registered disk.
 
 **Pass:**  
@@ -1487,7 +1487,7 @@ ax
 **Library:** disk.def
 
 ----------
-#### DiskGetVolumeName
+### DiskGetVolumeName
 Return the volume name of the disk specified by the passed handle.
 
 **Pass:**  
@@ -1505,7 +1505,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskRegisterDisk
+### DiskRegisterDisk
 Register a disk with the system.
 
 **Pass:**  
@@ -1521,7 +1521,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskRegisterDiskSilently
+### DiskRegisterDiskSilently
 Register a disk with the system without informing the user.
 
 **Pass:**  
@@ -1537,7 +1537,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskRestore
+### DiskRestore
 Restore a disk handle that had been saved to the state file with DiskSave.
 
 **Pass:**  
@@ -1578,7 +1578,7 @@ DRE_USER_CANCELED_RESTORE).
 **Library:** disk.def
 
 ----------
-#### DiskSave
+### DiskSave
 Save information that will allow a disk handle to be restored when the caller 
 is restoring itself from a state file after a shutdown.
 
@@ -1600,7 +1600,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DiskSetVolumeName
+### DiskSetVolumeName
 Set the name of a registered disk.
 
 **Pass:**  
@@ -1619,7 +1619,7 @@ Nothing.
 **Library:** disk.def
 
 ----------
-#### DosExec
+### DosExec
 Begin execution of a DOS application, shutting down GEOS to state files or 
 creating a new task in the task-switcher for the DOS application.
 
@@ -1655,7 +1655,7 @@ ax, bx, cx, dx, di, si, bp, ds, es
 **Library:** system.def
 
 ----------
-#### DriveGetDefaultMedia
+### DriveGetDefaultMedia
 Return the GEOS media descriptor of the highest density format supported 
 by the specified drive.
 
@@ -1672,7 +1672,7 @@ Nothing.
 **Library:** drive.def
 
 ----------
-#### DriveGetExtStatus
+### DriveGetExtStatus
 Return the extended status word for the specified drive.
 
 **Pass:**  
@@ -1688,7 +1688,7 @@ Nothing.
 **Library:** drive.def
 
 ----------
-#### DriveGetName
+### DriveGetName
 Return the name of the specified drive.
 
 **Pass:**  
@@ -1714,7 +1714,7 @@ Nothing.
 **Library:** drive.def
 
 ----------
-#### DriveGetStatus
+### DriveGetStatus
 Returns status information on the specified drive.
 
 **Pass:**  
@@ -1730,7 +1730,7 @@ Nothing.
 **Library:** drive.def
 
 ----------
-#### DriveTestMediaSupport
+### DriveTestMediaSupport
 Test if the specified drive supports the given media type.
 
 **Pass:**  

--- a/TechDocs/Markdown/Asmref/asme_f.md
+++ b/TechDocs/Markdown/Asmref/asme_f.md
@@ -1,7 +1,7 @@
 ## 2.2 Routines E-F
 
 ----------
-#### ECCheckBounds
+### ECCheckBounds
 Verifies that a pointer is in bounds (**ds** is a valid segment and **si** is a valid 
 offset).
 
@@ -17,7 +17,7 @@ Nothing.
 **Library:** ec.def
 
 ----------
-#### ECCheckClass
+### ECCheckClass
 Checks that the pointer actually points at a class definition.
 
 **Pass:**  
@@ -32,7 +32,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckDriverHandle
+### ECCheckDriverHandle
 Checks that the passed handle actually references a valid driver.
 
 **Pass:**  
@@ -47,7 +47,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckEventHandle
+### ECCheckEventHandle
 Checks that the passed handle references a valid **EventHandle**.
 
 **Pass:**  
@@ -62,7 +62,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckGeodeHandle
+### ECCheckGeodeHandle
 Checks that the passed handle actually references a valid geode.
 
 **Pass:**  
@@ -77,7 +77,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckGStateHandle
+### ECCheckGStateHandle
 Makes sure the passed handle actually references a valid GState.
 
 **Pass:**  
@@ -92,7 +92,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckLibraryHandle
+### ECCheckLibraryHandle
 Makes sure the passed handle actually references a valid library.
 
 **Pass:**  
@@ -107,7 +107,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckLMemHandle
+### ECCheckLMemHandle
 Ensures that the passed handle references a valid, sharable local memory 
 block.
 
@@ -123,7 +123,7 @@ Nothing.
 **Library:** ec.def
 
 ----------
-#### ECCheckLMemHandleNS
+### ECCheckLMemHandleNS
 Ensures that the passed handle references a valid local memory block, 
 ignoring issues of sharing.
 
@@ -139,7 +139,7 @@ Nothing.
 **Library:** ec.def
 
 ----------
-#### ECCheckLMemObject
+### ECCheckLMemObject
 Makes sure that the given pointer points to an object within an object block. 
 Will not allow the pointer to point to a Process object. (If it does, this routine 
 will call **FatalError**.)
@@ -156,7 +156,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckLMemOD
+### ECCheckLMemOD
 Makes sure that the given optr points to an object within an object block. Will 
 not allow the pointer to point to a Process object.
 
@@ -172,7 +172,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckLMemODCXDX
+### ECCheckLMemODCXDX
 Checks that the passed **cx:dx** is a valid optr to an LMem-based object (not a 
 Process).
 
@@ -188,7 +188,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### ECCheckMemHandle
+### ECCheckMemHandle
 Checks the validity of a passed global memory handle.
 
 **Pass:**  
@@ -203,7 +203,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckMemHandleNS
+### ECCheckMemHandleNS
 Checks the validity of the passed memory handle, ignoring sharing violation 
 errors (when a block should be sharable but is not).
 
@@ -220,7 +220,7 @@ routine was called.
 **Library:** ec.def
 
 ----------
-#### ECCheckObject
+### ECCheckObject
 Ensures that the locked object is valid. This routine can check both local 
 memory objects and Process objects.
 
@@ -237,7 +237,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckOD
+### ECCheckOD
 Ensures that the optr passed references an object. This routine considers 
 Process objects valid, unlike **ECCheckLMemOD**.
 
@@ -253,7 +253,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckODCXDX
+### ECCheckODCXDX
 Checks to see if the passed **cx:dx** is a valid optr.
 
 **Pass:**  
@@ -268,7 +268,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### ECCheckProcessHandle
+### ECCheckProcessHandle
 Checks that the passed handle actually references a valid Process.
 
 **Pass:**  
@@ -283,7 +283,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckQueueHandle
+### ECCheckQueueHandle
 Checks that the passed handle actually references a valid event queue.
 
 **Pass:**  
@@ -298,7 +298,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckResourceHandle
+### ECCheckResourceHandle
 Checks that the passed handle actually references a valid resource (device).
 
 **Pass:**  
@@ -313,7 +313,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckSegment
+### ECCheckSegment
 Checks that the passed segment value actually points to a locked block.
 
 **Pass:**  
@@ -328,7 +328,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckThreadHandle
+### ECCheckThreadHandle
 Checks that the passed handle actually references a valid thread.
 
 **Pass:**  
@@ -343,7 +343,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ECCheckUILMemOD
+### ECCheckUILMemOD
 Checks that the passed optr references a valid UI-run object (not a Process).
 
 **Pass:**  
@@ -358,7 +358,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### ECCheckUILMemODCXDX
+### ECCheckUILMemODCXDX
 Checks that the passed cx:dx is a valid optr pointing to a UI-run object in an 
 object block (not a Process).
 
@@ -374,7 +374,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### ECCheckWindowHandle
+### ECCheckWindowHandle
 Checks that the passed handle actually references a valid window.
 
 **Pass:**  
@@ -389,7 +389,7 @@ Nothing. Flags are preserved.
 **Library:** ec.def
 
 ----------
-#### ElementArrayAddElement
+### ElementArrayAddElement
 Add an element to a given element array. If the element already exists, its 
 reference count will be incremented.
 
@@ -427,7 +427,7 @@ CF - Set if the elements are equal.
 dereference all stored pointers after a call to this routine.
 
 ----------
-#### ElementArrayAddReference
+### ElementArrayAddReference
 Increments the reference count for an element in an element array.
 
 **Pass:**  
@@ -443,7 +443,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ElementArrayCreate
+### ElementArrayCreate
 Creates a new element array in the specified chunk. The new array will have 
 no elements.
 
@@ -467,7 +467,7 @@ Nothing.
 stored pointers must be dereferenced.
 
 ----------
-#### ElementArrayDelete
+### ElementArrayDelete
 Deletes an element regardless of its reference count.
 
 **Pass:**  
@@ -483,7 +483,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ElementArrayElementChanged
+### ElementArrayElementChanged
 Checks to see if a recently changed element is now equal to another element 
 If the element is now a duplicate, it will be combined with the other element, 
 and the other element's reference count will be incremented.
@@ -516,7 +516,7 @@ CF  Set if elements are equal, clear otherwise.
 **Library:** chunkarr.def
 
 ----------
-#### ElementArrayGetUsedCount
+### ElementArrayGetUsedCount
 Returns the number of elements in the array that actually hold data.
 
 **Pass:**  
@@ -545,7 +545,7 @@ otherwise.
 **Library:** chunkarr.def
 
 ----------
-#### ElementArrayRemoveReference
+### ElementArrayRemoveReference
 Removes a reference to the specified element, removing the element itself if 
 the reference count drops to zero.
 
@@ -573,7 +573,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ElementArrayTokenToUsedIndex
+### ElementArrayTokenToUsedIndex
 Returns the index of an element with respect to used elements in the array, 
 given its token.
 
@@ -604,7 +604,7 @@ CF - Set if the element qualifies as "used."
 **Library:** chunkarr.def
 
 ----------
-#### ElementArrayUsedIndexToToken
+### ElementArrayUsedIndexToToken
 Returns the token of an element given its index with respect to used elements 
 in the array.
 
@@ -636,7 +636,7 @@ CF - Set if the element passed qualifies as "used."
 **Library:** chunkarr.def
 
 ----------
-#### FatalError
+### FatalError
 Indicates that a fatal error has been encountered within an application. Note 
 that it is impossible to return from a fatal error. This routine is meant to 
 identify what precipitated the fatal error.
@@ -654,7 +654,7 @@ Not applicable
 **Library:** ec.def
 
 ----------
-#### FileAddStandardPathDirectory
+### FileAddStandardPathDirectory
 Adds the specified directory to the standard path table.
 
 **Pass:**  
@@ -672,7 +672,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileClose
+### FileClose
 Close an open file.
 
 **Pass:**  
@@ -690,7 +690,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileCommit
+### FileCommit
 Commits a file to the disk by forcing all changes to be written out.
 
 **Pass:**  
@@ -708,7 +708,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileComparePaths
+### FileComparePaths
 Compares two paths, returning their relationship.
 
 **Pass:**  
@@ -736,7 +736,7 @@ deal with links; call **FileConstructActualPath** on each path if you suspect
 either involves links.
 
 ----------
-#### FileConstructActualPath
+### FileConstructActualPath
 Similar to **FileConstructFullPath**, this routine also replaces links with 
 their actual targets. It creates a full path string from the passed information.
 
@@ -773,7 +773,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileConstructFullPath
+### FileConstructFullPath
 Constructs a full path given a standard path constant and a path relative to 
 the standard path. This routine does not resolve links; instead, use 
 **FileConstructActualPath**.
@@ -811,7 +811,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileCopy
+### FileCopy
 Copies a source file into a destination file. If the destination file does not 
 already exist, it will be created. Any existing destination file with the same 
 name will be truncated and overwritten.
@@ -842,7 +842,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileCopyExtAttributes
+### FileCopyExtAttributes
 Copies all the extended file attributes from an open file into another named 
 file.
 
@@ -860,7 +860,7 @@ ax, if not returned.
 **Library:** file.def
 
 ----------
-#### FileCopyLocal
+### FileCopyLocal
 Copies the source file to the destination file. If the destination file does not 
 exist, this routine will create it; if the destination file already exists, it will be 
 truncated to accommodate the new source.
@@ -894,7 +894,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileCopyPathExtAttributes
+### FileCopyPathExtAttributes
 Copies the extended attributes of a file to another file without opening either 
 file.
 
@@ -914,7 +914,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileCreate
+### FileCreate
 Creates a new file or truncates an existing file.
 
 **Pass:**  
@@ -947,7 +947,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileCreateDir
+### FileCreateDir
 Creates a new directory.
 
 **Pass:**  
@@ -965,7 +965,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileCreateTempFile
+### FileCreateTempFile
 Creates a temporary file with a unique name.
 
 **Pass:**  
@@ -988,7 +988,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileDelete
+### FileDelete
 Deletes the specified file.
 
 **Pass:**  
@@ -1007,7 +1007,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileDeleteDir
+### FileDeleteDir
 Deletes a directory and all the files and subdirectories within it.
 
 **Pass:**  
@@ -1027,7 +1027,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileDeleteStandardPathDirectory
+### FileDeleteStandardPathDirectory
 Deletes the specified directory from the standard path table.
 
 **Pass:**  
@@ -1045,7 +1045,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileDuplicateHandle
+### FileDuplicateHandle
 Duplicates the passed handle, returning a new handle referring to the same 
 file.
 
@@ -1063,7 +1063,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileEnum
+### FileEnum
 Enumerates all files in a directory, calling a callback routine for each. This 
 routine receives its parameters on the stack; the parameter structure is not 
 returned on the stack but is instead popped during the routine's execution.
@@ -1138,7 +1138,7 @@ the callback routine.
 **Library:** fileEnum.def
 
 ----------
-#### FileEnumLocateAttr
+### FileEnumLocateAttr
 Locates an extended attribute within an array of **FileExtAttrDesc** 
 structures. This routine usually acts as a "helper" of **FileEnum** callback 
 routines.
@@ -1161,7 +1161,7 @@ es, di if attribute searched for was not found.
 **Library:** fileEnum.def
 
 ----------
-#### FileEnumPtr
+### FileEnumPtr
 This routine performs an enumeration identical to **FileEnum** except that it 
 accepts a pointer to a **FileEnumParams** structure rather than needing all 
 of the parameters passed on the stack. It is, therefore, somewhat simpler to 
@@ -1204,7 +1204,7 @@ the callback routine.
 **Library:** fileEnum.def
 
 ----------
-#### FileEnumWildcard
+### FileEnumWildcard
 Checks if the virtual name of the current file matches the pattern passed to 
 **FileEnum** in *FEP_cbData1*. In this case, *FEP_cbData1* is cast to a far pointer 
 to the name string. This routine acts as a **FileEnum** "helper" routine.
@@ -1228,7 +1228,7 @@ Nothing.
 **Library:** fileEnum.def
 
 ----------
-#### FileGetAttributes
+### FileGetAttributes
 Retrieves a file's attributes.
 
 **Pass:**  
@@ -1247,7 +1247,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileGetCurrentPath
+### FileGetCurrentPath
 Returns the thread's current directory. If the directory is a standard path, the 
 returned disk handle (**bx**) will actually be a **StandardPath** constant and the 
 buffer will contain a relative path. To retrieve a full path, use 
@@ -1274,7 +1274,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileGetCurrentPathIDs
+### FileGetCurrentPathIDs
 Returns an array of **FilePathID** structures for the current path. These IDs 
 may be used in handling file change notification messages.
 
@@ -1293,7 +1293,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileGetDateAndTime
+### FileGetDateAndTime
 Returns the modification date and time of an open file.
 
 **Pass:**  
@@ -1309,7 +1309,7 @@ ax
 **Library:** file.def
 
 ----------
-#### FileGetDiskHandle
+### FileGetDiskHandle
 Retrieves the disk handle of an open file.
 
 **Pass:**  
@@ -1325,7 +1325,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileGetHandleExtAttributes
+### FileGetHandleExtAttributes
 Retrieves one or more extended attributes of the specified open file. This 
 routine is similar to **FileGetPathExtAttributes** except that the file must 
 be open.
@@ -1359,7 +1359,7 @@ Nothing. (**ax** destroyed if CF clear).
 **Library:** file.def
 
 ----------
-#### FileGetPathExtAttributes
+### FileGetPathExtAttributes
 Retrieves one or more extended attributes from the file whose path is 
 specified. This routine is similar to **FileGetHandleExtAttributes** but 
 specifies the file by its path rather than its handle.
@@ -1394,7 +1394,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileLockRecord
+### FileLockRecord
 Locks a region of a file. The region may later be unlocked with 
 **FileUnlockRecord**. This routine does not keep other threads from using or 
 writing to the file; it only keeps others from locking the same region.
@@ -1414,7 +1414,7 @@ Nothing. (**ax** destroyed if CF clear).
 **Library:** file.def
 
 ----------
-#### FileMove
+### FileMove
 Moves a file or subdirectory from one place in the file system to another. Some 
 file systems will allow directories to be moved across volumes, but other file 
 systems will return an error in this case. Files, however, will always be 
@@ -1454,7 +1454,7 @@ source or destination. To fix this, call **FileConstructActualPath** on either
 or both paths before calling **FileMove**.
 
 ----------
-#### FileOpen
+### FileOpen
 Opens an existing file.
 
 **Pass:**  
@@ -1480,7 +1480,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileOpenAndRead
+### FileOpenAndRead
 Opens a file and reads its contents into a memory block.
 
 **Pass:**  
@@ -1503,7 +1503,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileParseStandardPath
+### FileParseStandardPath
 Constructs the best combination of a **StandardPath** constant and a relative 
 path. If the file system on which GEOS resides is case-insensitive, then the 
 passed path must be in all upper case for it to be properly recognized.
@@ -1526,7 +1526,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FilePos
+### FilePos
 Sets an open file's read/write position.
 
 **Pass:**  
@@ -1549,7 +1549,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileRead
+### FileRead
 Reads a number of bytes from an open file.
 
 **Pass:**  
@@ -1573,7 +1573,7 @@ Nothing. (ax is destroyed if CF is set.)
 **Library:** file.def
 
 ----------
-#### FileRename
+### FileRename
 Renames the specified file. This routine may not be used for moving a file to 
 a new directory; use **FileMove** for that purpose.
 
@@ -1595,7 +1595,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileResolveStandardPath
+### FileResolveStandardPath
 Given a path and the current directory (set to a **StandardPath**), searches 
 the sub-directories of the standard path and returns both the full path of the 
 desired file and its disk handle.
@@ -1625,7 +1625,7 @@ ah, cx (bx if CF is set)
 **Library:** file.def
 
 ----------
-#### FileSetAttributes
+### FileSetAttributes
 Sets a file's FileAttrs record.
 
 **Pass:**  
@@ -1649,7 +1649,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileSetCurrentPath
+### FileSetCurrentPath
 Sets the current directory of the calling thread.
 
 **Pass:**  
@@ -1674,7 +1674,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileSetDateAndTime
+### FileSetDateAndTime
 Sets an open file's modification date and time attributes.
 
 **Pass:**  
@@ -1693,7 +1693,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileSetHandleExtAttributes
+### FileSetHandleExtAttributes
 Sets one or more of an open file's extended attributes, given the file's handle. 
 This is similar to **FileSetPathExtAttributes** except it specifies the file by 
 its handle rather than its name.
@@ -1722,7 +1722,7 @@ Nothing. (ax is destroyed if CF is clear.)
 **Library:** file.def
 
 ----------
-#### FileSetPathExtAttributes
+### FileSetPathExtAttributes
 Sets one or more of a file's extended attributes, given the file's path. This is 
 similar to **FileSetHandleExtAttributes** except it specifies the file by its 
 name rather than its handle.
@@ -1752,7 +1752,7 @@ Nothing. (ax is destroyed if CF is returned clear.)
 **Library:** file.def
 
 ----------
-#### FileSetStandardPath
+### FileSetStandardPath
 Changes the thread's current directory to one of the standard system paths.
 
 **Pass:**  
@@ -1767,7 +1767,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileSize
+### FileSize
 Returns the size of an open file, in bytes.
 
 **Pass:**  
@@ -1782,7 +1782,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileStdPathCheckIfSubDir
+### FileStdPathCheckIfSubDir
 Checks if the given **StandardPath** constant is actually a subdirectory of 
 another **StandardPath**.
 
@@ -1801,7 +1801,7 @@ Nothing.
 **Library:** file.def
 
 ----------
-#### FileTruncate
+### FileTruncate
 Truncates the given file to the passed length.
 
 **Pass:**  
@@ -1821,7 +1821,7 @@ cx, dx
 **Library:** file.def
 
 ----------
-#### FileUnlockRecord
+### FileUnlockRecord
 Unlocks a region of an open file previously locked with **FileLockRecord**.
 
 **Pass:**  
@@ -1839,7 +1839,7 @@ Nothing. (ax is destroyed if CF is clear.)
 **Library:** file.def
 
 ----------
-#### FileWrite
+### FileWrite
 Writes a string of bytes from a buffer to an open file.
 
 **Pass:**  
@@ -1866,7 +1866,7 @@ Nothing. (ax is destroyed if CF is clear.)
 there or append bytes to the end of the file.
 
 ----------
-#### FloatAsciiToFloat
+### FloatAsciiToFloat
 Converts a number represented in an ASCII text format into a GEOS FP 
 number. The routine recognizes two flags:
 
@@ -1894,7 +1894,7 @@ error-checking on the string is performed.
 **Library:** math.def
 
 ----------
-#### FloatComp
+### FloatComp
 Compares the top two FP numbers on the current floating point stack.
 
 **Pass:**  
@@ -1915,7 +1915,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatCompAndDrop
+### FloatCompAndDrop
 Compares the top two FP numbers on the current floating point stack.
 
 **Pass:**  
@@ -1936,7 +1936,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatCompESDI
+### FloatCompESDI
 Compares the top number of the FP stack with a number pointed at by 
 **es:di**. 
 
@@ -1954,7 +1954,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatCompPtr
+### FloatCompPtr
 Compares the top two FP numbers.
 
 **Pass:**  
@@ -1972,7 +1972,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatDateNumberGetMonthAndDay
+### FloatDateNumberGetMonthAndDay
 Given a GEOS date number, extracts the month and day.
 
 **Pass:**  
@@ -1989,7 +1989,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatDwordToFloat
+### FloatDwordToFloat
 Converts a signed double-word integer into a floating point number. The 
 floating point number is placed on the FP stack.
 
@@ -2005,7 +2005,7 @@ ax, dx
 **Library:** math.def
 
 ----------
-#### FloatEq0
+### FloatEq0
 Checks whether the number on top of the FP stack is equivalent to zero.
 
 **Pass:**  
@@ -2021,7 +2021,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatExit
+### FloatExit
 Frees the floating point stack for the current thread.
 
 **Pass:**  
@@ -2036,7 +2036,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatFloatToAscii
+### FloatFloatToAscii
 Converts a GEOS floating point number into an ASCII string. The FP number 
 on top of the FP stack is operated on unless 
 *FFA_stackFrame*.FFA_FROM_ADDR is passed a value of 1.
@@ -2061,7 +2061,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatFloatToAscii_StdFormat
+### FloatFloatToAscii_StdFormat
 Converts an FP number into an ASCII string using the format passed in al. 
 This routine provides a means of converting a GEOS FP number into an ASCII 
 string without having to set up the *FFA_stackFrame* required in 
@@ -2118,7 +2118,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatGeos80ToIEEE32
+### FloatGeos80ToIEEE32
 Converts a GEOS 80 bit FP number into a 32 bit IEEE-standard FP number.
 
 **Pass:**  
@@ -2133,7 +2133,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatGeos80ToIEEE64
+### FloatGeos80ToIEEE64
 Converts a GEOS FP number into a 64 bit IEEE-standard FP number and 
 pushes it onto the FP stack.
 
@@ -2149,7 +2149,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatGetDateNumber
+### FloatGetDateNumber
 Creates a GEOS date number for the given date.
 
 **Pass:**  
@@ -2168,7 +2168,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatGetDaysInMonth
+### FloatGetDaysInMonth
 This utility routine calculates the number of days in a month when also given 
 its year.
 
@@ -2185,7 +2185,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatGetStackDepth
+### FloatGetStackDepth
 Returns the current depth (in number of elements) of the floating point stack.
 
 **Pass:**  
@@ -2200,7 +2200,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatGetTimeNumber
+### FloatGetTimeNumber
 Calculates a GEOS time number given integral time data. GEOS time 
 numbers are consecutive decimal values that correspond to times from 
 midnight (0.000000) through 11:59:59 PM (0.999988).
@@ -2221,7 +2221,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatGt0
+### FloatGt0
 Checks whether the number on top of the FP stack is greater than zero.
 
 **Pass:**  
@@ -2237,7 +2237,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatIEEE32ToGeos80
+### FloatIEEE32ToGeos80
 Converts a 32 bit IEEE-standard FP number into a GEOS 80 bit FP number.
 
 **Pass:**  
@@ -2252,7 +2252,7 @@ ax, dx
 **Library:** math.def
 
 ----------
-#### FloatIEEE64ToGeos80
+### FloatIEEE64ToGeos80
 Converts a 64 bit IEEE-standard FP number into a GEOS 80 bit FP number.
 
 **Pass:**  
@@ -2268,7 +2268,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatInit
+### FloatInit
 Initializes a floating point stack for the current thread. This routine allocates 
 a block of memory for this purpose and makes note of it in 
 **ThreadPrivateData**.
@@ -2291,7 +2291,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatLt0
+### FloatLt0
 Checks whether the number on top of the FP stack is less than zero.
 
 **Pass:**  
@@ -2307,7 +2307,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatPick
+### FloatPick
 Selects an FP number on the floating point stack, copies it, and pushes it on 
 top of the FP stack. The entire stack is pushed in the process. For example, 
 **FloatPick** passed with a value of 3 would copy the contents of the third 
@@ -2327,7 +2327,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatPopNumber
+### FloatPopNumber
 Pops a floating point number off the FP stack into a passed location.
 
 **Pass:**  
@@ -2342,7 +2342,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatPushNumber
+### FloatPushNumber
 Pushes an FP number onto the top of the FP stack for the current thread 
 from a passed buffer. The number must be already set up in 80 bit, FP 
 format.
@@ -2359,7 +2359,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatRandomize
+### FloatRandomize
 Primes the random number generator, in preparation for a call to 
 **FloatRandom** or **FloatRandomN**. If **FloatRandomize** is passed the 
 flag RGIF_USE_SEED, the routine must also pass a developer supplied seed.
@@ -2380,7 +2380,7 @@ ax, dx
 **Library:** math.def
 
 ----------
-#### FloatRoll
+### FloatRoll
 Pushes a selected FP number onto the top of the stack, removing it from its 
 previous location in the process. **FloatRoll** passed with a value of 3 would 
 move the FP number in the third stack position onto the top of the stack, 
@@ -2400,7 +2400,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatRollDown
+### FloatRollDown
 Performs the inverse operation of **FloatRoll**, popping the top stack value 
 into a specified location on the stack. **FloatRollDown** passed with a value 
 of 3 would move the FP number on top of the stack into the third stack 
@@ -2419,7 +2419,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatRound
+### FloatRound
 Rounds the top FP stack number to a given number of decimal places. 
 **FloatRound** passed with zero as an argument rounds the top FP number 
 to the nearest integer, rounding up if greater than or equal to .5, rounding 
@@ -2438,7 +2438,7 @@ ax
 **Library:** math.def
 
 ----------
-#### FloatSetStackDepth
+### FloatSetStackDepth
 Sets the depth of the FP stack.
 
 **Pass:**  
@@ -2453,7 +2453,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatSetStackPointer
+### FloatSetStackPointer
 Sets the floating point stack pointer to a previous position saved with 
 **FloatGetStackPointer**. This routine must be passed a value that is 
 greater than or equal to the current value of the stack pointer. (I.e. you 
@@ -2471,7 +2471,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatSetStackSize
+### FloatSetStackSize
 Sets the size of the FP stack.
 
 **Pass:**  
@@ -2486,7 +2486,7 @@ Nothing.
 **Library:** math.def
 
 ----------
-#### FloatStringGetDateNumber
+### FloatStringGetDateNumber
 Parses a string containing a date and returns its date number.
 
 **Pass:**  
@@ -2503,7 +2503,7 @@ ax - **DateTimeFormat** used.
 **Library:** math.def
 
 ----------
-#### FloatStringGetTimeNumber
+### FloatStringGetTimeNumber
 Parses a string containing a time and returns its time number.
 
 **Pass:**  
@@ -2519,7 +2519,7 @@ al - (If CF is set) error code (FLOAT_GEN_ERR).
 **Library:** math.def
 
 ----------
-#### FloatWordToFloat
+### FloatWordToFloat
 Converts a signed integer (word value) into a GEOS 80 bit floating point 
 number on the FP stack.
 
@@ -2535,7 +2535,7 @@ ax, dx
 **Library:** math.def
 
 ----------
-#### FlowCheckKbdShortcut
+### FlowCheckKbdShortcut
 Determines whether the key-press event maps to a shortcut.
 
 **Pass:**  
@@ -2558,7 +2558,7 @@ Nothing.
 **Library:** uiInputC.def
 
 ----------
-#### FlowDispatchSendOnOrDestroyClassedEvent
+### FlowDispatchSendOnOrDestroyClassedEvent
 This utility routine relays a classed routine.
 
 **Pass:**  
@@ -2593,7 +2593,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### FlowGetTargetAtTargetLevel
+### FlowGetTargetAtTargetLevel
 This routine retrieves the target within the current level of the target 
 hierarchy.
 
@@ -2629,7 +2629,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### FlowGetUIButtonFlags
+### FlowGetUIButtonFlags
 Returns the current **UIButtonFlags**.
 
 **Pass:**  
@@ -2644,7 +2644,7 @@ Nothing.
 **Library:** uiInputC.def
 
 ----------
-#### FlowReleaseGrab
+### FlowReleaseGrab
 Releases the grab of the current OD if it matches that passed. The object is 
 sent a MSG_META_LOST_..._EXCL (if specified) and the OD and data word are 
 zeroed out to indicate that there is no current grab.
@@ -2677,7 +2677,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### FlowRequestGrab
+### FlowRequestGrab
 This routine grants the grab to the OD passed if there is no active grab. If the 
 OD passed matches that in existence then the data word is updated and no 
 message is sent.
@@ -2711,7 +2711,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### FlowTranslatePassiveButton
+### FlowTranslatePassiveButton
 This routine translates a MSG_META_PRE_PASSIVE_BUTTON or 
 MSG_META_POST_PASSIVE_BUTTON to a generic message.
 
@@ -2733,7 +2733,7 @@ Nothing.
 **Library:** uiInputC.def
 
 ----------
-#### FlowUpdateHierarchicalGrab
+### FlowUpdateHierarchicalGrab
 Update exclusive based on passed message.
 
 **Pass:**  

--- a/TechDocs/Markdown/Asmref/asmg_g.md
+++ b/TechDocs/Markdown/Asmref/asmg_g.md
@@ -1,7 +1,7 @@
 ## 2.3 Routines G-G
 
 ----------
-#### GCNListAdd
+### GCNListAdd
 Add an object or process to a GCN list. The object will be notified the next time 
 the list's notification is sent out.
 
@@ -25,7 +25,7 @@ Nothing.
 pointers.
 
 ----------
-#### GCNListAddToBlock
+### GCNListAddToBlock
 Add a new GCN list to the block containing the GCN list of lists.
 
 **Pass:**  
@@ -51,7 +51,7 @@ Nothing.
 pointers.
 
 ----------
-#### GCNListAddToList
+### GCNListAddToList
 Called by **GCNListAdd**, this routine adds an object to a specified GCN list. 
 Most programs will call **GCNListAdd**, not this routine.
 
@@ -73,7 +73,7 @@ Nothing.
 invalidating pointers into it.
 
 ----------
-#### GCNListCreateBlock
+### GCNListCreateBlock
 Create a new GCN list of lists within a locked LMem block.
 
 **Pass:**  
@@ -89,7 +89,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListCreateList
+### GCNListCreateList
 Create an empty GCN list within a locked LMem block.
 
 **Pass:**  
@@ -107,7 +107,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListDestroyBlock
+### GCNListDestroyBlock
 Cleanly destroy a GCN list of lists and all the lists in it.
 
 **Pass:**  
@@ -122,7 +122,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListDestroyList
+### GCNListDestroyList
 Cleanly destroy a GCN list.
 
 **Pass:**  
@@ -137,7 +137,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListFindItemInList
+### GCNListFindItemInList
 Return the address of the GCN list entry corresponding to the optr passed.
 
 **Pass:**  
@@ -157,7 +157,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListFindListInBlock
+### GCNListFindListInBlock
 Find the appropriate GCN list entry in the GCN list of lists. If necessary and 
 desired, this routine creates a new GCN list and adds it to the list of lists.
 
@@ -181,7 +181,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListRecordAndSend
+### GCNListRecordAndSend
 
 Broadcast the given message to all the objects on the specified GCN list. This 
 is a utility message used to make broadcasting such messages easier.
@@ -203,7 +203,7 @@ ax, dx, bp, di, si
 **Library:** gcnlist.def
 
 ----------
-#### GCNListRelocateBlock
+### GCNListRelocateBlock
 Relocate all the GCN lists within the given locked block, updating optrs and 
 other handles.
 
@@ -224,7 +224,7 @@ Nothing.
 into it.
 
 ----------
-#### GCNListRelocateList
+### GCNListRelocateList
 Relocate a particular GCN list. This routine is called by 
 **GCNListRelocateBlock** and will not generally be called by applications.
 
@@ -244,7 +244,7 @@ Nothing.
 into it.
 
 ----------
-#### GCNListRemove
+### GCNListRemove
 Remove an optr from a specified GCN list.
 
 **Pass:**  
@@ -262,7 +262,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListRemoveFromBlock
+### GCNListRemoveFromBlock
 Remove the given optr from the specified GCN list type in the passed block.
 
 **Pass:**  
@@ -283,7 +283,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListRemoveFromList
+### GCNListRemoveFromList
 Remove an optr from a GCN list. This routine is called by GCNListRemove; 
 in general, applications should call GCNListRemove instead of this routine.
 
@@ -303,7 +303,7 @@ Nothing.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListSend
+### GCNListSend
 Send a specified message to each element of a GCN list. If a data block with 
 a reference count is passed to this routine, the reference count should be 
 incremented before the call; otherwise, this routine will decrement the count 
@@ -344,7 +344,7 @@ decremented by this routine. To ensure the block does not get freed
 accidentally, increment the reference count before calling this routine.
 
 ----------
-#### GCNListSendToBlock
+### GCNListSendToBlock
 Send a specified message to each element in a GCN list. This routine differs 
 from **GCNListSend** only in that you pass a pointer to the list of lists to 
 indicate a particular GCN list block (usually a custom block) to use. Other 
@@ -387,7 +387,7 @@ decremented by this routine. To ensure the block does not get freed
 accidentally, increment the reference count before calling this routine.
 
 ----------
-#### GCNListSendToList
+### GCNListSendToList
 Dispatches a classed event to all the elements on a particular GCN list. This 
 routine is called by both **GCNListSend** and **GCNListSendToBlock**. In 
 general, you should use one of those two routines rather than this routine.
@@ -425,7 +425,7 @@ decremented by this routine. To ensure the block does not get freed
 accidentally, increment the reference count before calling this routine.
 
 ----------
-#### GCNListUnRelocateBlock
+### GCNListUnRelocateBlock
 Unrelocate all the GCN lists within the specified, locked GCN list block. This 
 routine will be called only in very rare situations by applications.
 
@@ -447,7 +447,7 @@ Nothing.
 to that block.
 
 ----------
-#### GCNListUnRelocateList
+### GCNListUnRelocateList
 Unrelocate a particular GCN list. This routine is called by 
 **GCNListUnRelocateBlock**; applications should call that routine instead.
 
@@ -467,7 +467,7 @@ Nothing.
 to that block.
 
 ----------
-#### GenControlOutputActionRegs
+### GenControlOutputActionRegs
 This utility routine calls MSG_GEN_OUTPUT_ACTION. This is used when a 
 controller needs to send out an action. This handles GenAttrs such as 
 GA_SIGNAL_INTERACTION_COMPLETE, GA_INITIATES_BUSY_STATE, and 
@@ -491,7 +491,7 @@ Nothing.
 **Library:** gCtrlC.def
 
 ----------
-#### GenControlOutputActionStack
+### GenControlOutputActionStack
 Utility routine to call MSG_GEN_OUTPUT_ACTION. This is used when a 
 controller needs to send out an action. This handles GenAttrs such as 
 GA_SIGNAL_INTERACTION_COMPLETE, GA_INITIATES_BUSY_STATE and 
@@ -513,7 +513,7 @@ Nothing.
 **Library:** gCtrlC.def
 
 ----------
-#### GenControlSendToOutputRegs
+### GenControlSendToOutputRegs
 Utility routine to send a message to the output of a controller. This message 
 may take arguments passed in via registers.
 
@@ -532,7 +532,7 @@ Nothing.
 **Library:** ui
 
 ----------
-#### GenControlSendToOutputStack
+### GenControlSendToOutputStack
 Utility routine to send a message to the output of a controller. This message 
 may take arguments passed via the stack.
 
@@ -552,7 +552,7 @@ Nothing.
 **Library:** gCtrlC.def
 
 ----------
-#### GenItemSendMsg
+### GenItemSendMsg
 This utility routine sends a message to a GenItemGroup's destination, with 
 the usual arguments.
 
@@ -572,7 +572,7 @@ Nothing.
 **Library:** gItemGC.def
 
 ----------
-#### GenPathConstructFullObjectPath
+### GenPathConstructFullObjectPath
 This utility routine constructs a full path from the object's path stored under 
 the passed vardata type.
 
@@ -605,7 +605,7 @@ ax, dx, bp.
 **Library:**    genC.def
 
 ----------
-#### GenPathGetObjectPath
+### GenPathGetObjectPath
 
 This utility scans the requested variable data field and fetches the path 
 stored in that field.
@@ -639,7 +639,7 @@ bx, dx.
 invalidating stored segment pointers to them.
 
 ----------
-#### GenPathSetCurrentPathFromObjectPath
+### GenPathSetCurrentPathFromObjectPath
 
 This utility routine sets the thread's current path to the value stored in a 
 GenFilePath in the object's vardata.
@@ -660,7 +660,7 @@ ax.
 **Library:**genC.def
 
 ----------
-#### GenPathSetObjectPath
+### GenPathSetObjectPath
 This utility routine changes the path stored in the indicated vardata entry to 
 match that passed.
 
@@ -687,7 +687,7 @@ bx, cx, dx.
 invalidating stored segment pointers to them.
 
 ----------
-#### GenPathUnrelocObjectPath
+### GenPathUnrelocObjectPath
 This utility routine changes the path stored in the indicated vardata entry to 
 match that passed.
 
@@ -710,7 +710,7 @@ Nothing.
 **Library:** genC.def
 
 ----------
-#### GenRelocMonikerList
+### GenRelocMonikerList
 This utility routine sends a message to a GenItemGroup's destination, with 
 the usual arguments. You can think of this routine as the equivalent of a 
 MSG_GEN_RELOC_MONIKER_LIST.
@@ -738,7 +738,7 @@ Nothing.
 **Library:** genC.def
 
 ----------
-#### GenReturnTrackingArgs
+### GenReturnTrackingArgs
 This utility routine sends the track scrolling information structure back to 
 the object which signalled the scroll event.
 
@@ -760,7 +760,7 @@ Nothing.
 and invalidating stored segment pointers to them.
 
 ----------
-#### GenSetupTrackingArgs
+### GenSetupTrackingArgs
 This utility routine fills in extra data for track scrolling. Normally this 
 routine is only called by a view.
 
@@ -780,7 +780,7 @@ Nothing.
 and invalidating stored segment pointers to them.
 
 ----------
-#### GenValueSendMsg
+### GenValueSendMsg
 This utility routine sends a message to a GenValue's destination.
 
 **Pass:**  
@@ -797,7 +797,7 @@ ax, cx, dx, bp, di, si
 **Library:** gValueC.def
 
 ----------
-#### GenViewSendToLinksIfNeeded
+### GenViewSendToLinksIfNeeded
 This utility routine encapsulates the current message and sends it to the 
 GenView's linked views, if there are any.
 
@@ -820,7 +820,7 @@ ax, cx, dx, bp if message successfully sent.
 **Library:** gViewC.def
 
 ----------
-#### GenViewSetSimpleBounds
+### GenViewSetSimpleBounds
 This utility routine fills in extra data for track scrolling.
 
 **Pass:**  
@@ -837,7 +837,7 @@ ax, cx, dx, bp.
 **Library:** gViewC.def
 
 ----------
-#### GeodeAddReference
+### GeodeAddReference
 Artificially increase the reference count of the specified geode. This is useful 
 for geodes which want to make sure they determine when they exit, by 
 keeping the reference count artificially above zero.
@@ -854,7 +854,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeAllocQueue
+### GeodeAllocQueue
 Allocate an event queue.
 
 **Pass:**  
@@ -869,7 +869,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeDuplicateResource
+### GeodeDuplicateResource
 Load a resource from a geode's file into a new block of memory.
 
 **Pass:**  
@@ -884,7 +884,7 @@ Nothing.
 **Library:** resource.def
 
 ----------
-#### GeodeFind
+### GeodeFind
 Find a geode, given its name, and return its handle.
 
 **Pass:**  
@@ -907,7 +907,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeFindResource
+### GeodeFindResource
 Locate a particular resource in the geode's **.geo** file. Every geode is laid out 
 as follows:  
 1. GeodeFileHeader  
@@ -935,7 +935,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeFlushQueue
+### GeodeFlushQueue
 Flush all events in one queue to another queue, synchronously.
 
 **Pass:**  
@@ -959,7 +959,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeFreeDriver
+### GeodeFreeDriver
 Free a driver, given its geode handle. The driver should have been loaded 
 with **GeodeUseDriver**.
 
@@ -975,7 +975,7 @@ bx
 **Library:** driver.def
 
 ----------
-#### GeodeFreeLibrary
+### GeodeFreeLibrary
 Free a library, given its geode handle. The library should have been loaded 
 with **GeodeUseLibrary**.
 
@@ -991,7 +991,7 @@ bx
 **Library:** library.def
 
 ----------
-#### GeodeFreeQueue
+### GeodeFreeQueue
 Free an event queue.
 
 **Pass:**  
@@ -1006,7 +1006,7 @@ bx
 **Library:** geode.def
 
 ----------
-#### GeodeGetAppObject
+### GeodeGetAppObject
 Return the optr of the **GenApplicationClass** object for the specified 
 process.
 
@@ -1023,7 +1023,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeGetDefaultDriver
+### GeodeGetDefaultDriver
 Return the handle of the default driver for the indicated type.
 
 **Pass:**  
@@ -1039,7 +1039,7 @@ Nothing.
 **Library:** driver.def
 
 ----------
-#### GeodeGetDGroupDS
+### GeodeGetDGroupDS
 Return the address of the dgroup segment of the geode owning the memory 
 handle passed. The segment is put into **ds**.
 
@@ -1056,7 +1056,7 @@ Nothing.
 **Library:** resource.def
 
 ----------
-#### GeodeGetDGroupES
+### GeodeGetDGroupES
 Return the address of the dgroup segment of the geode owning the memory 
 handle passed. The segment is put into **es**.
 
@@ -1073,7 +1073,7 @@ Nothing.
 **Library:** resource.def
 
 ----------
-#### GeodeGetGeodeResourceHandle
+### GeodeGetGeodeResourceHandle
 Return the resource handle of the specified resource in the given geode.
 
 **Pass:**  
@@ -1089,7 +1089,7 @@ Nothing.
 **Library:** resource.def
 
 ----------
-#### GeodeGetInfo
+### GeodeGetInfo
 Return information about a particular geode.
 
 **Pass:**  
@@ -1139,7 +1139,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeGetProcessHandle
+### GeodeGetProcessHandle
 Return the geode handle of the current process.
 
 **Pass:**  
@@ -1154,7 +1154,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeGetResourceHandle
+### GeodeGetResourceHandle
 Return the resource handle of the specified resource identifier owned by the 
 current geode.
 
@@ -1170,7 +1170,7 @@ Nothing.
 **Library:** resource.def
 
 ----------
-#### GeodeGetUIData
+### GeodeGetUIData
 Return the UI data (a reserved word which should not be used by 
 applications) for the specified process.
 
@@ -1187,7 +1187,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeInfoDriver
+### GeodeInfoDriver
 Return a pointer to the specified driver's information block.
 
 **Pass:**  
@@ -1203,7 +1203,7 @@ Nothing.
 **Library:** driver.def
 
 ----------
-#### GeodeInfoQueue
+### GeodeInfoQueue
 Return information about a driver.
 
 **Pass:**  
@@ -1218,7 +1218,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeLoad
+### GeodeLoad
 Load a geode from the given file and execute it based on its type.
 
 **Pass:**  
@@ -1257,7 +1257,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodePrivAlloc
+### GeodePrivAlloc
 Allocates a string of contiguous words in the geode's private data area.
 
 **Pass:**  
@@ -1273,7 +1273,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodePrivFree
+### GeodePrivFree
 Frees a group of contiguous words from the geode's private data area.
 
 **Pass:**  
@@ -1290,7 +1290,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodePrivRead
+### GeodePrivRead
 Reads a number of words from the geode's private data area, copying them 
 into a passed buffer.
 
@@ -1312,7 +1312,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodePrivWrite
+### GeodePrivWrite
 Writes a number of words into the specified geode's private data area.
 
 **Pass:**  
@@ -1331,7 +1331,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeRemoveReference
+### GeodeRemoveReference
 
 Remove an extra reference to the specified geode, decrementing its reference 
 count. If the reference count drops to zero, the geode will be removed from 
@@ -1351,7 +1351,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeSetDefaultDriver
+### GeodeSetDefaultDriver
 Sets the specified driver to be the default driver for the passed type.
 
 **Pass:**  
@@ -1368,7 +1368,7 @@ ax
 **Library:** driver.def
 
 ----------
-#### GeodeSetUIData
+### GeodeSetUIData
 Set the word of UI data for the specified process. This data is opaque to 
 applications and should not be used nor set by them.
 
@@ -1385,7 +1385,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### GeodeUseDriver
+### GeodeUseDriver
 Dynamically loads a driver given its file name.
 
 **Pass:**  
@@ -1405,7 +1405,7 @@ ax
 **Library:** driver.def
 
 ----------
-#### GeodeUseLibrary
+### GeodeUseLibrary
 Dynamically use the given library. If it is not already loaded, find it on the 
 disk and load it. If it is loaded, simply increment its reference count and 
 create an additional core block for it.
@@ -1429,7 +1429,7 @@ Nothing
 **Library:** library.def
 
 ----------
-#### GrApplyRotation
+### GrApplyRotation
 Apply a rotation to the transformation matrix for a GState, then mark the 
 current transformation as invalid. The effects are cumulative to previous 
 transformations.
@@ -1450,7 +1450,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrApplyScale
+### GrApplyScale
 Apply a scale factor to a GState's transformation matrix, then mark the 
 current transformation as invalid. The effects are cumulative to previous 
 transformations.
@@ -1471,7 +1471,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrApplyTransform
+### GrApplyTransform
 Apply a full transformation to the GState's transformation matrix, then 
 mark the current transformation as invalid. The effects are cumulative to 
 previous transformations. This routine requires advanced matrix 
@@ -1498,7 +1498,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrApplyTranslation
+### GrApplyTranslation
 Apply a translation to the passed GState's transformation matrix, then mark 
 the current transformation as invalid if necessary. The effects are cumulative 
 to previous transformations.
@@ -1519,7 +1519,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrApplyTranslationDWord
+### GrApplyTranslationDWord
 Apply a 32-bit extended translation to the GState's transformation matrix, 
 then mark the current transformation as invalid, if necessary. The effects are 
 cumulative to previous transformations.
@@ -1540,7 +1540,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrBeginPath
+### GrBeginPath
 Start a new graphics path definition, or alter the existing current path. All 
 graphics operations operated after this routine until **GrEndPath** become 
 part of the path.
@@ -1560,7 +1560,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrBeginUpdate
+### GrBeginUpdate
 Begin an update of an exposed, visible region. This routine is called by 
 applications upon receipt of MSG_META_EXPOSED. Drawing to the GState 
 passed to this routine will be clipped to the exposed region. After drawing is 
@@ -1581,7 +1581,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### GrBitBlt
+### GrBitBlt
 Transfer a bit-boundary block of pixels between two locations in the video 
 memory. This can be used to shove a block of pixels quickly to give the 
 impression of motion on the screen.
@@ -1610,7 +1610,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrBrushPolyline
+### GrBrushPolyline
 Brushes a connected polyline with the passed brush characteristics.
 
 **Pass:**  
@@ -1629,7 +1629,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrCharMetrics
+### GrCharMetrics
 Return the metrics for a single character, given its value and the information 
 to return.
 
@@ -1652,7 +1652,7 @@ Nothing.
 **Library:** font.def
 
 ----------
-#### GrCharWidth
+### GrCharWidth
 Return the width of a single character, given a GState and the character.
 
 **Pass:**  
@@ -1671,7 +1671,7 @@ Nothing.
 attributes-it simply returns the character's width.
 
 ----------
-#### GrCheckFontAvail
+### GrCheckFontAvail
 Check if the named font exists and return its ID if it does.
 
 **Pass:**  
@@ -1693,7 +1693,7 @@ Nothing.
 Otherwise a fatal error will result.
 
 ----------
-#### GrClearBitmap
+### GrClearBitmap
 Clear out the contents of the bitmap associated with the given GState. The 
 parts of the bitmap actually cleared (set to white) will depend on the bitmap's 
 mode. For the normal mode, the data part of the bitmap is cleared while the 
@@ -1714,7 +1714,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrCloseSubPath
+### GrCloseSubPath
 Geometrically closes the currently open path. This does not end the path 
 definition - you still must call **GrEndPath**.
 
@@ -1730,7 +1730,7 @@ Nothing.
 **Library:**    graphics.def
 
 ----------
-#### GrComment
+### GrComment
 Write a comment into a graphics string.
 
 **Pass:**  
@@ -1747,7 +1747,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrCompactBitmap
+### GrCompactBitmap
 Compact a bitmap stored in a huge array.
 
 **Pass:**  
@@ -1766,7 +1766,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrCopyGString
+### GrCopyGString
 Copy a graphics string from one GString to another.
 
 **Pass:**  
@@ -1797,7 +1797,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrCreateBitmap
+### GrCreateBitmap
 Allocate memory for a bitmap and associate the memory with a window.
 
 **Pass:**  
@@ -1820,7 +1820,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrCreateGString
+### GrCreateGString
 Open a graphics string and begin redirecting graphics commands to the 
 GString.
 
@@ -1843,7 +1843,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrCreatePalette
+### GrCreatePalette
 Create a color mapping table and associate it with the current window (the 
 window associated with the passed GState). Initialize the table to the default 
 values for the device's palette.
@@ -1860,7 +1860,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrCreateState
+### GrCreateState
 
 Create graphics state block containing a default GState associated with the 
 passed window. This routine is typically used to create a GState for drawing 
@@ -1881,7 +1881,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDeleteGStringElement
+### GrDeleteGStringElement
 Delete a range of GString elements from the specified GString.
 
 **Pass:**  
@@ -1898,7 +1898,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrDestroyBitmap
+### GrDestroyBitmap
 Free the bitmap associated with the given GState and disassociate it from 
 the window.
 
@@ -1918,7 +1918,7 @@ di
 **Library:** graphics.def
 
 ----------
-#### GrDestroyGString
+### GrDestroyGString
 Destroy the specified GString, either removing the GState from the data, or 
 freeing both GState and GString data. You may ask that an additional 
 GState be destroyed as well.
@@ -1940,7 +1940,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrDestroyPalette
+### GrDestroyPalette
 Free the current window's custom palette, if any.
 
 **Pass:**  
@@ -1955,7 +1955,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDestroyState
+### GrDestroyState
 Destroy a GState block and the GState handle. Typically called in 
 MSG_META_EXPOSED after drawing is finished. The GState is normally 
 created with **GrCreateState**.
@@ -1972,7 +1972,7 @@ di
 **Library:** graphics.def
 
 ----------
-#### GrDrawArc
+### GrDrawArc
 Draws an arc along the ellipse specified by a bounding box, a starting angle, 
 and an ending angle.
 
@@ -1991,7 +1991,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawArc3Point
+### GrDrawArc3Point
 Draw a circular arc specified by three points along the arc: both endpoints 
 and any other point on the arc.
 
@@ -2010,7 +2010,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawArc3PointTo
+### GrDrawArc3PointTo
 Draw a circular arc, given two points along the arc and using the current pen 
 position as the first endpoint. The other two points are the other endpoint 
 and any other point on the arc.
@@ -2028,7 +2028,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawBitmap
+### GrDrawBitmap
 Draw a bitmap at the coordinates passed. This routine will call a callback 
 routine that is expected to take a pointer to a slice of bitmap and return the 
 next slice. In most cases, the callback will be supplied by the kernel.
@@ -2058,7 +2058,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawBitmapAtCP
+### GrDrawBitmapAtCP
 Draw a bitmap at the current pen position. This routine will call a callback 
 routine that is expected to take a pointer to a slice of bitmap and return the 
 next slice. In most cases, the callback will be supplied by the kernel.
@@ -2088,7 +2088,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawChar
+### GrDrawChar
 Draw a given character at the specified position with the current text 
 drawing state.
 
@@ -2108,7 +2108,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawCharAtCP
+### GrDrawCharAtCP
 Draw a given character at the current pen position using the current text 
 drawing state.
 
@@ -2126,7 +2126,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawCurve
+### GrDrawCurve
 Draw a bezier curve specified by four points.
 
 ![image info](ASMRefFigures/9drawcurve.png)
@@ -2149,7 +2149,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawCurveTo
+### GrDrawCurveTo
 Draw a bezier curve beginning with the current pen position.
 
 **Pass:**  
@@ -2169,7 +2169,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawEllipse
+### GrDrawEllipse
 Draw a framed ellipse bounded by the passed rectangle.
 
 ![image info](ASMRefFigures/10drawellipse.png)
@@ -2189,7 +2189,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawGString
+### GrDrawGString
 Draw the passed GString at the given coordinates.
 
 **Pass:**  
@@ -2220,7 +2220,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrDrawGStringAtCP
+### GrDrawGStringAtCP
 Draw the passed GString at the current pen position.
 
 **Pass:**  
@@ -2251,7 +2251,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrDrawHLine
+### GrDrawHLine
 Draw a horizontal line.
 
 **Pass:**  
@@ -2269,7 +2269,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawHLineTo
+### GrDrawHLineTo
 Draw a horizontal line using the current pen position as the starting point.
 
 **Pass:**  
@@ -2285,7 +2285,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawHugeBitmap
+### GrDrawHugeBitmap
 Draw a bitmap residing in a HugeArray at the coordinates passed.
 
 **Pass:**  
@@ -2303,7 +2303,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawHugeBitmapAtCP
+### GrDrawHugeBitmapAtCP
 Draw a bitmap residing in a HugeArray at the current pen position.
 
 **Pass:**  
@@ -2320,7 +2320,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawHugeImage
+### GrDrawHugeImage
 Draw a bitmap at the passed position. The bitmap must reside in a 
 HugeArray, and the image may be drawn with a square block of video pixels 
 representing each bitmap pixel (i.e. a "magnified view").
@@ -2352,7 +2352,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawImage
+### GrDrawImage
 Draw a bitmap at the passed position. The bitmap may be drawn with a 
 square block of video pixels representing each bitmap pixel (i.e. a "magnified 
 view"). If the bitmap is in a HugeArray, you should use 
@@ -2385,7 +2385,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawLine
+### GrDrawLine
 Draw a line, given the two endpoints.
 
 **Pass:**  
@@ -2402,7 +2402,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawLineTo
+### GrDrawLineTo
 Draw a straight line from the pen position to the passed endpoint.
 
 **Pass:**  
@@ -2418,7 +2418,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawPath
+### GrDrawPath
 Draws the passed GState's path with the current line attributes.
 
 **Pass:**  
@@ -2434,7 +2434,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawPoint
+### GrDrawPoint
 Draw a single document pixel at the passed coordinates.
 
 **Pass:**  
@@ -2450,7 +2450,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawPointAtCP
+### GrDrawPointAtCP
 Draws a single document pixel at the current pen position.
 
 **Pass:**  
@@ -2465,7 +2465,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawPolygon
+### GrDrawPolygon
 Draws the passed connected polygon.
 
 **Pass:**  
@@ -2482,7 +2482,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawPolyline
+### GrDrawPolyline
 Draws a polyline using the passed GState's line attributes. To use special 
 "brush" attributes, call **GrBrushPolyline**.
 
@@ -2500,7 +2500,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawRect
+### GrDrawRect
 Draw a rectangle defined by the two corner points. To fill the rectangle, call 
 **GrFillRect**.
 
@@ -2518,7 +2518,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawRectTo
+### GrDrawRectTo
 Draw a rectangle defined by one corner point and the current pen position.
 
 **Pass:**  
@@ -2534,7 +2534,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawRegion
+### GrDrawRegion
 Draw a region.
 
 **Pass:**  
@@ -2553,7 +2553,7 @@ Nothing.
 **Library:** graphics.def.
 
 ----------
-#### GrDrawRegionAtCP
+### GrDrawRegionAtCP
 Draw a region at the current pen position.
 
 **Pass:**  
@@ -2571,7 +2571,7 @@ Nothing.
 **Library:** graphics.def.
 
 ----------
-#### GrDrawRelArc3PointTo
+### GrDrawRelArc3PointTo
 Draw a circular arc relative to the current pen position, given two additional 
 points: the other endpoint, and any other point on the arc. Both of the 
 additional points are given in offsets from (relative to) the pen position.
@@ -2591,7 +2591,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawRelCurveTo
+### GrDrawRelCurveTo
 Draw a bezier curve using the current pen position as the first endpoint. All 
 other points in the curve are defined by offsets from (relative to) the current 
 pen position. See **GrDrawCurve** for a diagram of a bezier curve.
@@ -2614,7 +2614,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawRelLineTo
+### GrDrawRelLineTo
 Draw a line from the current pen position to the point defined by the passed 
 displacements.
 
@@ -2632,7 +2632,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawRoundRect
+### GrDrawRoundRect
 Draw a rectangle with rounded corners.
 
 ![image info](ASMRefFigures/11drawroundrect.png)
@@ -2652,7 +2652,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawRoundRectTo
+### GrDrawRoundRectTo
 Draw a rounded rectangle at the current pen position.
 
 **Pass:**  
@@ -2669,7 +2669,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawSpline
+### GrDrawSpline
 Draw a collection of bezier curves defined by the passed array of Points.
 
 **Pass:**  
@@ -2687,7 +2687,7 @@ Nothing.
 **Library:** - graphics.def
 
 ----------
-#### GrDrawSplineTo
+### GrDrawSplineTo
 Draw a collection of bezier curves defined by the passed array of Points and 
 having its first anchor point at the current pen position.
 
@@ -2707,7 +2707,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawText
+### GrDrawText
 Draw a string at the given position with the current text drawing 
 characteristics (defined by the GState).
 
@@ -2727,7 +2727,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawTextAtCP
+### GrDrawTextAtCP
 Draw a string at the current pen position with the current text drawing 
 characteristics (defined by the GState).
 
@@ -2746,7 +2746,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawTextField
+### GrDrawTextField
 This routine draws a text field.
 
 **Pass:**  
@@ -2774,7 +2774,7 @@ ds:si - Pointer to text at offset
 **Library:**    graphics.def
 
 ----------
-#### GrDrawVLine
+### GrDrawVLine
 Draw a vertical line.
 
 **Pass:**  
@@ -2791,7 +2791,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrDrawVLineTo
+### GrDrawVLineTo
 Draw a vertical line beginning at the current pen position.
 
 **Pass:**  
@@ -2807,7 +2807,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrEditBitmap
+### GrEditBitmap
 Associate a previously created bitmap with a window and a GState to allow 
 the caller to edit the bitmap.
 
@@ -2826,7 +2826,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrEditGString
+### GrEditGString
 Set a specified graphics string into editing mode.
 
 **Pass:**  
@@ -2844,7 +2844,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrEndGString
+### GrEndGString
 End a definition of a GString. This is the complement to **GrBeginString**.
 
 **Pass:**  
@@ -2861,7 +2861,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrEndPath
+### GrEndPath
 Ends the definition of the current path. This is the complement to 
 **GrBeginPath**.
 
@@ -2877,7 +2877,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrEndUpdate
+### GrEndUpdate
 Unlock a window from a visual update begun with **GrBeginUpdate**.
 
 **Pass:**  
@@ -2892,7 +2892,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### GrEnumFonts
+### GrEnumFonts
 Generate a list of font names of the available fonts. Return the number of 
 matching fonts; the names are returned in a passed buffer.
 
@@ -2922,7 +2922,7 @@ Nothing.
 **Library:** font.def
 
 ----------
-#### GrEscape
+### GrEscape
 Write an "escape" element to a graphics string. This call is meaningful only 
 between calls to **GrBeginGString** and **GrEndGString**. The element, in 
 full, will have the following structure:
@@ -2948,7 +2948,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrFillArc
+### GrFillArc
 Draws an arc as in **GrDrawArc** and fills it like a pie wedge. The arc is 
 defined by an ellipse in a bounding box and two angles that intersect the 
 ellipse (see **GrDrawArc**).
@@ -2971,7 +2971,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillArc3Point
+### GrFillArc3Point
 Fill a circular arc defined by three points: two endpoints and any other point 
 along the arc. The filled portion will be the pie wedge defined by the arc.
 
@@ -2988,7 +2988,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillArc3PointTo
+### GrFillArc3PointTo
 Fill a circular arc defined by the current pen position (as the first endpoint) 
 and two other points: the opposite endpoint and any other point along the 
 arc. The filled portion will be the pie wedge defined by the arc.
@@ -3006,7 +3006,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillBitmap
+### GrFillBitmap
 
 Draw the given bitmap as if it were a mask, filling it with the current area 
 color.
@@ -3037,7 +3037,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillBitmapAtCP
+### GrFillBitmapAtCP
 Draw the given bitmap as if it were a mask, filling it with the current area 
 color. The bitmap will be drawn at the current pen position.
 
@@ -3066,7 +3066,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillEllipse
+### GrFillEllipse
 Draws a filled ellipse bounded by the passed rectangle.
 
 **Pass:**  
@@ -3083,7 +3083,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillHugeBitmap
+### GrFillHugeBitmap
 Treat a monochrome bitmap as a mask, filling it with the current area color. 
 The bitmap should be stored in a huge array.
 
@@ -3102,7 +3102,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillHugeBitmapAtCP
+### GrFillHugeBitmapAtCP
 Treat a monochrome bitmap as a mask, filling it with the current area color. 
 The bitmap should be stored in a huge array.
 
@@ -3121,7 +3121,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillPath
+### GrFillPath
 Draws a filled representation of the passed GState's current path, using the 
 supplied fill rule and current GState area attributes.
 
@@ -3138,7 +3138,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillPolygon
+### GrFillPolygon
 Draw a filled polygon.
 
 **Pass:**  
@@ -3156,7 +3156,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillRect
+### GrFillRect
 Fill the rectangle defined by the two passed points.
 
 **Pass:**  
@@ -3173,7 +3173,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillRectTo
+### GrFillRectTo
 Fill the rectangle defined by the current pen position and the passed point.
 
 **Pass:**  
@@ -3189,7 +3189,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillRoundRect
+### GrFillRoundRect
 Fill the rounded rectangle defined by the parameters.
 
 **Pass:**  
@@ -3207,7 +3207,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFillRoundRectTo
+### GrFillRoundRectTo
 Fill the rounded rectangle defined by the current pen position and the 
 parameters.
 
@@ -3225,7 +3225,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrFontMetrics
+### GrFontMetrics
 Return metrics information about the given GState's current font.
 
 **Pass:**  
@@ -3244,7 +3244,7 @@ Nothing.
 **Library:** font.def
 
 ----------
-#### GrGetAreaColor
+### GrGetAreaColor
 Return the area color set for the given GState.
 
 **Pass:**  
@@ -3261,7 +3261,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetAreaColorMap
+### GrGetAreaColorMap
 Return the area color map of the given GState.
 
 **Pass:**  
@@ -3276,7 +3276,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetAreaMask
+### GrGetAreaMask
 Return the area mask type of the passed GState.
 
 **Pass:**  
@@ -3297,7 +3297,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetAreaPattern
+### GrGetAreaPattern
 Return the fill pattern for the passed GState.
 
 **Pass:**  
@@ -3316,7 +3316,7 @@ Depending on return values, **ah**.
 **Library:**    graphics.def
 
 ----------
-#### GrGetBitmap
+### GrGetBitmap
 Copy a bitmap from the screen to a memory block.
 
 **Pass:**  
@@ -3341,7 +3341,7 @@ from the screen to memory. It is therefore useful for screen dumps but not
 necessarily useful for applications.
 
 ----------
-#### GrGetBitmapMode
+### GrGetBitmapMode
 Return the mode information for the editable bitmap owned by the passed 
 GState.
 
@@ -3363,7 +3363,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetBitmapRes
+### GrGetBitmapRes
 Return the resolution of the bitmap owned by the passed GState.
 
 **Pass:**  
@@ -3379,7 +3379,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetBitmapSize
+### GrGetBitmapSize
 Return the size of the bitmap owned by the passed GState.
 
 **Pass:**  
@@ -3395,7 +3395,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetClipRegion
+### GrGetClipRegion
 Return the region corresponding to the clip paths of the passed GState. The 
 region is in device coordinates; the first four words are its bounds.
 
@@ -3414,7 +3414,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetCurPos
+### GrGetCurPos
 Return the current drawing position for the passed GState.
 
 **Pass:**  
@@ -3430,7 +3430,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetCurPosWWFixed
+### GrGetCurPosWWFixed
 Return the current drawing position for the passed GState. The answer 
 returned is rather precise, with one word of fraction information for both the 
 *x* and *y* coordinates.
@@ -3448,7 +3448,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetDefFontID
+### GrGetDefFontID
 Return the default fond ID and point size as defined in the GEOS.INI file. Also 
 return the font data block.
 
@@ -3466,7 +3466,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetExclusive
+### GrGetExclusive
 Check to see if any GState has exclusive drawing rights to the screen.
 
 **Pass:**  
@@ -3483,7 +3483,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetFont
+### GrGetFont
 Return the current font's font ID and point size as set in the passed GState.
 
 **Pass:**  
@@ -3500,7 +3500,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetFontName
+### GrGetFontName
 Return the name string of a specified font.
 
 **Pass:**  
@@ -3522,7 +3522,7 @@ Nothing.
 **Library:** font.def
 
 ----------
-#### GrGetFontWeight
+### GrGetFontWeight
 Return the weight of the current font as set in the passed GState.
 
 **Pass:**  
@@ -3537,7 +3537,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetFontWidth
+### GrGetFontWidth
 Return the width of the current font as set in the passed GState.
 
 **Pass:**  
@@ -3552,7 +3552,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetGStringBounds
+### GrGetGStringBounds
 Return the coordinate bounds of a graphics string drawn at the current pen 
 position.
 
@@ -3576,7 +3576,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrGetGStringBoundsDWord
+### GrGetGStringBoundsDWord
 Get coordinate bounds of a graphics string.
 
 **Pass:**  
@@ -3594,7 +3594,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrGetGStringElement
+### GrGetGStringElement
 Extract and return an element from a graphics string.
 
 **Pass:**  
@@ -3614,7 +3614,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrGetGStringHandle
+### GrGetGStringHandle
 Return the handle of the graphics string associated with the passed GState.
 
 **Pass:**  
@@ -3629,7 +3629,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetHugeBitmapSize
+### GrGetHugeBitmapSize
 Return the size in points of the bitmap.
 
 **Pass:**  
@@ -3644,7 +3644,7 @@ Nothing.
 **Library:** graphics.def
     
 ----------
-#### GrGetInfo
+### GrGetInfo
 Return information about the GState as requested.
 
 **Pass:**  
@@ -3666,7 +3666,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetLineColor
+### GrGetLineColor
 Return the line drawing color set for the passed GState.
 
 **Pass:**  
@@ -3683,7 +3683,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetLineColorMap
+### GrGetLineColorMap
 Return the line color mapping information for the specified GState.
 
 **Pass:**  
@@ -3699,7 +3699,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetLineEnd
+### GrGetLineEnd
 Return the line end type set for the passed GState.
 
 **Pass:**  
@@ -3715,7 +3715,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetLineJoin
+### GrGetLineJoin
 Return the line join type set for the passed GState.
 
 **Pass:**  
@@ -3731,7 +3731,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetLineMask
+### GrGetLineMask
 Return information about the line mask set for the passed GState.
 
 **Pass:**  
@@ -3752,7 +3752,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetLineStyle
+### GrGetLineStyle
 Return the line style type (dash pattern) set for the passed GState.
 
 **Pass:**  
@@ -3769,7 +3769,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetLineWidth
+### GrGetLineWidth
 Return the line width set for the passed GState.
 
 **Pass:**  
@@ -3784,7 +3784,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetMaskBounds
+### GrGetMaskBounds
 Return the 16-bit bounds of the current clipping rectangle for the passed 
 GState.
 
@@ -3806,7 +3806,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetMaskBoundsDWord
+### GrGetMaskBoundsDWord
 Return the 32-bit bounds of the current clipping rectangle for the passed 
 GState.
 
@@ -3825,7 +3825,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetMiterLimit
+### GrGetMiterLimit
 Return the miter limit set for the passed GState. The miter limit is the 
 smallest angle that can be drawn with a miter join; smaller angles must be 
 drawn with a beveled join.
@@ -3842,7 +3842,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetMixMode
+### GrGetMixMode
 Return the mix mode set for the passed GState.
 
 **Pass:**  
@@ -3858,7 +3858,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetPalette
+### GrGetPalette
 Return the palette definition set for the passed GState.
 
 **Pass:**  
@@ -3877,7 +3877,7 @@ dx.
 **Library:** graphics.def
 
 ----------
-#### GrGetPath
+### GrGetPath
 Return the GString data defining the current path of the passed GState.
 
 **Pass:**  
@@ -3900,7 +3900,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetPathBounds
+### GrGetPathBounds
 Return the smallest rectangle that can encompass the path set in the passed 
 GState, as it would be filled.
 
@@ -3922,7 +3922,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetPathBoundsDWord
+### GrGetPathBoundsDWord
 Returns the rectangular bounds that encompass the current path (as it 
 would be filled)
 
@@ -3942,7 +3942,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetPathRegion
+### GrGetPathRegion
 Return the region defined by the path in the passed GState. The region is 
 expressed in terms of device coordinates; the first four words of the returned 
 region are its bounds.
@@ -3964,7 +3964,7 @@ Nothing.
 **Warning:** The returned bounds are in device coordinates, not document coordinates.
 
 ----------
-#### GrGetPoint
+### GrGetPoint
 Return the color of a single document pixel.
 
 **Pass:**  
@@ -3983,7 +3983,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetSubscriptAttr
+### GrGetSubscriptAttr
 Return the subscript attributes used by the passed GState.
 
 **Pass:**  
@@ -4000,7 +4000,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetSuperscriptAttr
+### GrGetSuperscriptAttr
 Return the superscript attributes used by the passed GState.
 
 **Pass:**  
@@ -4017,7 +4017,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextBounds
+### GrGetTextBounds
 Return the bounds of the smallest rectangle that can enclose the given text 
 string using the passed GState's text attributes.
 
@@ -4041,7 +4041,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextColor
+### GrGetTextColor
 Return the text color set in the passed GState.
 
 **Pass:**  
@@ -4058,7 +4058,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextColorMap
+### GrGetTextColorMap
 Return the color map used by the given GState when drawing text.
 
 **Pass:**  
@@ -4074,7 +4074,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextDrawOffset
+### GrGetTextDrawOffset
 Return the number of characters to be drawn at the end of a string.
 
 **Pass:**  
@@ -4090,7 +4090,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextMask
+### GrGetTextMask
 Return information about the given GState's text drawing mask.
 
 **Pass:**  
@@ -4113,7 +4113,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextMode
+### GrGetTextMode
 Return the text mode used by the passed GState.
 
 **Pass:**  
@@ -4128,7 +4128,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextPattern
+### GrGetTextPattern
 Return the text fill pattern set for the passed GState.
 
 **Pass:**  
@@ -4150,7 +4150,7 @@ Nothing. Possibly **ah**; see return values.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextSpacePad
+### GrGetTextSpacePad
 Return the given GState's space padding setting. This determines the 
 amount to pad spaces when drawing text.
 
@@ -4167,7 +4167,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTextStyle
+### GrGetTextStyle
 Return the text style set in the passed GState.
 
 **Pass:**  
@@ -4182,7 +4182,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTrackKern
+### GrGetTrackKern
 Return the degree of track kerning used by the passed GState.
 
 **Pass:**  
@@ -4197,7 +4197,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetTransform
+### GrGetTransform
 Return the transformation matrix set for the passed GState.
 
 **Pass:**  
@@ -4220,7 +4220,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetWinBounds
+### GrGetWinBounds
 Return the bounds of the current window's region, in document coordinates. 
 The window is specified by the passed GState.
 
@@ -4242,7 +4242,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetWinBoundsDWord
+### GrGetWinBoundsDWord
 Return the bounds of the current window's region, in document coordinates. 
 These coordinates are 32-bit values for extended transformations. If one of 
 the window's transformation matrixes contains a rotation, the returned 
@@ -4263,7 +4263,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGetWinHandle
+### GrGetWinHandle
 Return the window handle of the window associated with the passed GState.
 
 **Pass:**  
@@ -4278,7 +4278,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrGrabExclusive
+### GrGrabExclusive
 Grab the video driver's exclusive access in order to begin drawing directly to 
 the video driver. It is very rare that applications will ever need this.
 
@@ -4295,7 +4295,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrInitDefaultTransform
+### GrInitDefaultTransform
 Replace the default transformation matrix with the passed GState's current 
 transformation matrix. This routine should be used only with great care; it 
 will be called by applications only in the absolute rarest of situations.
@@ -4314,7 +4314,7 @@ Nothing.
 **Warning:** This routine should almost never be used by applications.
 
 ----------
-#### GrInvalRect
+### GrInvalRect
 Invalidate a portion of the window associated with the passed GState. The 
 rectangle passed will be added to the window's update region. If the rectangle 
 is rotated, the region will be built out before being added to the window's 
@@ -4336,7 +4336,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrInvalRectDWord
+### GrInvalRectDWord
 Invalidate a portion of the window associated with the passed GState. This 
 routine is like **GrInvalRect** except that it uses 32-bit coordinates rather than 
 16-bit coordinates.
@@ -4355,7 +4355,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrLabel
+### GrLabel
 Write a label element to a graphics string. This routine writes out three bytes 
 to the graphics string; the first byte is a GR_LABEL opcode, and the second 
 and third bytes are the label passed in ax.
@@ -4373,7 +4373,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrLoadGString
+### GrLoadGString
 Load a graphics string from a file, a stream, or a locked block. Allocate new 
 memory for the loaded graphics stream, returning the handle of the new 
 block. (This routine does not actually copy the entire string into the new 
@@ -4399,7 +4399,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrMapColorIndex
+### GrMapColorIndex
 Map a color index to its RGB equivalent.
 
 **Pass:**  
@@ -4418,7 +4418,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrMapColorRGB
+### GrMapColorRGB
 Map an RGB color to its palette index.
 
 **Pass:**  
@@ -4440,7 +4440,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrMoveReg
+### GrMoveReg
 Move a region by a given amount both horizontally and vertically.
 
 **Pass:**  
@@ -4457,7 +4457,7 @@ ax
 **Library:** graphics.def
 
 ----------
-#### GrMoveTo
+### GrMoveTo
 Set the current pen position for the passed GState.
 
 **Pass:**  
@@ -4474,7 +4474,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrMulDWFixed
+### GrMulDWFixed
 Multiply two 48-bit signed numbers, where each integer is a DWFixed 
 structure.
 
@@ -4495,7 +4495,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrMulDWFixedPtr
+### GrMulDWFixedPtr
 Multiply two 48-bit signed numbers, where each integer is a **DWFixed** 
 structure. The parameters are passed in two buffers, unlike 
 **GrMulDWFixed**.
@@ -4515,7 +4515,7 @@ Nothing.
 **Library:**    graphics.def
 
 ----------
-#### GrMulWWFixed
+### GrMulWWFixed
 Multiply two 32-bit signed numbers of type **WWFixed**.
 
 **Pass:**  
@@ -4531,7 +4531,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrMulWWFixedPtr
+### GrMulWWFixedPtr
 Multiply two 32-bit signed numbers of type WWFixed, passed in two buffers.
 
 **Pass:**  
@@ -4547,7 +4547,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrNewPage
+### GrNewPage
 Execute a form feed for the GState or GString passed. When drawing to a 
 path, this routine is ignored. When writing to a graphics string, it stores a 
 GR_NEW_PAGE code. Otherwise, it invalidates the entire window 
@@ -4566,7 +4566,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrNullOp
+### GrNullOp
 Write a no-operation code to a graphics string.
 
 **Pass:**  
@@ -4581,7 +4581,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrParseGString
+### GrParseGString
 Parse a graphics string by invoking a callback routine on each desired 
 element.
 
@@ -4612,7 +4612,7 @@ Any. May *not* write into the block pointed to by **ds**.
 **Library:** gstring.def
 
 ----------
-#### GrPolarToCartesian
+### GrPolarToCartesian
 Convert a polar coordinate to its corresponding cartesian equivalents.
 
 **Pass:**  
@@ -4630,7 +4630,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrQuickArcSine
+### GrQuickArcSine
 Calculate an inverse sine. This routine returns the largest integral angle 
 with a sine less than the passed value.
 
@@ -4647,7 +4647,7 @@ ax, bx
 **Library:** graphics.def
 
 ----------
-#### GrQuickCosine
+### GrQuickCosine
 Calculate the cosine of an angle.
 
 **Pass:**  
@@ -4664,7 +4664,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrQuickSine
+### GrQuickSine
 Calculate the sine of an angle.
 
 **Pass:**  
@@ -4681,7 +4681,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrQuickTangent
+### GrQuickTangent
 Calculate the tangent of the passed angle.
 
 **Pass:**  
@@ -4696,7 +4696,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrReleaseExclusive
+### GrReleaseExclusive
 Release the exclusive grab made on a video driver with **GrGrabExclusive**.
 
 **Pass:**  
@@ -4712,7 +4712,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrRelMoveTo
+### GrRelMoveTo
 Set the current pen position of the passed GState. Sets the new position 
 relative to the current position; to set the position absolutely, use 
 **GrMoveTo**.
@@ -4731,7 +4731,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrRestoreState
+### GrRestoreState
 Restore the current GState from a GState previously saved with 
 **GrSaveState**.
 
@@ -4747,7 +4747,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrRestoreTransform
+### GrRestoreTransform
 Set the passed GState's transformation matrix to be the one previously saved 
 with **GrSaveTransform**.
 
@@ -4764,7 +4764,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSaveState
+### GrSaveState
 Save the current GState characteristics for later restoration with 
 **GrRestoreState**.
 
@@ -4780,7 +4780,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSaveTransform
+### GrSaveTransform
 Save the transformation matrix of the passed GState for later restoration 
 with **GrRestoreTransform**.
 
@@ -4796,7 +4796,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSDivDWFbyWWF
+### GrSDivDWFbyWWF
 Divide the **WWFixed** value into the **DWFixed** value. The result is a **DWFixed**. 
 This routine is optimized for size over speed.
 
@@ -4813,7 +4813,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSDivWWFixed
+### GrSDivWWFixed
 Divide a 32-bit **WWFixed** value by another 32-bit **WWFixed** value.
 
 **Pass:**  
@@ -4830,7 +4830,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetAreaAttr
+### GrSetAreaAttr
 Set all the area attributes of the given GState.
 
 **Pass:**  
@@ -4846,7 +4846,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetAreaColor
+### GrSetAreaColor
 Set the GState's current area drawing color.
 
 **Pass:**  
@@ -4865,7 +4865,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetAreaColorMap
+### GrSetAreaColorMap
 Set the GState's current area color mapping mode.
 
 **Pass:**  
@@ -4881,7 +4881,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetAreaMask
+### GrSetAreaMask
 Set the GState's current area drawing pattern.
 
 **Pass:**  
@@ -4902,7 +4902,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetAreaPattern
+### GrSetAreaPattern
 Set the GState's area fill pattern.
 
 **Pass:**  
@@ -4923,7 +4923,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetBitmapMode
+### GrSetBitmapMode
 Set the GState's mode bits for an editable bitmap.
 
 **Pass:**  
@@ -4945,7 +4945,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetBitmapRes
+### GrSetBitmapRes
 Set the resolution of the GState's bitmap.
 
 **Pass:**  
@@ -4962,7 +4962,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetClipPath
+### GrSetClipPath
 Set the GState's current clip path to be the clip path for all future graphics 
 operations on the GState. The path is affected only by the window's 
 transformation matrix.
@@ -4982,7 +4982,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetClipRect
+### GrSetClipRect
 Modify a window's clipping path by intersecting it with the specified 
 rectangle. The rectangle should be defined in the document coordinate space 
 of the passed GState; the rectangle will be transformed appropriately when 
@@ -5007,7 +5007,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetDefaultTransform
+### GrSetDefaultTransform
 Reset the GState's transformation matrix to be the same as the default 
 transformation matrix. In most cases, the default transformation matrix is 
 simply the identity matrix (no transformations); this is not true in all cases, 
@@ -5026,7 +5026,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetFont
+### GrSetFont
 Set the font used by the GState for all subsequent text drawing. If the desired 
 font is not available, then the default font is set instead.
 
@@ -5045,7 +5045,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetFontWeight
+### GrSetFontWeight
 Set the font weight used by the GState.
 
 **Pass:**  
@@ -5061,7 +5061,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetFontWidth
+### GrSetFontWidth
 Set the font width used by the GState.
 
 **Pass:**  
@@ -5077,7 +5077,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetGStringBounds
+### GrSetGStringBounds
 Store a GR_SET_GSTRING_BOUNDS opcode to a graphics string, along with 
 the bounds of the string.
 
@@ -5097,7 +5097,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrSetGStringPos
+### GrSetGStringPos
 Set the current drawing position of a graphics string.
 
 **Pass:**  
@@ -5120,7 +5120,7 @@ Nothing.
 **Library:** gstring.def
 
 ----------
-#### GrSetLineAttr
+### GrSetLineAttr
 Set all the line drawing attributes for the given GState.
 
 **Pass:**  
@@ -5136,7 +5136,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetLineColor
+### GrSetLineColor
 Set the current line drawing color for the GState.
 
 **Pass:**  
@@ -5155,7 +5155,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetLineColorMap
+### GrSetLineColorMap
 Set the GState's current line color mapping mode.
 
 **Pass:**  
@@ -5171,7 +5171,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetLineEnd
+### GrSetLineEnd
 Set the line end type for the passed GState.
 
 **Pass:**  
@@ -5188,7 +5188,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetLineJoin
+### GrSetLineJoin
 Set the line join type for the passed GState.
 
 **Pass:**  
@@ -5205,7 +5205,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetLineMask
+### GrSetLineMask
 Set the current line drawing mask for the passed GState.
 
 **Pass:**  
@@ -5226,7 +5226,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetLineStyle
+### GrSetLineStyle
 Set the current line drawing style (dash pattern) of the passed GState.
 
 **Pass:**  
@@ -5246,7 +5246,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetLineWidth
+### GrSetLineWidth
 Set the line drawing width of the passed GState.
 
 **Pass:**  
@@ -5262,7 +5262,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetMiterLimit
+### GrSetMiterLimit
 Set the miter limit for the passed GState. The miter limit is the smallest 
 angle that can be drawn with a miter join; smaller angles must be drawn 
 with a beveled join.
@@ -5280,7 +5280,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetMixMode
+### GrSetMixMode
 Set the drawing mix mode for the passed GState.
 
 **Pass:**  
@@ -5298,7 +5298,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetNullTransform
+### GrSetNullTransform
 Replace the GState's transformation matrix with the null (identity) 
 transformation matrix. This routine should not be substituted for 
 **GrSetDefaultTransform**, which reverts a transformation matrix to the 
@@ -5316,7 +5316,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetPalette
+### GrSetPalette
 Set one or more palette entries in the GState's color map.
 
 **Pass:**  
@@ -5334,7 +5334,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetPaletteEntry
+### GrSetPaletteEntry
 Set a single entry in the GState's palette.
 
 **Pass:**  
@@ -5353,7 +5353,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetPrivateData
+### GrSetPrivateData
 Set the private data for the given GState. This may be retrieved with 
 **GrGetInfo**; applications should not use the GState's private data, however.
 
@@ -5370,7 +5370,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetStrokePath
+### GrSetStrokePath
 Replace the GState's current path with the one defined as the stroked 
 representation of the current path.
 
@@ -5386,7 +5386,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetSubscriptAttr
+### GrSetSubscriptAttr
 Set the GState's subscript attributes.
 
 **Pass:**  
@@ -5403,7 +5403,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetSuperscriptAttr
+### GrSetSuperscriptAttr
 Set the GState's superscript attributes.
 
 **Pass:**  
@@ -5420,7 +5420,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextAttr
+### GrSetTextAttr
 Set all the GState's text drawing attributes.
 
 **Pass:**  
@@ -5436,7 +5436,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextColor
+### GrSetTextColor
 Set the current text drawing color for the GState.
 
 **Pass:**  
@@ -5455,7 +5455,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextColorMap
+### GrSetTextColorMap
 Set the GState's current text color mapping mode.
 
 **Pass:**  
@@ -5471,7 +5471,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextDrawOffset
+### GrSetTextDrawOffset
 Set the number of characters at the end of a string to draw. This operation is 
 never saved out to a graphics string.
 
@@ -5489,7 +5489,7 @@ Nothing.
 **Library:** text.def
 
 ----------
-#### GrSetTextMask
+### GrSetTextMask
 Set the current text drawing mask for the passed GState.
 
 **Pass:**  
@@ -5510,7 +5510,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextMode
+### GrSetTextMode
 Set the GState's current text drawing mode.
 
 **Pass:**  
@@ -5527,7 +5527,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextPattern
+### GrSetTextPattern
 Set the GState's text fill pattern.
 
 **Pass:**  
@@ -5548,7 +5548,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextSpacePad
+### GrSetTextSpacePad
 Set the amount to pad spaces when drawing text with **GrPutString**.
 
 **Pass:**  
@@ -5565,7 +5565,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTextStyle
+### GrSetTextStyle
 Set the GState's current text style.
 
 **Pass:**  
@@ -5584,7 +5584,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTrackKern
+### GrSetTrackKern
 Set the GState's track kerning.
 
 **Pass:**  
@@ -5600,7 +5600,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetTransform
+### GrSetTransform
 Replace the GState's current transformation matrix with another.
 
 **Pass:**  
@@ -5623,7 +5623,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetVMFile
+### GrSetVMFile
 Sets the VM file in the associated Window or GString, if any.
 
 This routine must be called is the VM file handle stored in the Window or 
@@ -5642,7 +5642,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetWinClipPath
+### GrSetWinClipPath
 Set the GState's current path to be the document clip path for all future 
 graphics operations. This path is affected by both the window and GState's 
 transformation matrixes.
@@ -5661,7 +5661,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSetWinClipRect
+### GrSetWinClipRect
 Modify a window's clipping path by intersecting it with the specified 
 rectangle. The rectangle should be defined in the document coordinate space 
 of the passed GState; the rectangle will be transformed appropriately when 
@@ -5686,7 +5686,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSqrRootWWFixed
+### GrSqrRootWWFixed
 Calculate the square root of a 32-bit number. Numbers less than one return 
 the value one.
 
@@ -5702,7 +5702,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrSqrWWFixed
+### GrSqrWWFixed
 Calculate the square of a 32-bit number.
 
 **Pass:**  
@@ -5717,7 +5717,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTestPath
+### GrTestPath
 Checks for the existence of a path.
 
 **Pass:**  
@@ -5733,7 +5733,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTestPointInPath
+### GrTestPointInPath
 Determine if the passed point is inside the GState's current path.
 
 **Pass:**  
@@ -5750,7 +5750,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTestPointInPolygon
+### GrTestPointInPolygon
 Determine if the passed point is inside the given polygon.
 
 **Pass:**  
@@ -5770,7 +5770,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTestPointInReg
+### GrTestPointInReg
 Determine if the passed point is inside a given region. If so, return the 
 rectangle inside the region including the point.
 
@@ -5791,7 +5791,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTestRectInMask
+### GrTestRectInMask
 Determine if a given rectangle is inside the current clip region.
 
 **Pass:**  
@@ -5811,7 +5811,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTestRectInReg
+### GrTestRectInReg
 Determine if a given rectangle is inside a specified region.
 
 **Pass:**  
@@ -5833,7 +5833,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTextPosition
+### GrTextPosition
 Return the nearest offset into a text string when given a pixel position in the 
 string.
 
@@ -5856,7 +5856,7 @@ Nothing.
 **Library:** text.def
 
 ----------
-#### GrTextWidth
+### GrTextWidth
 Return the width of a text string, including kerning.
 
 **Pass:**  
@@ -5874,7 +5874,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTextWidthWBFixed
+### GrTextWidthWBFixed
 Return the width of a text string, including kerning.
 
 **Pass:**  
@@ -5892,7 +5892,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTransform
+### GrTransform
 Transform the given coordinate pair from document units to screen 
 coordinates, including the effects of the GState and window transformation 
 matrixes.
@@ -5911,7 +5911,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTransformByMatrix
+### GrTransformByMatrix
 Transform the given coordinate pair using the passed transformation matrix.
 
 **Pass:**  
@@ -5927,7 +5927,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTransformByMatrixDWord
+### GrTransformByMatrixDWord
 Transform the given coordinate pair using the passed transformation matrix. 
 Coordinates are 32-bit values rather than normal 16-bit values.
 
@@ -5946,7 +5946,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTransformDWFixed
+### GrTransformDWFixed
 Transform the given coordinate pair from document units to screen 
 coordinates, including the effects of the GState and window transformation 
 matrixes. Coordinates are in **DWFixed** format.
@@ -5965,7 +5965,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTransformDWord
+### GrTransformDWord
 Transform the given 32-bit coordinate pair from document units to screen 
 coordinates, including the effects of the GState and window transformation 
 matrixes.
@@ -5985,7 +5985,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrTransformWWFixed
+### GrTransformWWFixed
 Transform the given 32-bit fixed point coordinate pair using the passed 
 GState's transformation matrix. Coordinates are in **WWFixed** format.
 
@@ -6006,7 +6006,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrUDivWWFixed
+### GrUDivWWFixed
 Divide two 32-bit unsigned numbers.
 
 **Pass:**  
@@ -6024,7 +6024,7 @@ Nothing.
 **Library:**graphics.def
 
 ----------
-#### GrUncompactBitmap
+### GrUncompactBitmap
 Uncompact a huge bitmap (a bitmap in a HugeArray).
 
 **Pass:**  
@@ -6043,7 +6043,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrUntransform
+### GrUntransform
 Transform the given coordinate pair from screen coordinates to document 
 coordinates, including the effects of the GState and window transformation 
 matrixes.
@@ -6062,7 +6062,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrUntransformByMatrix
+### GrUntransformByMatrix
 Untransform the given coordinate pair using the passed transformation 
 matrix. This is the inverse operation of transforming the coordinates using 
 the matrix.
@@ -6080,7 +6080,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrUntransformByMatrixDWord
+### GrUntransformByMatrixDWord
 Untransform the given coordinate pair using the passed transformation 
 matrix. This is the inverse operation of transforming the coordinates using 
 the matrix.
@@ -6100,7 +6100,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrUntransformDWFixed
+### GrUntransformDWFixed
 Untransform the given coordinate pair from screen coordinates to document 
 coordinates using the GState passed.
 
@@ -6119,7 +6119,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrUntransformDWord
+### GrUntransformDWord
 Untransform the given 32-bit coordinate pair from screen coordinates to 
 document coordinates.
 
@@ -6138,7 +6138,7 @@ Nothing.
 **Library:** graphics.def
 
 ----------
-#### GrUntransformWWFixed
+### GrUntransformWWFixed
 Untransform the given 32-bit coordinate pair using the GState passed.
 
 **Pass:**  

--- a/TechDocs/Markdown/Asmref/asmh_l.md
+++ b/TechDocs/Markdown/Asmref/asmh_l.md
@@ -1,7 +1,7 @@
 ## 2.4 Routines H-L
 
 ----------
-#### HandleModifyOwner
+### HandleModifyOwner
 Modifies the owner of a block. If passed a process handle, changes the parent 
 process instead of the owner.
 
@@ -18,7 +18,7 @@ ax
 **Library:** heap.def
 
 ----------
-#### HandleP
+### HandleP
 Sets a semaphore on the passed block. This provides the caller with exclusive 
 access to the block if all other processes use the **HandleP/HandleV** 
 mechanism. The *HM_otherInfo* field of the block is used for the semaphore 
@@ -44,7 +44,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### HandleV
+### HandleV
 Releases a semaphore on the given block.
 
 **Pass:**  
@@ -59,7 +59,7 @@ Nothing. (Flags preserved.)
 **Library:** heap.def
 
 ----------
-#### HugeArrayAppend
+### HugeArrayAppend
 
 Appends element(s) to the tail end of a Huge Array. If elements are of fixed 
 size, this routine may append several elements. If elements are of variable 
@@ -84,7 +84,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayCompressBlocks
+### HugeArrayCompressBlocks
 Compress all the free space out of VM blocks containing a HugeArray data.
 
 **Pass:**  
@@ -99,7 +99,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayContract
+### HugeArrayContract
 Deletes element(s) in a Huge Array. The elements may be of fixed or variable 
 size but must already be locked down. Elements will be deleted starting at 
 the element location passed.
@@ -119,7 +119,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayCreate
+### HugeArrayCreate
 Creates a Huge Array. Allocates a VM block for the directory block, initializes 
 the directory block header and allocates enough VM blocks for any initial 
 elements.
@@ -144,7 +144,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayDelete
+### HugeArrayDelete
 Locks down a Huge Array VM block and deletes element(s) starting at the 
 passed element number.
 
@@ -164,7 +164,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayDestroy
+### HugeArrayDestroy
 Destroys a Huge Array. This routine frees all blocks in the Huge Array.
 
 **Pass:**  
@@ -180,7 +180,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayDirty
+### HugeArrayDirty
 Marks a VM block containing an element in a Huge Array dirty
 
 **Pass:**  
@@ -195,7 +195,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayEnum
+### HugeArrayEnum
 Calls a callback routine for multiple elements within a Huge Array. Pass this 
 routine the element to start at, the number of elements to call the routine on, 
 and the address of the callback routine. The Index number of elements is a 
@@ -243,7 +243,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayExpand
+### HugeArrayExpand
 Insert element(s) into a locked Huge Array. Elements are inserted starting at 
 the passed element position.
 
@@ -269,7 +269,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayGetCount
+### HugeArrayGetCount
 Retrieves the number of element(s) in a Huge Array.
 
 **Pass:**  
@@ -285,7 +285,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayInsert
+### HugeArrayInsert
 Locks down and insert element(s) into a HugeArray.
 
 **Pass:**  
@@ -309,7 +309,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayLock
+### HugeArrayLock
 Locks down a HugeArray element. To unlock a locked HugeArray element, 
 use **HugeArrayUnlock**.
 
@@ -332,7 +332,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayLockDir
+### HugeArrayLockDir
 Locks a HugeArray directory block.
 
 **Pass:**  
@@ -348,7 +348,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayNext
+### HugeArrayNext
 Locks and points to the next HugeArray element. 
 
 **Pass:**  
@@ -368,7 +368,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayPrev
+### HugeArrayPrev
 Locks and points to the previous Huge Array element.
 
 **Pass:**  
@@ -389,7 +389,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayReplace
+### HugeArrayReplace
 Replace element(s) in a Huge Array.
 
 **Pass:**  
@@ -413,7 +413,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayResize
+### HugeArrayResize
 Resizes an array element. If the element is resized to a smaller size then data 
 at the end of the element is truncated (and lost). If it gets larger, the new data 
 is initialized to zero.
@@ -433,7 +433,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayUnlock
+### HugeArrayUnlock
 Unlocks a previously locked Huge Array element. 
 
 **Pass:**  
@@ -448,7 +448,7 @@ Nothing. (Flags preserved.)
 **Library:** hugearr.def
 
 ----------
-#### HugeArrayUnlockDir
+### HugeArrayUnlockDir
 Unlocks a previously locked block containing the **HugeArrayDirectory**.
 
 **Pass:**  
@@ -463,7 +463,7 @@ Nothing.
 **Library:** hugearr.def
 
 ----------
-#### IACPConnect
+### IACPConnect
 Establish a connection with one or all of the servers on a particular list.
 
 **Pass:**  
@@ -487,7 +487,7 @@ bx, dx.
 **Library:** iacp.def
 
 ----------
-#### IACPCreateDefaultLaunchBlock
+### IACPCreateDefaultLaunchBlock
 Utility routine to create an AppLaunchBlock to be given to IACPConnect. 
 The block is initialized with the following defaults:
 
@@ -513,7 +513,7 @@ Nothing.
 **Library:** iacp.def
 
 ----------
-#### IACPFinishConnect
+### IACPFinishConnect
 Complete the process of connecting. Called by the server when it's ready to 
 accept messages from the client.
 
@@ -530,7 +530,7 @@ Nothing
 **Library:** iacp.def
 
 ----------
-#### IACPGetDocumentID
+### IACPGetDocumentID
 Figure the 48-bit ID for a data file, dealing with links.
 
 **Pass:**  
@@ -549,7 +549,7 @@ Nothing.
 **Library:** iacp.def
 
 ----------
-#### IACPGetServerNumber
+### IACPGetServerNumber
 Returns the number a server object is for a particular IACP connection, so 
 the client can use the number to direct a message to a particular server.
 
@@ -567,7 +567,7 @@ Nothing.
 **Library:** iacp.def
 
 ----------
-#### IACPLostConnection
+### IACPLostConnection
 Utility routine for server objects to handle 
 MSG_META_IACP_LOST_CONNECTION
 
@@ -584,7 +584,7 @@ ax, cx, dx, bp, bx, di.
 **Library:** iacp.def
 
 ----------
-#### IACPProcessMessage
+### IACPProcessMessage
 Utility routine to handle a MSG_META_IACP_PROCESS_MESSAGE. Can 
 be bound as the method for this message for any class that might receive it.
 
@@ -605,7 +605,7 @@ ax, bx, cx, dx, bp, si, di
 **Library:** iacp.def
 
 ----------
-#### IACPRegisterDocument
+### IACPRegisterDocument
 Register a document as being open, specifying the server to which to connect 
 to communicate about the document.
 
@@ -623,7 +623,7 @@ Nothing
 **Library:** iacp.def
 
 ----------
-#### IACPRegisterServer
+### IACPRegisterServer
 Register an object as a server for a particular list. Can also be used to change 
 the mode in which the server is registered.
 
@@ -642,7 +642,7 @@ Nothing.
 **Library:** iacp.def
 
 ----------
-#### IACPSendMessage
+### IACPSendMessage
 Send a message through an IACP connection to all connected servers, or to 
 the client, depending on which side is doing the sending.
 
@@ -663,7 +663,7 @@ bx, cx, dx, both recorded messages.
 **Library:** iacp.def
 
 ----------
-#### IACPSendMessageToServer
+### IACPSendMessageToServer
 Send a message through an IACP connection to a specific connected server.
 
 **Pass:**  
@@ -683,7 +683,7 @@ bx, cx, dx, both recorded messages.
 **Library:** iacp.def
 
 ----------
-#### IACPShutdown
+### IACPShutdown
 Sever an IACP connection. MSG_META_IACP_LOST_CONNECTION is sent to 
 the other side of the connection.
 
@@ -700,7 +700,7 @@ ax.
 **Library:** iacp.def
 
 ----------
-#### IACPShutdownAll
+### IACPShutdownAll
 Shutdown all connections open to or from an object.
 
 **Pass:**  
@@ -716,7 +716,7 @@ ax
 **Library:** iacp.def
 
 ----------
-#### IACPShutdownConnection
+### IACPShutdownConnection
 Utility routine to handle MSG_META_IACP_SHUTDOWN_CONNECTION, as 
 generated by a call to **IACPLostConnection**.
 
@@ -733,7 +733,7 @@ ax, cx, dx, bp.
 **Library:** iacp.def
 
 ----------
-#### IACPUnregisterDocument
+### IACPUnregisterDocument
 Indicate a document is closed. New-connection messages may still be queued 
 based on the document having been registered, so the caller will need to 
 handle those gracefully.
@@ -752,7 +752,7 @@ Nothing.
 **Library:** iacp.def
 
 ----------
-#### IACPUnregisterServer
+### IACPUnregisterServer
 Unregister an object as a server for a particular list.
 
 **Pass:**  
@@ -768,7 +768,7 @@ Nothing.
 **Library:** iacp.def
 
 ----------
-#### ImpexCreateTempFile
+### ImpexCreateTempFile
 Creates and opens a unique Metafile in the waste directory.
 
 **Pass:**  
@@ -787,7 +787,7 @@ Nothing.
 **Library:** impex.def
 
 ----------
-#### ImpexDeleteTempFile
+### ImpexDeleteTempFile
 Closes and deletes a metafile in the waste directory.
 
 **Pass:**  
@@ -805,7 +805,7 @@ Nothing.
 **Library:** impex.def
 
 ----------
-#### ImpexExportToMetafile
+### ImpexExportToMetafile
 Converts a transfer format into a metafile.
 
 **Pass:**  
@@ -827,7 +827,7 @@ Nothing.
 **Library:** impex.def
 
 ----------
-#### ImpexImportExportCompleted
+### ImpexImportExportCompleted
 Sends a message back to the Import/ExportControl object stating that the 
 application has completed it's import or export operation.
 
@@ -843,7 +843,7 @@ Nothing.
 **Library:** impex.def
 
 ----------
-#### ImpexImportFromMetafile
+### ImpexImportFromMetafile
 Converts a metafile into a transfer format.
 
 **Pass:**  
@@ -865,7 +865,7 @@ Nothing.
 **Library:** impex.def
 
 ----------
-#### ImpexUpdateImportExportStatus
+### ImpexUpdateImportExportStatus
 Apprise the user of the status of an import or export. This routine should only 
 be called by translation libraries, and can be called at any time during the 
 import/export process. If a translation library chooses not to call this 
@@ -887,7 +887,7 @@ Nothing.
 **Library:**    impex.def
 
 ----------
-#### InitFileDeleteCategory
+### InitFileDeleteCategory
 Deletes an entire category (and therefore all its associated keys) from the 
 GEOS.INI file.
 
@@ -904,7 +904,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileDeleteEntry
+### InitFileDeleteEntry
 Deletes a "key" entry from the GEOS.INI file. Only matching keys within the 
 passed category will be deleted. Keys in other categories are unaffected.
 
@@ -923,7 +923,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileDeleteStringSection
+### InitFileDeleteStringSection
 Deletes the specific string "blob" starting at the zero-based string number. 
 "Blobs" are usually set off from each other in the GEOS.INI file with CR or LF 
 characters.
@@ -944,7 +944,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileEnumStringSection
+### InitFileEnumStringSection
 Calls the passed function on each matching string section within the 
 GEOS.INI file.
 
@@ -982,7 +982,7 @@ ax, cx, dx, di, si, bp, es
 **Library:** initfile.def
 
 ----------
-#### InitFileGetTimeLastModified
+### InitFileGetTimeLastModified
 Returns the time (from system counter) when the GEOS.INI file was last 
 written to.
 
@@ -999,7 +999,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileGrab
+### InitFileGrab
 Grab exclusive access on the initfile routines, and use the passed buffer as a 
 temporary init file.
 
@@ -1019,7 +1019,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileReadBoolean
+### InitFileReadBoolean
 Returns the Boolean value specified in the given category and key of the 
 GEOS.INI file.
 
@@ -1040,7 +1040,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileReadData
+### InitFileReadData
 Locates the contents of the given category and key of the GEOS.INI file and 
 returns a pointer to the associated data.
 
@@ -1068,7 +1068,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileReadInteger
+### InitFileReadInteger
 Returns the integer value specified in the given category and key of the 
 GEOS.INI file.
 
@@ -1088,7 +1088,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileReadString
+### InitFileReadString
 Locates the contents of the given category and key of the GEOS.INI file and 
 returns a pointer to the associated string.
 
@@ -1116,7 +1116,7 @@ bx (if not returned).
 **Library:** initfile.def
 
 ----------
-#### InitFileReadStringSection
+### InitFileReadStringSection
 Locates the contents of the given category and key of the GEOS.INI file, copies 
 a specified section of the string, and returns a pointer to the copied string 
 section.
@@ -1147,7 +1147,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileRevert
+### InitFileRevert
 Restores the GEOS.INI to its backed-up previous state.
 
 **Pass:**  
@@ -1162,7 +1162,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileSave
+### InitFileSave
 Saves the GEOS.INI file.
 
 **Pass:**  
@@ -1177,7 +1177,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileWriteBoolean
+### InitFileWriteBoolean
 Writes out a Boolean value to the GEOS.INI file.
 
 **Pass:**  
@@ -1196,7 +1196,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileWriteData
+### InitFileWriteData
 Writes out a string of data (which may represent a null-terminated text 
 string, a Boolean value, or an integer value) to the GEOS.INI file. You may 
 instead use **InitFileWriteString**, **InitFileWriteInteger**, or 
@@ -1219,7 +1219,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileWriteInteger
+### InitFileWriteInteger
 Writes out an integer to the GEOS.INI file.
 
 **Pass:**  
@@ -1238,7 +1238,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileWriteString
+### InitFileWriteString
 Writes out a string to the GEOS.INI file.
 
 **Pass:**  
@@ -1258,7 +1258,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InitFileWriteStringSection
+### InitFileWriteStringSection
 Appends a string onto the end of a pre-existing GEOS.INI entry.
 
 **Pass:**  
@@ -1278,7 +1278,7 @@ Nothing.
 **Library:** initfile.def
 
 ----------
-#### InkCompress
+### InkCompress
 Compress ink data from a VisInk object.
 
 **Pass:**  
@@ -1301,7 +1301,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkDBGetDisplayInfo
+### InkDBGetDisplayInfo
 Returns the current folder handle, note ID if any is selected and the page 
 number within the note.
 
@@ -1319,7 +1319,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkDBGetHeadFolder
+### InkDBGetHeadFolder
 Returns the head (root) folder for the associated Ink DB file.
 
 **Pass:**  
@@ -1334,7 +1334,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkDBInit
+### InkDBInit
 Creates and initializes a new DB file for use by the Ink object. This routine 
 must be called before calling any other Ink Database functions.
 
@@ -1350,7 +1350,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkDBSetDisplayInfo
+### InkDBSetDisplayInfo
 
 Displays the contents of the passed Folder, Note, and Page display 
 information, if applicable.
@@ -1370,7 +1370,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkDecompress
+### InkDecompress
 Uncompresses compressed ink data so that it may be loaded to a VisInk 
 object.
 
@@ -1387,7 +1387,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderCreateSubFolder
+### InkFolderCreateSubFolder
 Creates a new folder as a child of the passed folder.
 
 **Pass:**  
@@ -1403,7 +1403,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderDelete
+### InkFolderDelete
 Deletes a folder. If the folder contains children, it recursively deletes all 
 children.
 
@@ -1420,7 +1420,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderDepthFirstTraverse
+### InkFolderDepthFirstTraverse
 Performs a depth-first traversal of the folder tree, calling the passed routine 
 with all encountered folders.
 
@@ -1439,7 +1439,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderDisplayChildInList
+### InkFolderDisplayChildInList
 Displays a note or folder's name in a GenDynamicList. This routine builds 
 and sends a moniker to the passed list.
 
@@ -1460,7 +1460,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderGetChildInfo
+### InkFolderGetChildInfo
 Returns information on a folder's child, specifying whether the child is a 
 folder or a note along with the child's ID number.
 
@@ -1479,7 +1479,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderGetChildNumber
+### InkFolderGetChildNumber
 Returns the child's number given its folder or note ID.
 
 **Pass:**  
@@ -1496,7 +1496,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderGetContents
+### InkFolderGetContents
 Returns a chunk array containing all of the folder's subfolders and a chunk 
 array containing all the folder's child notes.
 
@@ -1514,7 +1514,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderGetNumChildren
+### InkFolderGetNumChildren
 Returns the number of children within the passed folder.
 
 **Pass:**  
@@ -1531,7 +1531,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderMove
+### InkFolderMove
 Moves a folder, attaching it below the passed parent folder.
 
 **Pass:**  
@@ -1548,7 +1548,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderSetTitle
+### InkFolderSetTitle
 Sets the title of a folder to use the passed text string.
 
 **Pass:**  
@@ -1565,7 +1565,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkFolderSetTitleFromTextObject
+### InkFolderSetTitleFromTextObject
 Sets the title of a folder from the entire text within the passed text object.
 
 **Pass:**  
@@ -1582,7 +1582,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkGetDocCustomGString
+### InkGetDocCustomGString
 Retrieves the custom GString field from the **InkDataFileMap** structure 
 
 **Pass:**  
@@ -1597,7 +1597,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkGetDocGString
+### InkGetDocGString
 Retrieves the background picture (in the form of a GString) of the Ink object. 
 If this function returns a token indicating that the Ink object is using a 
 custom GString, use **InkGetDocCustomGString**.
@@ -1614,7 +1614,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkGetDocPageInfo
+### InkGetDocPageInfo
 Retrieves the current page information for the Ink database.
 
 **Pass:**  
@@ -1630,7 +1630,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkGetParentFolder
+### InkGetParentFolder
 Returns the parent folder of the passed folder or note.
 
 **Pass:**  
@@ -1646,7 +1646,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkGetTitle
+### InkGetTitle
 Returns the title of the passed folder or note.
 
 **Pass:**  
@@ -1664,7 +1664,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteCopyMoniker
+### InkNoteCopyMoniker
 Copies the icon and note name into a visMoniker structure. (May also be used 
 to copy a folder's name into a visMoniker.)
 
@@ -1683,7 +1683,7 @@ ax, bx, cx, dx, si, di
 **Library:** pen.def
 
 ----------
-#### InkNoteCreate
+### InkNoteCreate
 Creates a note below the passed folder.
 
 **Pass:**  
@@ -1699,7 +1699,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteCreatePage
+### InkNoteCreatePage
 Creates a new page within a note.
 
 **Pass:**  
@@ -1716,7 +1716,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteDelete
+### InkNoteDelete
 Deletes the note and all references to it.
 
 **Pass:**  
@@ -1732,7 +1732,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteFindByKeywords
+### InkNoteFindByKeywords
 Retrieves a note by its associated keywords. Returns the first 20,000 or so 
 notes that match the given keywords.
 
@@ -1756,7 +1756,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteFindByTitle
+### InkNoteFindByTitle
 Retrieves a note by its associated title. Returns the first 20,000 or so notes 
 that match the given title.
 
@@ -1780,7 +1780,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteGetCreationDate
+### InkNoteGetCreationDate
 Returns the creation date of the passed note.
 
 **Pass:**  
@@ -1798,7 +1798,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteGetKeywords
+### InkNoteGetKeywords
 Copies the keyword string used by the passed note into the passed 
 destination address.
 
@@ -1816,7 +1816,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteGetModificationDate
+### InkNoteGetModificationDate
 Returns the date the passed note was last modified.
 
 **Pass:**  
@@ -1834,7 +1834,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteGetNoteType
+### InkNoteGetNoteType
 Returns the note type (ink or text) in use by the passed note.
 
 **Pass:**  
@@ -1850,7 +1850,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteGetNumPages
+### InkNoteGetNumPages
 Returns the number of pages associated with the passed note.
 
 **Pass:**  
@@ -1866,7 +1866,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteGetPages
+### InkNoteGetPages
 Returns the DB item in which the note's information is stored. This DB item 
 contains a chunk array of pages.
 
@@ -1883,7 +1883,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteLoadPage
+### InkNoteLoadPage
 Loads an ink or text object from a page of a note.
 
 **Pass:**  
@@ -1902,7 +1902,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteMove
+### InkNoteMove
 Moves a note from one folder to another.
 
 **Pass:**  
@@ -1919,7 +1919,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSavePage
+### InkNoteSavePage
 Saves an ink or text object from the page of a note to the instance data of that 
 object.
 
@@ -1939,7 +1939,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSendKeywordsToTextObject
+### InkNoteSendKeywordsToTextObject
 Replaces a text object's text with the passed note's keywords.
 
 **Pass:**  
@@ -1956,7 +1956,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSetKeywords
+### InkNoteSetKeywords
 Sets the keywords of the passed note using the passed text string.
 
 **Pass:**  
@@ -1973,7 +1973,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSetKeywordsFromTextObject
+### InkNoteSetKeywordsFromTextObject
 Sets the keywords of the passed note using the text within a text object.
 
 **Pass:**  
@@ -1990,7 +1990,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSetModificationDate
+### InkNoteSetModificationDate
 Sets the modification date of the passed note. This allows you to update the 
 note when writing changes.
 
@@ -2008,7 +2008,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSetNoteType
+### InkNoteSetNoteType
 Sets the note type (ink or text) in use by the passed note.
 
 **Pass:**  
@@ -2025,7 +2025,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSetTitle
+### InkNoteSetTitle
 Sets the title in use by the passed note to the passed text string.
 
 **Pass:**  
@@ -2042,7 +2042,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkNoteSetTitleFromTextObject
+### InkNoteSetTitleFromTextObject
 Sets the title in use by the passed note to the text within a text object.
 
 **Pass:**  
@@ -2059,7 +2059,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkSendTitleToTextObject
+### InkSendTitleToTextObject
 Sets the text within a text object to the text within the passed note or folder's 
 title.
 
@@ -2077,7 +2077,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkSetDocCustomGString
+### InkSetDocCustomGString
 Sets the custom GString field (*IDFM_customGstring*) in an Ink object's 
 **InkDataFileMap** field.
 
@@ -2094,7 +2094,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkSetDocGString
+### InkSetDocGString
 Sets the GString field (*IDFM_gstring*) in an Ink object's **InkDataFileMap** 
 field.
 
@@ -2111,7 +2111,7 @@ Nothing.
 **Library:** pen.def
 
 ----------
-#### InkSetDocPageInfo
+### InkSetDocPageInfo
 Sets the current page information in use by Ink database.
 
 **Pass:**  
@@ -2127,7 +2127,7 @@ Nothing.
 **Library:**    pen.def
 
 ----------
-#### LMemAlloc
+### LMemAlloc
 Allocates space (a new chunk) on the local-memory heap. This routine may 
 resize the LMem block, moving it on the heap, and invalidating stored 
 segment pointers to it.
@@ -2150,7 +2150,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### LMemContract
+### LMemContract
 Compacts a local memory block. The local memory manager routines 
 ordinarily take care of heap compaction. This routine compacts the heap 
 manually and frees the unused heap space. The block is guaranteed to 
@@ -2168,7 +2168,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### LMemDeleteAt
+### LMemDeleteAt
 Deletes space from within the middle of a chunk on the local memory heap. 
 
 **Pass:**  
@@ -2186,7 +2186,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### LMemFree
+### LMemFree
 Frees the space occupied by a local-memory chunk. This routine does not 
 resize the block or shuffle any other chunks.
 
@@ -2203,7 +2203,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### LMemInitHeap
+### LMemInitHeap
 Creates and initializes a local-memory heap block. This routine may resize 
 the LMem block, moving it on the heap, and invalidating stored segment 
 pointers to it. Where possible, you should try to use the higher-level routines: 
@@ -2229,7 +2229,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### LMemInsertAt
+### LMemInsertAt
 Inserts space within the middle of a chunk on the local memory heap. The 
 new space is initialized to zeroes.
 
@@ -2249,7 +2249,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### LMemReAlloc
+### LMemReAlloc
 Changes the size of a chunk in a local memory heap.
 
 **Pass:**  
@@ -2271,7 +2271,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### LocalAsciiToFixed
+### LocalAsciiToFixed
 This routine converts the ASCII expression of a number to a **WWFixed** 
 number.
 
@@ -2290,7 +2290,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCalcDaysInMonth
+### LocalCalcDaysInMonth
 Return the number of days in the passed month/year.
 
 **Pass:**  
@@ -2306,7 +2306,7 @@ Nothing
 **Library:** localize.def
 
 ----------
-#### LocalCmpChars
+### LocalCmpChars
 This routine does a lexical comparison of two characters, determining which 
 comes first in alphabetic order. 
 
@@ -2335,7 +2335,7 @@ Nothing.
 cannot compare them a character at a time.
 
 ----------
-#### LocalCmpCharsNoCase
+### LocalCmpCharsNoCase
 This routine does a lexical comparison of two characters, determining which 
 comes first in alphabetic order. It will ignore case.
 
@@ -2363,7 +2363,7 @@ LocalCmpStrings. DBCS support requires special parsing of strings-you
 cannot compare them a character at a time.
 
 ----------
-#### LocalCmpStrings
+### LocalCmpStrings
 This routine does a lexical comparison of two text strings, determining which 
 comes sooner in alphabetic order.
 
@@ -2389,7 +2389,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCmpStringsDosToGeos
+### LocalCmpStringsDosToGeos
 Compares strings as does **LocalCmpStrings**, above, but one or both of the 
 strings may be Dos text.
 
@@ -2419,7 +2419,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCmpStringsNoCase
+### LocalCmpStringsNoCase
 Compares strings as does **LocalCmpStrings**, except that case is ignored.
 
 **Pass:**  
@@ -2444,7 +2444,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCmpStringsNoSpace
+### LocalCmpStringsNoSpace
 Compares two text strings as does **LocalCmpStrings**, except that spaces 
 are ignored.
 
@@ -2470,7 +2470,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCmpStringsNoSpaceCase
+### LocalCmpStringsNoSpaceCase
 Compares two text strings as does **LocalCmpStrings**, except that spaces 
 and case are ignored.
 
@@ -2496,7 +2496,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCodePageToGeos
+### LocalCodePageToGeos
 Converts Dos text to GEOS text. The Dos text may use any code page.
 
 **Pass:**  
@@ -2517,7 +2517,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCodePageToGeosChar
+### LocalCodePageToGeosChar
 Convert a single Dos character to GEOS text. The character may be in any 
 Dos code page.
 
@@ -2536,7 +2536,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCustomFormatDateTime
+### LocalCustomFormatDateTime
 
 Format a date or time. If you call this directly then you will not be language 
 independent. This routine is intended to be used by applications who do not 
@@ -2568,7 +2568,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalCustomParseDateTime
+### LocalCustomParseDateTime
 
 Parse a text string using a specific format string.
 
@@ -2597,7 +2597,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalDistanceFromAscii
+### LocalDistanceFromAscii
 This routine extracts a distance value from an ASCII text string.
 
 **Pass:**  
@@ -2614,7 +2614,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalDistanceToAscii
+### LocalDistanceToAscii
 Construct an ASCII string from a distance value.
 
 **Pass:**  
@@ -2634,7 +2634,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalDosToGeos
+### LocalDosToGeos
 This routine converts a Dos text string to GEOS text format.
 
 **Pass:**  
@@ -2654,7 +2654,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalDosToGeosChar
+### LocalDosToGeosChar
 This routine converts a single Dos character to a GEOS character.
 
 **Pass:**  
@@ -2671,7 +2671,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalDowncaseChar
+### LocalDowncaseChar
 This routine returns the lowercase equivalent of any character (if the 
 character has no lower-case equivalent, the character will be returned 
 untouched).
@@ -2688,7 +2688,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalDowncaseString
+### LocalDowncaseString
 This routine converts a string to all lower case.
 
 **Pass:**  
@@ -2705,7 +2705,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalFixedToAscii
+### LocalFixedToAscii
 This routine converts a **WWFixed** number to its ASCII string equivalent.
 
 **Pass:**  
@@ -2722,7 +2722,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalFormatDateTime
+### LocalFormatDateTime
 This routine takes a date or time and a enumerated type describing how that 
 time should be formatted and returns a text string containing the time/date 
 information formatted nicely.
@@ -2749,7 +2749,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalFormatFileDateTime
+### LocalFormatFileDateTime
 Like **LocalFormatDateTime**, except it works off a **FileDate** and a **FileTime** 
 record
 
@@ -2769,7 +2769,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGeosToCodePage
+### LocalGeosToCodePage
 Convert GEOS text string to Dos text using an arbitrary code page.
 
 **Pass:**  
@@ -2790,7 +2790,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGeosToCodePageChar
+### LocalGeosToCodePageChar
 Convert one character of GEOS text to Dos text using an arbitrary code page.
 
 **Pass:**  
@@ -2808,7 +2808,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGeosToDos
+### LocalGeosToDos
 Concert a string of GEOS text to its Dos equivalent.
 
 **Pass:**  
@@ -2828,7 +2828,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGeosToDosChar
+### LocalGeosToDosChar
 Convert one character of GEOS text to its Dos text equivalent.
 
 **Pass:**  
@@ -2846,7 +2846,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGetCodePage
+### LocalGetCodePage
 This routine returns the value of the current code page.
 
 **Pass:**  
@@ -2861,7 +2861,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGetCurrencyFormat
+### LocalGetCurrencyFormat
 This routine returns the information necessary to format currency text 
 strings in the way preferred by the user.
 
@@ -2882,7 +2882,7 @@ Nothing.
 **Library:**    localize.def
 
 ----------
-#### LocalGetDateTimeFormat
+### LocalGetDateTimeFormat
 Returns the text string associated with a **TimeDateFormat**.
 
 **Pass:**  
@@ -2899,7 +2899,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGetNumericFormat
+### LocalGetNumericFormat
 This routine returns the information necessary to format currency text 
 strings in the way preferred by the user.
 
@@ -2920,7 +2920,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalGetQuotes
+### LocalGetQuotes
 This routine returns the localized symbols to use as single or double quotes.
 
 **Pass:**  
@@ -2938,7 +2938,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalIsAlpha
+### LocalIsAlpha
 This routine detects alphabetic characters.
 
 **Pass:**  
@@ -2950,7 +2950,7 @@ ZF - Clear if character is alphabetic.
 **Library:** localize.def
 
 ----------
-#### LocalIsAlphaNumeric
+### LocalIsAlphaNumeric
 This routine detects alphabetic and numeric characters.
 
 **Pass:**  
@@ -2962,7 +2962,7 @@ ZF - Clear if character is alphanumeric.
 **Library:** localize.def
 
 ----------
-#### LocalIsCodePageSupported
+### LocalIsCodePageSupported
 Checks to see if the passed code page is a supported one.
 
 **Pass:**  
@@ -2977,7 +2977,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalIsControl
+### LocalIsControl
 This routine detects control characters.
 
 **Pass:**  
@@ -2989,7 +2989,7 @@ ZF - Clear if character is a control character.
 **Library:** localize.def
 
 ----------
-#### LocalIsDateChar
+### LocalIsDateChar
 This routine detects date characters.
 
 **Pass:**  
@@ -3002,7 +3002,7 @@ associated with DTF_SHORT.
 **Library:** localize.def
 
 ----------
-#### LocalIsDigit
+### LocalIsDigit
 This routine detects numeric characters.
 
 **Pass:**  
@@ -3014,7 +3014,7 @@ ZF - Clear if character is numeric.
 **Library:** localize.def
 
 ----------
-#### LocalIsDosChar
+### LocalIsDosChar
 This routine detects characters which are members of the Dos character set.
 
 **Pass:**  
@@ -3026,7 +3026,7 @@ ZF - Clear if character is in the Dos character set.
 **Library:** localize.def
 
 ----------
-#### LocalIsGraphic
+### LocalIsGraphic
 This routine detects characters that require some sort of drawing. Control 
 characters are not graphic; neither are line-feeds or spaces. Letters, 
 numbers, and punctuation marks are all good examples of graphic symbols.
@@ -3040,7 +3040,7 @@ ZF - Clear if character is graphic.
 **Library:** localize.def
 
 ----------
-#### LocalIsHexDigit
+### LocalIsHexDigit
 This routine detects numeric characters, including those letters necessary for 
 expressing hexadecimal numbers.
 
@@ -3053,7 +3053,7 @@ ZF - Clear if character is a hexidecimal digit.
 **Library:** localize.def
 
 ----------
-#### LocalIsLower
+### LocalIsLower
 This routine detects lower-case alphabetic characters.
 
 **Pass:**  
@@ -3065,7 +3065,7 @@ ZF - Clear if character is lower-case.
 **Library:** localize.def
 
 ----------
-#### LocalIsNumChar
+### LocalIsNumChar
 This routine detects numeric characters, including the decimal separator.
 
 **Pass:**  
@@ -3077,7 +3077,7 @@ ZF - Clear if character is part of the number format.
 **Library:** localize.def
 
 ----------
-#### LocalIsPrintable
+### LocalIsPrintable
 This routine detects printable characters (this includes all graphic 
 characters and the space character).
 
@@ -3090,7 +3090,7 @@ ZF - Clear if character is printable.
 **Library:** localize.def
 
 ----------
-#### LocalIsPunctuation
+### LocalIsPunctuation
 This routine detects punctuation marks.
 
 **Pass:**  
@@ -3102,7 +3102,7 @@ ZF - Clear if character is a punctuation mark.
 **Library:** localize.def
 
 ----------
-#### LocalIsSpace
+### LocalIsSpace
 This routine detects white-space.
 
 **Pass:**  
@@ -3114,7 +3114,7 @@ ZF - Clear if character is a space.
 **Library:** localize.def
 
 ----------
-#### LocalIsSymbol
+### LocalIsSymbol
 This routine detects symbol characters.
 
 **Pass:**  
@@ -3126,7 +3126,7 @@ ZF - Clear if character is a symbol.
 **Library:** localize.def
 
 ----------
-#### LocalIsTimeChar
+### LocalIsTimeChar
 This routine detects characters which are digits or part of the format string 
 associated with DTF_HMS.
 
@@ -3139,7 +3139,7 @@ ZF - Clear if character is part of a time string.
 **Library:** localize.def
 
 ----------
-#### LocalIsUpper
+### LocalIsUpper
 This routine detects upper-case alphabetic characters.
 
 **Pass:**  
@@ -3151,7 +3151,7 @@ ZF - Clear if character is upper-case.
 **Library:** localize.def
 
 ----------
-#### LocalLexicalValue
+### LocalLexicalValue
 This routine returns the lexical value of a character, useful when sorting 
 things into alphabetical order. Note that knowing the lexical value of just one 
 character is not much use - lexical values are only meaningful when 
@@ -3169,7 +3169,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalLexicalValueNoCase
+### LocalLexicalValueNoCase
 This routine returns the case-insensitive lexical value of a character, useful 
 when sorting things into alphabetical order. Note that knowing the 
 case-insensitive lexical value of just one character is not much use-lexical 
@@ -3187,7 +3187,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalParseDateTime
+### LocalParseDateTime
 This routine parses a text string and extracts time or date information from 
 it. Any field for which there is not data specified in the format string is 
 returned containing -1.
@@ -3215,7 +3215,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalSetCurrencyFormat
+### LocalSetCurrencyFormat
 This routine sets the currency format information. All items will be added to 
 the .INI file.
 
@@ -3233,7 +3233,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalSetDateTimeFormat
+### LocalSetDateTimeFormat
 Sets the localization date/time format in use by a **DateTimeFormatString**. 
 
 **Pass:**  
@@ -3249,7 +3249,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalSetMeasurementType
+### LocalSetMeasurementType
 This routine sets the measurement type. The correct value will be written to 
 the .INI file.
 
@@ -3265,7 +3265,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalSetNumericFormat
+### LocalSetNumericFormat
 This routine sets the fields used when formatting number strings. The 
 correct values will be written to the .INI file.
 
@@ -3285,7 +3285,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalSetQuotes
+### LocalSetQuotes
 This routine sets the localized single and double quotes.
 
 **Pass:**  
@@ -3303,7 +3303,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalStringLength
+### LocalStringLength
 This routine computes the number of characters in a null-terminated text 
 string. This routine allows for double byte character support.
 
@@ -3319,7 +3319,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalStringSize
+### LocalStringSize
 This routine determines the number of bytes used to store a null-terminated 
 text string.
 
@@ -3335,7 +3335,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalUpcaseChar
+### LocalUpcaseChar
 This routine returns a character's upper-case equivalent.
 
 **Pass:**  
@@ -3350,7 +3350,7 @@ Nothing.
 **Library:** localize.def
 
 ----------
-#### LocalUpcaseString
+### LocalUpcaseString
 This routine returns the all-caps equivalent of a text string.
 
 **Pass:**  

--- a/TechDocs/Markdown/Asmref/asmm_q.md
+++ b/TechDocs/Markdown/Asmref/asmm_q.md
@@ -1,7 +1,7 @@
 ## 2.5 Routines M-Q
 
 ----------
-#### MemAlloc
+### MemAlloc
 Creates a block and assigns a handle to it. This block can be discardable, 
 swapable, fixed or movable. A passed flag determines whether heap 
 compaction or discarding of objects should be used to generate free space.
@@ -22,7 +22,7 @@ cx
 **Library:** heap.def
 
 ----------
-#### MemAllocLMem
+### MemAllocLMem
 Allocates a block within a local memory heap from scratch. To take an 
 existing block and create a local memory heap built on it, use 
 **LMemInitHeap**.
@@ -41,7 +41,7 @@ Nothing.
 **Library:** lmem.def
 
 ----------
-#### MemAllocSetOwner
+### MemAllocSetOwner
 Creates a block, assigns a handle to it, and explicitly sets the owner of the 
 new block by passing the handle of the owning geode. Otherwise, it is 
 identical to **MemAlloc**.
@@ -63,7 +63,7 @@ cx
 **Library:** heap.def
 
 ----------
-#### MemDecRefCount
+### MemDecRefCount
 Decrements a reference count in a memory handle and immediately frees it 
 when the count reaches zero.
 
@@ -81,7 +81,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemDerefDS
+### MemDerefDS
 Returns the address of the block referenced by its block handle into the DS 
 register. The block must be locked before calling this routine. This routine is 
 useful in allocating a fixed or locked block.
@@ -98,7 +98,7 @@ Nothing. Flags preserved.
 **Library:** heap.def
 
 ----------
-#### MemDerefES
+### MemDerefES
 Returns the address of a block referenced by its block handle into the ES 
 register. the block must be locked before calling this routine.
 
@@ -114,7 +114,7 @@ Nothing. Flags preserved.
 **Library:** heap.def
 
 ----------
-#### MemDiscard
+### MemDiscard
 Throws away the contents of a discardable memory block.
 
 **Pass:**  
@@ -131,7 +131,7 @@ bx
 **Library:** heap.def
 
 ----------
-#### MemDowngradeExclLock
+### MemDowngradeExclLock
 Downgrades an exclusive lock to a shared lock, waking any shared lockers 
 blocked on the block.
 
@@ -147,7 +147,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemFree
+### MemFree
 Frees a memory block. The block may be locked at the time it is freed. 
 Therefore, make sure that no other thread has locked the block before freeing 
 it.
@@ -164,7 +164,7 @@ bx
 **Library:** heap.def
 
 ----------
-#### MemGetInfo
+### MemGetInfo
 Returns information about a memory block. Pass this routine the proper 
 **MemGetInfoType**. The return values depend on what information you 
 request.
@@ -195,7 +195,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemIncRefCount
+### MemIncRefCount
 Increments a reference count on a memory handle.
 
 **Pass:**  
@@ -210,7 +210,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemInitRefCount
+### MemInitRefCount
 Initializes a reference count for a memory handle.
 
 **Pass:**  
@@ -226,7 +226,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemLock
+### MemLock
 Locks the given block, returning the absolute address of the block of memory 
 pointed to by the given handle. Increments the lock count by one. Locked 
 memory blocks cannot be moved or discarded (though they may be freed). You 
@@ -245,7 +245,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemLockExcl
+### MemLockExcl
 
 Locks a memory block for exclusive read/write access. If no one has locked the 
 block, the thread will gain exclusive access; otherwise, the thread will block 
@@ -264,7 +264,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemLockFixedOrMovable
+### MemLockFixedOrMovable
 Given a virtual segment, locks the corresponding block down if the segment 
 is movable.
 
@@ -282,7 +282,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemLockShared
+### MemLockShared
 Locks a block down for shared (usually read-only) access.
 
 **Pass:**  
@@ -297,7 +297,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemModifyFlags
+### MemModifyFlags
 Modify the *HM_flags* associated with a memory block. The following bits may 
 be altered: HF_SHARABLE, HF_DISCARDABLE, HF_SWAPABLE, and 
 HF_LMEM.
@@ -316,7 +316,7 @@ ax
 **Library:** heap.def
 
 ----------
-#### MemModifyOtherInfo
+### MemModifyOtherInfo
 Modifies the *HM_otherInfo* field associated with a memory block.
 
 **Pass:**  
@@ -332,7 +332,7 @@ ax
 **Library:** heap.def
 
 ----------
-#### MemOwner
+### MemOwner
 Returns the owner field of a handle.
 
 **Pass:**  
@@ -348,7 +348,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemPLock
+### MemPLock
 Calls **HandleP** and **MemLock** in that order.
 
 **Pass:**  
@@ -363,7 +363,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemReAlloc
+### MemReAlloc
 Reallocates space within a given block, changing its size. Also used to 
 reallocate space for a block that has been discarded.
 
@@ -385,7 +385,7 @@ ax, cx
 **Library:** heap.def
 
 ----------
-#### MemSegmentToHandle
+### MemSegmentToHandle
 Returns the corresponding handle of a passed segment value.
 
 **Pass:**  
@@ -401,7 +401,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemThreadGrab
+### MemThreadGrab
 Locks a block and increments a semaphore on the block; the current thread 
 will be able to perform more **MemThreadGrab** operations but other threads 
 will block on **MemThreadGrab**. If another thread has the semaphore 
@@ -422,7 +422,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemThreadGrabNB
+### MemThreadGrabNB
 Performs the same function as **MemThreadGrab** (locks a block and 
 increments a semaphore on the block) except that it doesn't block if another 
 thread has the semaphore.
@@ -440,7 +440,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemThreadRelease
+### MemThreadRelease
 Releases a thread previously grabbed by **MemThreadGrab**.
 
 **Pass:**  
@@ -455,7 +455,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MemUnlock
+### MemUnlock
 Unlocks a given block of memory by decrementing its lock count. If the lock 
 count reaches zero then the block is subject to moving or discarding.
 
@@ -475,7 +475,7 @@ NULL_SEGMENT upon return from this procedure.)
 **Library:** heap.def
 
 ----------
-#### MemUnlockFixedOrMovable
+### MemUnlockFixedOrMovable
 Given a virtual segment, unlocks the corresponding block if the segment is 
 movable.
 
@@ -491,7 +491,7 @@ Nothing (flags preserved).
 **Library:** heap.def
 
 ----------
-#### MemUnlockShared
+### MemUnlockShared
 Unlocks a block that was locked by either **MemLockShared** or 
 **MemLockExcl**. 
 
@@ -507,7 +507,7 @@ Nothing (flags preserved).
 **Library:** heap.def
 
 ----------
-#### MemUnlockV
+### MemUnlockV
 Unlocks a block and releases a semaphore on that block. (Performs a 
 **MemUnlock** and a **HandleV** in that order.)
 
@@ -523,7 +523,7 @@ Nothing (flags preserved).
 **Library:** heap.def
 
 ----------
-#### MemUpgradeSharedLock
+### MemUpgradeSharedLock
 Upgrades a shared lock to an exclusive lock. If the block is shared by other 
 threads this will block and the memory block may move on the heap before 
 gaining exclusive access.
@@ -544,7 +544,7 @@ Nothing.
 **Library:** heap.def
 
 ----------
-#### MessageDispatch
+### MessageDispatch
 Dispatches a passed message without destroying the handle of the message 
 (event) to dispatch using **ObjMessage**.
 
@@ -563,7 +563,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### MessageProcess
+### MessageProcess
 Processes a message (event) dispatching it via a custom callback routine.
 
 **Pass:**  
@@ -595,7 +595,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### MessageSetDestination
+### MessageSetDestination
 Changes an event's destination optr.
 
 **Pass:**  
@@ -611,7 +611,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### MetaGrabFocusExclLow
+### MetaGrabFocusExclLow
 This routine grabs the focus exclusive for the object.
 
 **Pass:**  
@@ -630,7 +630,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### MetaGrabModelExclLow
+### MetaGrabModelExclLow
 This routine grabs the model exclusive for the object.
 
 **Pass:**  
@@ -649,7 +649,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### MetaGrabTargetExclLow
+### MetaGrabTargetExclLow
 This routine grabs the target exclusive for the object.
 
 **Pass:**  
@@ -668,7 +668,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### MetaReleaseFocusExclLow
+### MetaReleaseFocusExclLow
 This routine releases the focus exclusive for the object.
 
 **Pass:**  
@@ -687,7 +687,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### MetaReleaseFTExclLow
+### MetaReleaseFTExclLow
 This routine releases the focus and target exclusives for the object.
 
 **Pass:**  
@@ -706,7 +706,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### MetaRelaseModelExclLow
+### MetaRelaseModelExclLow
 This routine releases the model exclusive for the object.
 
 **Pass:**  
@@ -725,7 +725,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### MetaReleaseTargetExclLow
+### MetaReleaseTargetExclLow
 This routine releases the target exclusive for the object.
 
 **Pass:**  
@@ -744,7 +744,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### NameArrayAdd
+### NameArrayAdd
 Creates an element within a name array and copies the data and name into 
 it. If an element with the same name already exists, this routine will not 
 create a duplicate; if NAAF_SET_DATA_ON_REPLACE is passed, the newly 
@@ -770,7 +770,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### NameArrayChangeName
+### NameArrayChangeName
 Changes the element's name within the passed name array.
 
 This routine may resize the LMem block, moving it on the heap and 
@@ -791,7 +791,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### NameArrayCreate
+### NameArrayCreate
 Creates a name array with zero elements. Add elements with 
 **NameArrayAdd**.
 
@@ -814,7 +814,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### NameArrayFind
+### NameArrayFind
 
 Finds a name element within a name array.
 
@@ -834,7 +834,7 @@ Nothing.
 **Library:** chunkarr.def
 
 ----------
-#### ObjBlockGetOutput
+### ObjBlockGetOutput
 Returns the optr of the object set to receive output messages from all objects 
 within the object block. (This output optr is stored in an object block's 
 **ObjLMemBlockHeader**.)
@@ -851,7 +851,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjBlockSetOutput
+### ObjBlockSetOutput
 Sets the optr of the object set to receive output messages from all objects 
 within the object block. (This output optr is stored in an object block's 
 **ObjLMemBlockHeader**.)
@@ -869,7 +869,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjCallClassNoLock
+### ObjCallClassNoLock
 
 Sends a message (invokes a method) of the given class for an object. If the 
 message is not resident in the passed class, sends that message on to the 
@@ -920,7 +920,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjCallInstanceNoLock
+### ObjCallInstanceNoLock
 Invokes a message of the given instance's class, fixing up **ds** upon return. 
 
 This routine assumes that the object block containing the receiving object is 
@@ -967,7 +967,7 @@ Nothing. (Possibly **es**; see above.)
 **Library:** object.def
 
 ----------
-#### ObjCallInstanceNoLockES
+### ObjCallInstanceNoLockES
 Invokes a message of the given object instance's class, fixing up both **ds** and 
 **es** upon return.
 
@@ -1017,7 +1017,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjCallSuperNoLock
+### ObjCallSuperNoLock
 Invokes a message of the given object instance's superclass.
 
 This routine assumes that the object block containing the receiving object is 
@@ -1063,7 +1063,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjCompAddChild
+### ObjCompAddChild
 Adds a child object to the composite field of another, composite object.
 
 **Pass:**  
@@ -1085,7 +1085,7 @@ ax, bx, di, bp.
 **Library:** metaC.def
 
 ----------
-#### ObjCompFindChild
+### ObjCompFindChild
 Pass a message to the next sibling of a linkable object.
 
 **Pass:**  
@@ -1114,7 +1114,7 @@ Nothing.
 **Library:** metaC.def
 
 ----------
-#### ObjCompMoveChild
+### ObjCompMoveChild
 This routine performs a MSG_MOVE_CHILD for a composite object.
 
 This routine is used to move a child to a different location in the list of 
@@ -1149,7 +1149,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them.
 
 ----------
-#### ObjCompProcessChildren
+### ObjCompProcessChildren
 This routine processes the children of a composite object via a callback 
 routine or via several predefined callback routines.
 
@@ -1207,7 +1207,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them.
 
 ----------
-#### ObjCompRemoveChild
+### ObjCompRemoveChild
 This routine performs a MSG_REMOVE_CHILD for a composite object.
 
 This routine is used to remove a child from a composite. The child to be 
@@ -1241,7 +1241,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them.
 
 ----------
-#### ObjDecInUseCount
+### ObjDecInUseCount
 Decrements the in-use count for an object block, stored in the 
 **ObjLMemBlockHeader** structure at the from of an object block. The in-use 
 count ensures that an object block being used is not freed prematurely.
@@ -1261,7 +1261,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjDecInteractibleCount
+### ObjDecInteractibleCount
 Decrements the interactible count of the passed object block. This count 
 quantifies the number of objects in the block that are currently interactible 
 with the user.
@@ -1281,7 +1281,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjDoRelocation
+### ObjDoRelocation
 
 Relocates a single piece of data (word or double word) within an object block. 
 
@@ -1304,7 +1304,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjDoUnRelocation
+### ObjDoUnRelocation
 Unrelocates a single piece of data (word or double word) within an object 
 block.
 
@@ -1327,7 +1327,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjDuplicateMessage
+### ObjDuplicateMessage
 Duplicates an encapsulated message (event), returning a copy of the event.
 
 **Pass:**  
@@ -1342,7 +1342,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjDuplicateResource
+### ObjDuplicateResource
 Duplicates an object resource block (and any objects and chunks within that 
 object block), returning the handle of the newly-created block. 
 
@@ -1368,7 +1368,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjEnableDetach
+### ObjEnableDetach
 Acknowledge detach for an object.
 
 **Pass:**  
@@ -1388,7 +1388,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them
 
 ----------
-#### ObjFreeChunk
+### ObjFreeChunk
 Frees a chunk within an object block. (Chunks within resources will remain, 
 with their size resized to zero.)
 
@@ -1404,7 +1404,7 @@ ax
 **Library:** object.def
 
 ----------
-#### ObjFreeDuplicate
+### ObjFreeDuplicate
 Frees a block created by ObjDuplicateResource or saved with 
 ObjSaveBlock. 
 
@@ -1420,7 +1420,7 @@ bx
 **Library:** object.def
 
 ----------
-#### ObjFreeMessage
+### ObjFreeMessage
 Frees an event handle (and the event attached to that handle).
 
 **Pass:**  
@@ -1435,7 +1435,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjFreeObjBlock
+### ObjFreeObjBlock
 Frees an object block. Object blocks created with **ObjDuplicateBlock** or 
 **ObjSaveBlock** should use **ObjFreeDuplicate** instead.
 
@@ -1451,7 +1451,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjGetFlags
+### ObjGetFlags
 Returns the **ObjChunkFlags** associated with an object block's chunk.
 
 **Pass:**  
@@ -1468,7 +1468,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjGetMessageInfo
+### ObjGetMessageInfo
 Returns information about an event handle.
 
 **Pass:**  
@@ -1486,7 +1486,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjGotoSuperTailRecurse
+### ObjGotoSuperTailRecurse
 This is an optimized version of **ObjCallSuperNoLock** that only works in 
 the case of tail recursion.
 
@@ -1508,7 +1508,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjIncDetach
+### ObjIncDetach
 Increment the acknowledge count for a detaching object.
 
 **Pass:**  
@@ -1523,7 +1523,7 @@ Nothing.
 **Library:** metaC.def
 
 ----------
-#### ObjIncInUseCount
+### ObjIncInUseCount
 Increments the in-use count for an object block, stored in the 
 **ObjLMemBlockHeader** structure at the front of an object block. The in-use 
 count ensures that an object block being used is not freed prematurely.
@@ -1543,7 +1543,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjIncInteractibleCount
+### ObjIncInteractibleCount
 Increments the interactible count of the passed object block. This count 
 quantifies the number of objects in the block that are currently interactible 
 with the user.
@@ -1563,7 +1563,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjInitDetach
+### ObjInitDetach
 Prepare to detach an object.
 
 **Pass:**  
@@ -1587,7 +1587,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them
 
 ----------
-#### ObjInitializeMaster
+### ObjInitializeMaster
 Initializes a master part of an object.
 
 **Pass:**  
@@ -1604,7 +1604,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjInitializePart
+### ObjInitializePart
 Ensures that an object is expanded, and initialized if necessary, for all master 
 parts down through the part passed. This routine sends 
 MSG_META_RESOLVE_VARIANT_SUPERCLASS to any master parts above the 
@@ -1626,7 +1626,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjInstantiate
+### ObjInstantiate
 Instantiates (creates) an object of the passed class, allocating a chunk for the 
 object, initializing the chunk to zeroes, filling in the class pointer and passing 
 MSG_PROCESS_INSTANTIATE to the object (if it has no master classes).
@@ -1648,7 +1648,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjIsClassADescendant
+### ObjIsClassADescendant
 Test whether a given class is a subclass of another specified class.
 
 **Pass:**  
@@ -1665,7 +1665,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjIsObjectInClass
+### ObjIsObjectInClass
 Tests whether or not an object is of a given class. If a variant class is 
 encountered, the object will not be grown out past that class in the search. 
 
@@ -1685,7 +1685,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjLinkCallNextSibling
+### ObjLinkCallNextSibling
 Pass a message to the next sibling of a linkable object.
 
 **Pass:**  
@@ -1713,7 +1713,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them.
 
 ----------
-#### ObjLinkCallParent
+### ObjLinkCallParent
 Pass a message to the parent of a linkable object.
 
 **Pass:**  
@@ -1743,7 +1743,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them.
 
 ----------
-#### ObjLinkFindParent
+### ObjLinkFindParent
 Pass a method to the next sibling of a linkable object.
 
 **Pass:**  
@@ -1766,7 +1766,7 @@ invalidating stored segment pointers and current register or stored offsets to
 them.
 
 ----------
-#### ObjLockObjBlock
+### ObjLockObjBlock
 Locks an object block, loading in the resource if necessary. If the block is an 
 LMem heap but is not an object block, this routine acts like **MemLock**.
 
@@ -1782,7 +1782,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjMapSavedToState
+### ObjMapSavedToState
 Maps a saved/duplicated block to its corresponding VM block handle in the 
 process' state file.
 
@@ -1800,7 +1800,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjMapStateToSaved
+### ObjMapStateToSaved
 Maps a VM block ID from a state file to the corresponding memory block 
 handle for a process.
 
@@ -1819,7 +1819,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjMarkDirty
+### ObjMarkDirty
 Register-saving routine to mark an object dirty.
 
 **Pass:**  
@@ -1834,7 +1834,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjMessage
+### ObjMessage
 Sends a message to an object.
 
 **Pass:**  
@@ -1882,7 +1882,7 @@ bx, si, di, ds, es (and unused return registers above).
 **Library:** object.def
 
 ----------
-#### ObjProcBroadcastMessage
+### ObjProcBroadcastMessage
 Broadcasts an event to all threads with event queues.
 
 **Pass:**  
@@ -1897,7 +1897,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjRelocOrUnRelocSuper
+### ObjRelocOrUnRelocSuper
 Relocate or unrelocate an object's superclass structures and pointers.
 
 **Pass:**  
@@ -1914,7 +1914,7 @@ ax, dx, dx
 **Library:** object.def
 
 ----------
-#### ObjResizeMaster
+### ObjResizeMaster
 Resizes a master class part of an object.
 
 **Pass:**  
@@ -1931,7 +1931,7 @@ ax
 **Library:** object.def
 
 ----------
-#### ObjSaveBlock
+### ObjSaveBlock
 Sets up an LMem block to be saved to its owner's state file.
 
 **Pass:**  
@@ -1948,7 +1948,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjSetFlags
+### ObjSetFlags
 Sets the object flags (**ObjChunkFlags**) associated with a chunk.
 
 **Pass:**  
@@ -1966,7 +1966,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjSwapLock
+### ObjSwapLock
 This utility routine locks a new object block and saves the old object's block 
 handle. This is useful when using **ObjCallInstanceNoLock** is much more 
 desirable than using **ObjMessage** for repeated operations; for example, if an 
@@ -1987,7 +1987,7 @@ Nothing. Flags preserved.
 **Library:** object.def
 
 ----------
-#### ObjSwapLockParent
+### ObjSwapLockParent
 This utility routine locks the parent of an object and saves the child's block 
 handle. This is useful when using **ObjCallInstanceNoLock** is much more 
 desirable than using **ObjMessage** for repeated operations; for example, if an 
@@ -2011,7 +2011,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjSwapUnlock
+### ObjSwapUnlock
 This utility routine swaps a locked object block, unlocking it in the process, 
 with a new object block.
 
@@ -2029,7 +2029,7 @@ Nothing. Flags preserved.
 **Library:** object.def
 
 ----------
-#### ObjTestIfObjBlockRunByCurThread
+### ObjTestIfObjBlockRunByCurThread
 Determines if the current running thread owns a given object block. 
 
 **Pass:**  
@@ -2050,7 +2050,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarAddData
+### ObjVarAddData
 Adds a new vardata entry or replaces the existing data within an entry (with 
 zeroed data). This routine returns a pointer to the extra data section of the 
 vardata entry in order to allow you to initialize this data immediately.
@@ -2073,7 +2073,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarCopyDataRange
+### ObjVarCopyDataRange
 Copies a group of vardata entries (matching the specified range values) from 
 one object into another object. You can pass an identical start and end 
 vardata type value to copy a single vardata entry from one object another.
@@ -2096,7 +2096,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarDeleteData
+### ObjVarDeleteData
 Deletes a specified vardata entry field and associated extra data (if any) 
 within an object.
 
@@ -2115,7 +2115,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarDeleteDataAt
+### ObjVarDeleteDataAt
 Deletes a vardata entry field (specified at by the passed opaque pointer).
 
 **Pass:**  
@@ -2132,7 +2132,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarDeleteDataRange
+### ObjVarDeleteDataRange
 Deletes a group of vardata entries (matching the specified range values). You 
 may also specify that you only wish to delete vardata entries that are not 
 marked VDF_SAVE_TO_STATE.
@@ -2157,7 +2157,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarDerefData
+### ObjVarDerefData
 Returns either a pointer to a vardata entry's extra data section or an opaque 
 pointer to the vardata entry type passed. (If there is no extra data, it returns 
 a pointer to the data entry + offset *VDI_extraData*. This is used as an opaque 
@@ -2179,7 +2179,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarFindData
+### ObjVarFindData
 Searches an object's vardata section for a given vardata type. If found, this 
 routine returns a pointer to the appropriate vardata section (or an opaque 
 pointer if there is no extra data; this opaque pointer should be used before 
@@ -2204,7 +2204,7 @@ Nothing.
 **Library:** object.def
 
 ----------
-#### ObjVarScanData
+### ObjVarScanData
 Scans an object's vardata and calls all pertaining routines listed in a "vardata 
 handler" table.
 
@@ -2240,7 +2240,7 @@ ax, bx, si, di, es
 **Library:** object.def
 
 ----------
-#### ParserAddDependencies
+### ParserAddDependencies
 Adds a set of dependencies from a dependency block.
 
 **Pass:**  
@@ -2257,7 +2257,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### ParserAddSingleDependency
+### ParserAddSingleDependency
 Adds a single dependency to a cell.
 
 **Pass:**  
@@ -2276,7 +2276,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### ParserErrorMessage
+### ParserErrorMessage
 Returns a text-based error message string, when passed a 
 **ParserScannerEvaluatorError**.
 
@@ -2293,7 +2293,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserEvalExpression
+### ParserEvalExpression
 Evaluates a stream of parser tokens.
 
 **Pass:**  
@@ -2324,7 +2324,7 @@ ah
 **Library:** parse.def
 
 ----------
-#### ParserEvalForeachArg
+### ParserEvalForeachArg
 Calls a callback routine for each argument within an argument stack.
 
 **Pass:**  
@@ -2351,7 +2351,7 @@ CF - Set on error.
 **Library:** parse.def
 
 ----------
-#### ParserEvalPopNArgs
+### ParserEvalPopNArgs
 Pops a number of arguments off the argument stack. It is important to note 
 that this routine does not perform any sort of destructive acts to the 
 argument stack.
@@ -2370,7 +2370,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserEvalPropagateEvalError
+### ParserEvalPropagateEvalError
 Propagates an error up the argument stack.
 
 **Pass:**  
@@ -2390,7 +2390,7 @@ ax.
 **Library:** parse.def
 
 ----------
-#### ParserEvalPushArgument
+### ParserEvalPushArgument
 
 Pushes an argument onto the argument stack.
 **Pass:**  
@@ -2413,7 +2413,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserEvalPushCellReference
+### ParserEvalPushCellReference
 Pushes a cell reference on the argument stack.
 
 **Pass:**  
@@ -2433,7 +2433,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### ParserEvalPushNumericConstant
+### ParserEvalPushNumericConstant
 Pushes a numeric constant on the argument stack.
 
 **Pass:**  
@@ -2454,7 +2454,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### ParserEvalPushNumericConstantWord
+### ParserEvalPushNumericConstantWord
 Pushes a word-length numeric constant onto the argument stack.
 
 **Returns:**  
@@ -2472,7 +2472,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserEvalPushRange
+### ParserEvalPushRange
 Pushes a range on the argument stack.
 
 **Pass:**  
@@ -2491,7 +2491,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### ParserEvalPushStringConstant
+### ParserEvalPushStringConstant
 Pushes a string constant on the argument stack.
 
 **Pass:**  
@@ -2511,7 +2511,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### ParserEvalRangeIntersection
+### ParserEvalRangeIntersection
 Implements the range intersection operator on two passed ranges.
 
 **Pass:**  
@@ -2533,7 +2533,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### ParserForeachPrecedent
+### ParserForeachPrecedent
 Calls a routine for each entry within a precedent list. (Precedents are the 
 actual cells that an expression depends on.)
 
@@ -2562,7 +2562,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserForeachReference
+### ParserForeachReference
 Calls a routine for each reference within the given expression. (References 
 are the cells that are referred to in the expression; this may be either a cell 
 reference or a name.)
@@ -2595,7 +2595,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserForeachToken
+### ParserForeachToken
 Calls a routine for each token within the given expression. (A token is a 
 distinct, separate element within an expression; e.g. a number, operator, 
 function, etc.)
@@ -2628,7 +2628,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserFormatCellReference
+### ParserFormatCellReference
 Formats a single cell reference of the form AB123.
 
 **Pass:**  
@@ -2646,7 +2646,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserFormatColumnReference
+### ParserFormatColumnReference
 Formats a column reference in the form "AB."
 
 **Pass:**  
@@ -2663,7 +2663,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserFormatExpression
+### ParserFormatExpression
 Formats a parsed expression into a text string.
 
 **Pass:**  
@@ -2680,7 +2680,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserFormatRangeReference
+### ParserFormatRangeReference
 Formats a multiple (range) cell reference of the form AB123:CD456.
 
 **Pass:**  
@@ -2700,7 +2700,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserFormatRowReference
+### ParserFormatRowReference
 Formats a row reference in the form "123."
 
 **Pass:**  
@@ -2718,7 +2718,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserFormatWordConstant
+### ParserFormatWordConstant
 Formats a word constant.
 
 **Pass:**  
@@ -2736,7 +2736,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserGetFunctionArgs
+### ParserGetFunctionArgs
 Returns the arguments of a specified parser function. The arguments are 
 stored as a text string within the passed buffer.
 
@@ -2754,7 +2754,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserGetFunctionDescription
+### ParserGetFunctionDescription
 Returns a description of a specified parser function. The description string is 
 stored in the passed buffer.
 
@@ -2772,7 +2772,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserGetFunctionMoniker
+### ParserGetFunctionMoniker
 Returns the name of the specified parser function.
 
 **Pass:**  
@@ -2789,7 +2789,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserGetNumberOfFunctions
+### ParserGetNumberOfFunctions
 Returns the number of parser functions matching a particular function type.
 
 **Pass:**  
@@ -2804,7 +2804,7 @@ Nothing.
 **Library:** parse.def
 
 ----------
-#### ParserLocalizeFormats
+### ParserLocalizeFormats
 Re-initialize localization information.
 
 **Pass:**  
@@ -2819,7 +2819,7 @@ Nothing.
 Library: parse.def
 
 ----------
-#### ParserParseString
+### ParserParseString
 Parses a string.
 
 **Pass:**  
@@ -2839,7 +2839,7 @@ ah
 **Library:** parse.def
 
 ----------
-#### ParserRemoveDependencies
+### ParserRemoveDependencies
 Removes a set of dependencies from a dependency block.
 
 **Pass:**  
@@ -2856,7 +2856,7 @@ ax
 **Library:** parse.def
 
 ----------
-#### PrefTestVideoDevice
+### PrefTestVideoDevice
 Checks if the selected video driver is available on the machine.
 
 **Pass:**  
@@ -2876,7 +2876,7 @@ cx, dx, di
 **Library:** config.def
 
 ----------
-#### ProcCallFixedOrMovable
+### ProcCallFixedOrMovable
 Calls the routine specified by the passed virtual far pointer.
 
 **Pass:**  
@@ -2894,7 +2894,7 @@ All registers returned by called routine will be returned to the caller of
 **Library:** resource.def
 
 ----------
-#### ProcCallModuleRoutine
+### ProcCallModuleRoutine
 Calls a process' routine in another code resource. The stack usage of this 
 routine is guaranteed; the routine called will return two words of the return 
 address on the stack followed by any parameters that the caller may have 
@@ -2915,7 +2915,7 @@ All registers returned by called routine will be returned to the caller of
 **Library:** resource.def
 
 ----------
-#### ProcGetLibraryEntry
+### ProcGetLibraryEntry
 Returns the address of a routine within a library. You can pass the result 
 directly to **ProcCallFixedOrMovable** to call the routine.
 
@@ -2932,7 +2932,7 @@ Nothing.
 **Library:** resource.def
 
 ----------
-#### ProcInfo
+### ProcInfo
 Returns the contents of the *HM_otherInfo* field for a given process. This field 
 holds the first thread of this process.
 
@@ -2949,7 +2949,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### QueueGetMessage
+### QueueGetMessage
 Returns the next event from a given event queue; this routine blocks the 
 queue if it is currently empty until an event is added which can be returned.
 
@@ -2965,7 +2965,7 @@ Nothing.
 **Library:** geode.def
 
 ----------
-#### QueuePostMessage
+### QueuePostMessage
 Adds the passed event to the specified event queue.
 
 **Pass:**  

--- a/TechDocs/Markdown/Asmref/asmr_u.md
+++ b/TechDocs/Markdown/Asmref/asmr_u.md
@@ -1,7 +1,7 @@
 ## 2.6 Routines R-U
 
 ----------
-#### RangeEnum
+### RangeEnum
 Enumerate all cells in a range of cells, calling a callback routine on each.
 
 **Pass:**  
@@ -106,7 +106,7 @@ change the data pointed at by *REP_columnFlagsArray* and return the flag
 REF_COLUMN_FLAGS_MODIFIED.
 
 ----------
-#### RangeExists
+### RangeExists
 Check for the existence of cells in a given range.
 
 **Pass:**  
@@ -124,7 +124,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### RangeInsert
+### RangeInsert
 Insert or delete a range of cells.
 
 **Pass:**  
@@ -149,7 +149,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### RangeSort
+### RangeSort
 Sort a range of cells either in ascending order or via callback routine.
 
 **Pass:**  
@@ -192,7 +192,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### RowGetFlags
+### RowGetFlags
 Get flags for specified row.
 
 **Pass:**  
@@ -209,7 +209,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### RowSetFlags
+### RowSetFlags
 Set the flags for a given row.
 
 **Pass:**  
@@ -226,7 +226,7 @@ Nothing.
 **Library:** cell.def
 
 ----------
-#### RulerScaleDocToWinCoords
+### RulerScaleDocToWinCoords
 Scale a ruler point in document coordinates to window coordinates.
 
 **Pass:**  
@@ -242,7 +242,7 @@ Nothing.
 **Library:** ruler.def
 
 ----------
-#### RulerScaleWinToDocCoords
+### RulerScaleWinToDocCoords
 Scale a ruler point in window coordinates to document coordinates.
 
 **Pass:**  
@@ -258,7 +258,7 @@ Nothing.
 **Library:** ruler.def
 
 ----------
-#### SoundAllocMusic
+### SoundAllocMusic
 Allocate a handle to play FM sounds from fixed memory
 
 **Pass:**  
@@ -278,7 +278,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundAllocMusicNote
+### SoundAllocMusicNote
 Allocate a note and return its handle.
 
 **Pass:**  
@@ -300,7 +300,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundAllocMusicStream
+### SoundAllocMusicStream
 Allocate a stream to play FM sounds on.
 
 **Pass:**  
@@ -321,7 +321,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundAllocNote
+### SoundAllocNote
 Allocate a note structure, define it, and return its handle. A note is a simple 
 sound that has a pre-defined sound buffer. The handle returned may be used 
 with other sound routines to play or free the sound.
@@ -345,7 +345,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundAllocSampleStream
+### SoundAllocSampleStream
 Allocate a sound handle for the sound.
 
 **Pass:**  
@@ -362,7 +362,7 @@ bx or ax - See above.
 **Library:** sound.def
 
 ----------
-#### SoundAllocSimple
+### SoundAllocSimple
 Allocate a handle to play FM sounds from fixed memory
 
 **Pass:**  
@@ -382,7 +382,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundAllocSimpleFM
+### SoundAllocSimpleFM
 Allocate space on the global heap for a simple, frequency-modulated sound 
 stream for a song. The song should already be created and located in fixed or 
 locked memory. The handle returned references a block containing the sound 
@@ -405,7 +405,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundChangeOwner
+### SoundChangeOwner
 Change the owner of a sound.
 
 **Pass:**  
@@ -421,7 +421,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundChangeOwnerMusic
+### SoundChangeOwnerMusic
 Change the owner of a sound.
 
 **Pass:**  
@@ -437,7 +437,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundChangeOwnerSimple
+### SoundChangeOwnerSimple
 Change the owner of a sound.
 
 **Pass:**  
@@ -453,7 +453,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundChangeOwnerStream
+### SoundChangeOwnerStream
 Change the owner of a sound stream.
 
 **Pass:**  
@@ -469,7 +469,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundDisableSampleStream
+### SoundDisableSampleStream
 Removes the association of DAC and the sound.
 
 **Pass:**  
@@ -484,7 +484,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundEnableSampleStream
+### SoundEnableSampleStream
 Associate a real DAC device to a sound.
 
 **Pass:**  
@@ -504,7 +504,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundFreeMusic
+### SoundFreeMusic
 Free up a simple FM sound stream.
 
 **Pass:**  
@@ -519,7 +519,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundFreeMusicNote
+### SoundFreeMusicNote
 Free up an allocated music note.
 
 **Pass:**  
@@ -534,7 +534,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundFreeMusicStream
+### SoundFreeMusicStream
 Free an FM sound stream.
 
 **Pass:**  
@@ -549,7 +549,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundFreeNote
+### SoundFreeNote
 Free the given note originally allocated with **SoundAllocNote**; the note 
 must not be playing when it is freed. If the note may be playing, call 
 **SoundStopNote** before freeing it.
@@ -566,7 +566,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundFreeSampleStream
+### SoundFreeSampleStream
 Frees up the Sound structure of the sound.
 
 **Pass:**  
@@ -581,7 +581,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundFreeSimple
+### SoundFreeSimple
 Free up a simple FM sound stream.
 
 **Pass:**  
@@ -596,7 +596,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundFreeSimpleFM
+### SoundFreeSimpleFM
 Free a simple frequency-modulated sound originally allocated with 
 **SoundAllocSimpleFM**. The sound must not be playing; if it may be playing, 
 call **SoundStopStream** before freeing it.
@@ -613,7 +613,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundGetExclusive
+### SoundGetExclusive
 Get exclusive access to the sound driver, blocking if it is currently in use. 
 Generally, applications will call the higher level sound routines rather than 
 access the sound driver's strategy routine directly. If you do call this routine, 
@@ -633,7 +633,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundGetExclusiveNB
+### SoundGetExclusiveNB
 Get exclusive access to the sound driver, returning with the carry flag set if 
 it is currently in use. Generally, applications will call the higher level sound 
 routines rather than access the sound driver's strategy routine directly. If 
@@ -656,7 +656,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundInitMusic
+### SoundInitMusic
 Initialize a pre-defined simple FM sound structure.
 
 **Pass:**  
@@ -672,7 +672,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundInitSimple
+### SoundInitSimple
 Initialize a pre-defined simple FM sound structure.
 
 **Pass:**  
@@ -688,7 +688,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundInitSimpleFM
+### SoundInitSimpleFM
 Initialize a pre-defined simple frequency-modulated sound structure. This 
 routine is automatically called when a note is allocated with 
 **SoundAllocNote** or **SoundAllocSimpleFM**.
@@ -706,7 +706,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundPlayMusic
+### SoundPlayMusic
 Play a simple FM sound.
 
 **Pass:**  
@@ -725,7 +725,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundPlayMusicNote
+### SoundPlayMusicNote
 Play a note of music.
 
 **Pass:**  
@@ -744,7 +744,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundPlayNote
+### SoundPlayNote
 Play the given note according to the other parameters. If the note is currently 
 playing, it will be stopped and immediately restarted. This routine is 
 identical to **SoundPlaySimpleFM**.
@@ -766,7 +766,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundPlaySimple
+### SoundPlaySimple
 Play a note of music.
 
 **Pass:**  
@@ -785,7 +785,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundPlaySimpleFM
+### SoundPlaySimpleFM
 Play the given note according to the other parameters. If the sound is 
 currently playing, it will be restarted at the beginning with the new tempo 
 and priority.
@@ -807,7 +807,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundPlayToMusicStream
+### SoundPlayToMusicStream
 Play an FM sound to a stream.
 
 **Pass:**  
@@ -825,7 +825,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundPlayToSampleStream
+### SoundPlayToSampleStream
 Play a given piece of DAC data to the DAC device.
 
 **Pass:**  
@@ -844,7 +844,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundReallocMusic
+### SoundReallocMusic
 Change the song setting for a simple stream.
 
 **Pass:**  
@@ -861,7 +861,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundReallocMusicNote
+### SoundReallocMusicNote
 Change the settings of the given note. The note must not be playing; if it may 
 be, call SoundStopNote before reallocating the note.
 
@@ -883,7 +883,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundReallocNote
+### SoundReallocNote
 Change the settings of the given note. The note must not be playing; if it may 
 be, call **SoundStopNote** before reallocating the note.
 
@@ -904,7 +904,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundReallocSimple
+### SoundReallocSimple
 Change the song setting for a simple stream.
 
 **Pass:**  
@@ -921,7 +921,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundReallocSimpleFM
+### SoundReallocSimpleFM
 Change the settings for a simple note or simple song's stream. This routine 
 restarts the song with the new sound buffer, but it leaves the voices in the 
 state they were in at the end of the last song. This allows playing a very long 
@@ -944,7 +944,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundReleaseExclusive
+### SoundReleaseExclusive
 Release exclusive access to the sound library and sound driver routines. Any 
 thread that calls **SoundGrabExclusive** or **SoundGrabExclusiveNB** 
 must call this routine after grabbing the exclusive. In general, a thread 
@@ -962,7 +962,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundSampleDriverInfo
+### SoundSampleDriverInfo
 Get information on Sample Driver.
 
 **Pass:**  
@@ -978,7 +978,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundStopMusic
+### SoundStopMusic
 Stop a simple stream.
 
 **Pass:**  
@@ -994,7 +994,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundStopMusicNote
+### SoundStopMusicNote
 Stop a music note.
 
 **Pass:**  
@@ -1010,7 +1010,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundStopMusicStream
+### SoundStopMusicStream
 Stop a music stream.
 
 **Pass:**  
@@ -1026,7 +1026,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundStopNote
+### SoundStopNote
 Stop a note that is playing. This routine should be called before freeing, 
 changing, or reallocating a note if that note could be playing at the time.
 
@@ -1043,7 +1043,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SoundStopSimple
+### SoundStopSimple
 Stop a music stream.
 
 **Pass:**  
@@ -1059,7 +1059,7 @@ See above.
 **Library:** sound.def
 
 ----------
-#### SoundStopSimpleFM
+### SoundStopSimpleFM
 Stop a simple frequency-modulated sound from playing. This is similar in 
 usage to **SoundStopNote**.
 
@@ -1073,7 +1073,7 @@ ax - On error, a **SoundErrors** value; otherwise destroyed.
 **Library:** sound.def
 
 ----------
-#### SoundSynthDriverInfo
+### SoundSynthDriverInfo
 Get information on the synthesizer driver.
 
 **Pass:**  
@@ -1090,7 +1090,7 @@ Nothing.
 **Library:** sound.def
 
 ----------
-#### SpoolAddJob
+### SpoolAddJob
 Add the passed job (a GString file) to the print queue. If the spooler thread 
 has not started, or if there is no queue for the desired device and port, this 
 routine will start them.
@@ -1111,7 +1111,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolConvertPaperSize
+### SpoolConvertPaperSize
 Convert a width and height pair to a paper size index. This is the complement 
 to **SpoolGetPaperSize**.
 
@@ -1131,7 +1131,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolCreatePaperSize
+### SpoolCreatePaperSize
 Create a new paper size index and store it in the GEOS.INI file.
 
 **Pass:**  
@@ -1152,7 +1152,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolCreatePrinter
+### SpoolCreatePrinter
 Create a new printer, adding it to the end of the list of installed printers. This 
 routine does not initialize all the information for the printer but only adds it 
 to the installed list.
@@ -1172,7 +1172,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolCreateSpoolFile
+### SpoolCreateSpoolFile
 Create and open a new, unique spool file in the SP_SPOOL directory.
 
 **Pass:**  
@@ -1190,7 +1190,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolDelJob
+### SpoolDelJob
 Delete a job from the spooler queue, given a job ID.
 
 **Pass:**  
@@ -1205,7 +1205,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolDelayJob
+### SpoolDelayJob
 Move the specified job to the end of the spooler queue.
 
 **Pass:**  
@@ -1220,7 +1220,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolDeletePaperSize
+### SpoolDeletePaperSize
 Delete a paper size from the paper size list.
 
 **Pass:**  
@@ -1236,7 +1236,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolDeletePrinter
+### SpoolDeletePrinter
 Delete a printer from the list of currently installed printers.
 
 **Pass:**  
@@ -1251,7 +1251,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolGetDefaultPageSizeInfo
+### SpoolGetDefaultPageSizeInfo
 Return the default page information for the spooler.
 
 **Pass:**  
@@ -1272,7 +1272,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolGetNumPaperSizes
+### SpoolGetNumPaperSizes
 Return the number of defined paper sizes for the given type.
 
 **Pass:**  
@@ -1288,7 +1288,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolGetNumPrinters
+### SpoolGetNumPrinters
 Return the number of printers installed for the given driver type.
 
 **Pass:**  
@@ -1306,7 +1306,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolGetPaperSize
+### SpoolGetPaperSize
 Return the dimensions of the requested paper size. This is the complement 
 to **SpoolConvertPageSize**.
 
@@ -1325,7 +1325,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolGetPaperSizeOrder
+### SpoolGetPaperSizeOrder
 Return the paper size order array for the given page type.
 
 **Pass:**  
@@ -1358,7 +1358,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolGetPaperString
+### SpoolGetPaperString
 Return the paper size string for the specified paper size and page type.
 
 **Pass:**  
@@ -1379,7 +1379,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolGetPrinterString
+### SpoolGetPrinterString
 Return the printer name string for the specified printer.
 
 **Pass:**  
@@ -1401,7 +1401,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolHurryJob
+### SpoolHurryJob
 Move the given print job to the front of the spooler's queue.
 
 **Pass:**  
@@ -1416,7 +1416,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolInfo
+### SpoolInfo
 Return information about either the spooler's jobs or the spooler's queue.
 
 **Pass:**  
@@ -1461,7 +1461,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolMapToPrinterFont
+### SpoolMapToPrinterFont
 Map the GEOS font passed to the closest printer font available.
 
 **Pass:**  
@@ -1488,7 +1488,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolModifyPriority
+### SpoolModifyPriority
 Modify the priority of a spool queue's thread.
 
 **Pass:**  
@@ -1505,7 +1505,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolSetDefaultPageSizeInfo
+### SpoolSetDefaultPageSizeInfo
 Set the default page information for the system.
 
 **Pass:**  
@@ -1521,7 +1521,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolSetDefaultPrinter
+### SpoolSetDefaultPrinter
 Set the printer to be used as the system default.
 
 **Pass:**  
@@ -1536,7 +1536,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolSetDocSize
+### SpoolSetDocSize
 Set the document size for a given application.
 
 **Pass:**  
@@ -1554,7 +1554,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolSetPaperSizeOrder
+### SpoolSetPaperSizeOrder
 Set a new order in which paper sizes should be displayed, for a particular 
 page type.
 
@@ -1577,7 +1577,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolUpdateTranslationTable
+### SpoolUpdateTranslationTable
 Initialize the translation table in the passed  -  structure. This routine 
 is called any time a change in font or country occurs resulting in a change in 
 the ISO substitutions. It is also called once on startup of any print job. This 
@@ -1598,7 +1598,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SpoolVerifyPrinterPort
+### SpoolVerifyPrinterPort
 Verify the existence of a printer port.
 
 **Pass:**  
@@ -1614,7 +1614,7 @@ Nothing.
 **Library:** spool.def
 
 ----------
-#### SysGetDosEnvironment
+### SysGetDosEnvironment
 Retrieve the value of a DOS environment variable from the environment 
 buffer.
 
@@ -1634,7 +1634,7 @@ Nothing.
 **Library:** system.def
 
 ----------
-#### SysGetECLevel
+### SysGetECLevel
 Return the current **ErrorCheckingFlags** record set for the system and the 
 block, if ECF_BLOCK_CHECKSUM is set. For full information, see the 
 reference entry for **ErrorCheckingFlags**.
@@ -1653,7 +1653,7 @@ Nothing.
 **Library:** ec.def
 
 ----------
-#### SysGetInfo
+### SysGetInfo
 Return general system information dependent on the type passed.
 
 **Pass:**  
@@ -1692,7 +1692,7 @@ dx, if not returning value.
 **Library:** sysstats.def
 
 ----------
-#### SysLocateFileInDosPath
+### SysLocateFileInDosPath
 Search for a file along the path specified in the DOS PATH environment 
 variable.
 
@@ -1716,7 +1716,7 @@ Nothing.
 **Library:** system.def
 
 ----------
-#### SysLockBIOS
+### SysLockBIOS
 Gain exclusive access to the BIOS or DOS. Use of this routine is strongly 
 discouraged.
 
@@ -1735,7 +1735,7 @@ Flags are destroyed.
 This is a dangerous routine.
 
 ----------
-#### SysNotify
+### SysNotify
 Put the **SysNotify** dialog box (the white box with black borders) on the 
 screen. The dialog may have two strings printed in it, which are passed with 
 this routine. This box is typically used for unrecoverable errors, but it may be 
@@ -1773,7 +1773,7 @@ Nothing (except SNF_REBOOT).
 **Library:** system.def
 
 ----------
-#### SysRegisterScreen
+### SysRegisterScreen
 
 Register a new screen with the error mechanism, creating a new window and 
 GState. Use of this routine is strongly discouraged.
@@ -1791,7 +1791,7 @@ Nothing.
 **Library:** system.def
 
 ----------
-#### SysSetECLevel
+### SysSetECLevel
 Set the current error-checking flags.
 
 **Pass:**  
@@ -1811,7 +1811,7 @@ Nothing.
 **Library:** ec.def
 
 ----------
-#### SysSetExitFlags
+### SysSetExitFlags
 Set the record of exit flags for use with task-switching drivers. The exit flags 
 are also used for other purposes. Use of this routine is strongly discouraged. 
 For full information on the flags, see the reference entry for **ExitFlags**.
@@ -1839,7 +1839,7 @@ bh is destroyed.
 This is a dangerous routine.
 
 ----------
-#### SysShutdown
+### SysShutdown
 Cause the system to exit based on the **SysShutdownType** passed.
 **Pass:**  
 ax - **SysShutDownType**. Each shutdown type takes its own 
@@ -1936,7 +1936,7 @@ ax, bx, cx, dx, bp
 **Library:** system.def
 
 ----------
-#### SysStatistics
+### SysStatistics
 Return system performance statistics.
 
 **Pass:**  
@@ -1959,7 +1959,7 @@ Nothing.
 **Library:** sysstats.def
 
 ----------
-#### SysUnlockBIOS
+### SysUnlockBIOS
 Relinquish exclusive access to BIOS or DOS, originally gained with 
 **SysLockBIOS**. Use of these routines is strongly discouraged.
 
@@ -1975,7 +1975,7 @@ Nothing (flags preserved).
 **Library:** system.def
 
 ----------
-#### TextAllocClipboardObject
+### TextAllocClipboardObject
 This utility routine allocates a temporary object associated with the 
 clipboard file for purposes of producing a transfer item. 
 
@@ -1993,7 +1993,7 @@ Nothing.
 **Library:** vTextC.def
 
 ----------
-#### TextFindDefaultCharAttr
+### TextFindDefaultCharAttr
 Given an **VisTextCharAttr** structure, determine if it is one of the default 
 character attributes.
 
@@ -2010,7 +2010,7 @@ Nothing.
 **Library:** vTextC.def
 
 ----------
-#### TextFinishWithClipboardObject
+### TextFinishWithClipboardObject
 Finish with an object created by TextAllocClipboardObject.
 
 **Pass:**  
@@ -2028,7 +2028,7 @@ Nothing
 **Library:** vTextC.def
 
 ----------
-#### TextGetSystemCharAttrRun
+### TextGetSystemCharAttrRun
 This routine returns the system character attribute run for this object's 
 specific UI. 
 
@@ -2055,7 +2055,7 @@ This routine may resize LMem or object blocks, moving them on the heap and
 invalidating stored segment pointers to them.
 
 ----------
-#### TextSearchInHugeArray
+### TextSearchInHugeArray
 This routine finds an occurrence of a string within another string.
 
 **Pass:**  
@@ -2087,7 +2087,7 @@ Nothing.
 **Library:** vTextC.def
 
 ----------
-#### TextSearchInString
+### TextSearchInString
 This routine finds an occurrence of a string within another string (both 
 strings must be less than 64K in size. 
 
@@ -2128,7 +2128,7 @@ Nothing.
 **Library:** vTextC.def
 
 ----------
-#### TextSetSpellLibrary
+### TextSetSpellLibrary
 This routine sets the handle of the spell library to make calls to. 
 
 **Pass:**  
@@ -2143,7 +2143,7 @@ Nothing.
 **Library:** vTextC.def
 
 ----------
-#### ThreadAllocSem
+### ThreadAllocSem
 Allocate a semaphore with the initial passed value. The initial value is the 
 number of locks the semaphore can legally have before it causes users to 
 block. This number is nearly always one.
@@ -2160,7 +2160,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadAllocThreadLock
+### ThreadAllocThreadLock
 Allocate a thread lock semaphore; this type of semaphore allows a single 
 thread to lock it multiple times without hitting deadlock.
 
@@ -2176,7 +2176,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadAttachToQueue
+### ThreadAttachToQueue
 Attach a thread to an event queue, blocking on the queue until an event is 
 received by it.
 
@@ -2198,7 +2198,7 @@ Does not return.
 **Library:** thread.def
 
 ----------
-#### ThreadCreate
+### ThreadCreate
 Create a new procedural thread. When the thread is started, it begins 
 execution at the routine specified. If you really want to create an event thread 
 (one that runs objects), send MSG_PROCESS_CREATE_EVENT_THREAD to 
@@ -2257,7 +2257,7 @@ ax, dx, si, di, bp
 **Library:** thread.def
 
 ----------
-#### ThreadDestroy
+### ThreadDestroy
 Exit the current process or thread and destroy it.
 
 **Pass:**  
@@ -2280,7 +2280,7 @@ Does not return.
 **Library:** thread.def
 
 ----------
-#### ThreadFreeSem
+### ThreadFreeSem
 Free a semaphore allocated with **ThreadAllocSem**.
 
 **Pass:**  
@@ -2295,7 +2295,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadFreeThreadLock
+### ThreadFreeThreadLock
 Free a semaphore allocated with **ThreadGrabThreadLock**.
 
 **Pass:**  
@@ -2310,7 +2310,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadGetDGroupDS
+### ThreadGetDGroupDS
 Load the **ds** register with the segment of the current thread's dgroup.
 
 **Pass:**  
@@ -2325,7 +2325,7 @@ Nothing.
 **Library:** resource.def
 
 ----------
-#### ThreadGetInfo
+### ThreadGetInfo
 Return information about a thread, depending on the type passed.
 
 **Pass:**  
@@ -2347,7 +2347,7 @@ Nothing.
 **Library:** thread.def
 
 ----------
-#### ThreadGrabThreadLock
+### ThreadGrabThreadLock
 Grab a thread lock (like doing a "P" on a semaphore). A thread that grabs a 
 thread lock it already holds will not deadlock. A thread that grabs a thread 
 lock held by another thread will block until the thread lock is available.
@@ -2365,7 +2365,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadHandleException
+### ThreadHandleException
 Define a handler function so a thread may handle one of the processor 
 exceptions.
 
@@ -2391,7 +2391,7 @@ Nothing.
 **Library:** thread.def
 
 ----------
-#### ThreadModify
+### ThreadModify
 Change a thread's base priority, and/or set the thread's recent CPU usage to 
 zero.
 
@@ -2413,7 +2413,7 @@ ax
 **Library:** thread.def
 
 ----------
-#### ThreadPrivAlloc
+### ThreadPrivAlloc
 Allocate a block of contiguous words in the thread's private data area.
 
 **Pass:**  
@@ -2431,7 +2431,7 @@ Nothing.
 **Library:** thread.def
 
 ----------
-#### ThreadPrivFree
+### ThreadPrivFree
 Free a range of thread-private space owned by the geode. This space must 
 have been allocated with **ThreadPrivAlloc**.
 
@@ -2449,7 +2449,7 @@ Nothing.
 **Library:** thread.def
 
 ----------
-#### ThreadPSem
+### ThreadPSem
 Grab a semaphore (perform a "P" operation on it). If another thread has the 
 semaphore, the caller will block until the semaphore is available. If the 
 calling thread has the semaphore, the thread will deadlock. This routine 
@@ -2469,7 +2469,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadPTimedSem
+### ThreadPTimedSem
 Grab a semaphore as with **ThreadPSem**, except return an error if the 
 semaphore is not available within a certain time limit. If the timeout is 
 returned, the caller should not proceed with the protected action but should 
@@ -2491,7 +2491,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadReleaseThreadLock
+### ThreadReleaseThreadLock
 Release a thread lock grabbed with **ThreadGrabThreadLock**. A thread 
 should call this routine once and only once for each time it grabbed the thread 
 lock.
@@ -2508,7 +2508,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### ThreadVSem
+### ThreadVSem
 Release a semaphore (perform a "V" operation on it). This routine should be 
 called once and only once for each call to **ThreadPSem** on the semaphore by 
 the calling thread.
@@ -2527,7 +2527,7 @@ Nothing.
 **Library:** sem.def
 
 ----------
-#### TimerGetCount
+### TimerGetCount
 Return the system time counter, reflecting the total number of ticks since 
 GEOS was started.
 
@@ -2544,7 +2544,7 @@ Nothing (flags preserved).
 **Library:** timer.def
 
 ----------
-#### TimerGetDateAndTime
+### TimerGetDateAndTime
 Return the current date and time.
 
 **Pass:**  
@@ -2565,7 +2565,7 @@ Nothing.
 **Library:** timedate.def
 
 ----------
-#### TimerSetDateAndTime
+### TimerSetDateAndTime
 Set the system's date and time. This routine should not normally be called by 
 any application other than the GEOS Preferences Manager.
 
@@ -2589,7 +2589,7 @@ ax, bx, cx, dx
 **Library:** timedate.def
 
 ----------
-#### TimerSleep
+### TimerSleep
 Block the calling thread for the given length of time. This routine is not an 
 acceptable substitute for the use of semaphores when synchronizing threads.
 
@@ -2605,7 +2605,7 @@ Nothing.
 **Library:** timer.def
 
 ----------
-#### TimerStart
+### TimerStart
 Start an event or routine timer, either continual or one-shot. A routine timer 
 calls a specified routine when time is up; an event timer sends a specified 
 message. A one-shot timer counts only once; a continual timer counts until 
@@ -2669,7 +2669,7 @@ Nothing. Interrupts are in the same state as before.
 **Library:** timer.def
 
 ----------
-#### TimerStartSetOwner
+### TimerStartSetOwner
 This routine is exactly the same as **TimerStart**, above, except that it allows 
 the caller to set the timer's owner. All other aspects of the timer are the same. 
 See **TimerStart** for complete details.
@@ -2687,7 +2687,7 @@ See **TimerStart**.
 **Library:** timer.def
 
 ----------
-#### TimerStop
+### TimerStop
 Stop a timer and remove it. This routine is typically called for continual 
 timers. Note that a continual event timer may have sent one or more events 
 that may be in the recipient's event queue; therefore, you can not assume 
@@ -2707,7 +2707,7 @@ ax, bx
 **Library:** timer.def
 
 ----------
-#### TocAddDisk
+### TocAddDisk
 Add a disk to the disk array
 
 **Pass:**  
@@ -2723,7 +2723,7 @@ Nothing
 **Library:** config.def
 
 ----------
-#### TocCreateNewFile
+### TocCreateNewFile
 create a new TOC file in the current working directory. All subsequent TOC 
 routines will operate on this new file.
 
@@ -2740,7 +2740,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocDBlock
+### TocDBlock
 Lock a DB item in the config library's TOC file.
 
 **Pass:**  
@@ -2755,7 +2755,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocFindCategory
+### TocFindCategory
 Find a category in the Toc file. 
 
 **Pass:**  
@@ -2770,7 +2770,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocGetFileHandle
+### TocGetFileHandle
 Return the TOC file handle.
 
 **Pass:**  
@@ -2785,7 +2785,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocNameArrayAdd
+### TocNameArrayAdd
 Add an element to a TOC name array.
 
 **Pass:**  
@@ -2803,7 +2803,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocNameArrayFind
+### TocNameArrayFind
 Find a name in the passed name array. 
 
 **Pass:**  
@@ -2821,7 +2821,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocNameArrayGetElement
+### TocNameArrayGetElement
 Return data about an element, given its number. 
 
 **Pass:**  
@@ -2839,7 +2839,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocSortedNameArrayAdd
+### TocSortedNameArrayAdd
 Add an element to the name array, inserting it in the proper order.
 
 **Pass:**  
@@ -2857,7 +2857,7 @@ Nothing
 **Library:** config.def
 
 ----------
-#### TocSortedNameArrayFind
+### TocSortedNameArrayFind
 Find a name in a sorted name array.
 
 **Pass:**  
@@ -2877,7 +2877,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TocUpdateCategory
+### TocUpdateCategory
 Create the category if it doesn't exist, and update the file lists by scanning 
 the current directory for files.
 
@@ -2894,7 +2894,7 @@ Nothing.
 **Library:** config.def
 
 ----------
-#### TokenDefineToken
+### TokenDefineToken
 This routine adds a new token and moniker list to the token database. If the 
 token already exists in the token database, the old token will be replaced. 
 This routine may only be called by the thread capable of locking the block 
@@ -2917,7 +2917,7 @@ items), invalidating any stored segment pointers to them.
 **Library:** token.def
 
 ----------
-#### TokenExitTokenDB
+### TokenExitTokenDB
 Close the token database file.
 
 **Pass:**  
@@ -2932,7 +2932,7 @@ Nothing
 **Library:** token.def
 
 ----------
-#### TokenGetTokenInfo
+### TokenGetTokenInfo
 Get information about a token. 
 
 **Pass:**  
@@ -2948,7 +2948,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenInitTokenDB
+### TokenInitTokenDB
 Open the local token database file read/write and, if the path for a globally 
 shared token database appears in the .INI file, open that file shared-multiple 
 read-only.
@@ -2969,7 +2969,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenListTokens
+### TokenListTokens
 Make a list of the tokens in the token.db file and return it in a memory block 
 as an array of **GeodeToken** structures. Along with the list, the number of 
 items in the list is returned. Because groups are mixed in with tokens, we 
@@ -2994,7 +2994,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenLoadMoniker
+### TokenLoadMoniker
 This routine loads a specified token's moniker. 
 
 If you ask that this routine create an LMem block for you, and ds or es is 
@@ -3036,7 +3036,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenLoadToken
+### TokenLoadToken
 Load **TokenEntry** structure for a token into a buffer. 
 
 If you ask that this routine create an LMem block for you, and **ds** or **es** is 
@@ -3068,7 +3068,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenLockTokenMoniker
+### TokenLockTokenMoniker
 Lock moniker for drawing. 
 
 **Pass:**  
@@ -3085,7 +3085,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenLookupMoniker
+### TokenLookupMoniker
 Get the specific moniker for a token, given display type and other attributes. 
 
 **Pass:**  
@@ -3107,7 +3107,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenRemoveToken
+### TokenRemoveToken
 Get information about a token. 
 
 **Pass:**  
@@ -3123,7 +3123,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### TokenUnlockTokenMoniker
+### TokenUnlockTokenMoniker
 This routine unlocks a moniker that had been locked with 
 **TokenLockMoniker**(). Pass a pointer to the locked moniker, as returned by 
 the locking routine. 
@@ -3140,7 +3140,7 @@ Nothing.
 **Library:** token.def
 
 ----------
-#### UserAddAutoExec
+### UserAddAutoExec
 Add an application to the list of those that are to be loaded when the system 
 is booted. This works with the "execOnStartup" field of the initialization 
 field. Welcome is an example of an application that might be executed on 
@@ -3159,7 +3159,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserAddItemToGroup
+### UserAddItemToGroup
 Add a font GenItem to the list, set it usable and set its action/data
 
 **Pass:**  
@@ -3177,7 +3177,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserAllocObjBlock
+### UserAllocObjBlock
 Allocate a block on the heap, to be used for holding UI objects.
 
 **Pass:**  
@@ -3192,7 +3192,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserCallApplication
+### UserCallApplication
 Call application object of process which owns block passed.
 
 **Pass:**  
@@ -3212,7 +3212,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserCallFlow
+### UserCallFlow
 Call the UI flow object.
 
 **Pass:**  
@@ -3231,7 +3231,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserCheckAcceleratorChar
+### UserCheckAcceleratorChar
 Returns carry set if passed an accelerator-type character.
 
 **Pass:**  
@@ -3249,7 +3249,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserCheckInsertableCtrlChar
+### UserCheckInsertableCtrlChar
 Checks passed key to see if it is a control character that maps to an insertable 
 ASCII character.
 
@@ -3268,7 +3268,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserCopyChunkOut
+### UserCopyChunkOut
 This routine copies part of a local memory chunk to another location.
 
 **Pass:**  
@@ -3302,7 +3302,7 @@ bx, dx, di, bp.
 **Library:** ui.def
 
 ----------
-#### UserCreateDialog
+### UserCreateDialog
 Duplicates a template dialog block, attaches the dialog to an application 
 object, and sets it fully usable. The dialog at this point may be used with 
 **UserDoDialog()**. The dialog should be removed and destroyed by the caller 
@@ -3327,7 +3327,7 @@ and invalidating stored segment pointers to them.
 **Library:** ui.def
 
 ----------
-#### UserCreateInkDestinationInfo
+### UserCreateInkDestinationInfo
 This routine creates an **InkDestinationInfo** structure to be returned with 
 MSG_META_QUERY_IF_PRESS_IS_INK.
 
@@ -3349,7 +3349,7 @@ Nothing
 **Library:** ui.def
 
 ----------
-#### UserCreateItem
+### UserCreateItem
 Create a GenItem for a given string.
 
 **Pass:**  
@@ -3370,7 +3370,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserDestroyDialog
+### UserDestroyDialog
 Duplicates a template dialog block, attaches the dialog to an application 
 object, and sets it fully usable. The dialog at this point may be used with 
 **UserDoDialog()**. The dialog should be removed and destroyed by the caller 
@@ -3388,7 +3388,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserDiskRestore
+### UserDiskRestore
 Front-end for **DiskRestore** that automatically passes a callback function to 
 prompt for the disk, if **DiskRestore** can't do it by itself.
 
@@ -3406,7 +3406,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserDoDialog
+### UserDoDialog
 This routine allows the application to invoke a dialog (GenInteraction set up 
 to be a modal dialog) and block until the user responds. The passed object 
 must be linked into a generic tree and be fully usable. Where possible, use 
@@ -3428,7 +3428,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserGetDefaultMonikerFont
+### UserGetDefaultMonikerFont
 Get the UI moniker font, size for the passed object.
 
 **Pass:**  
@@ -3446,7 +3446,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserGetDisplayType
+### UserGetDisplayType
 Get the display type for the passed object. Currently reads the global variable 
 **uiDisplayType**, set by GenScreen in 
 MSG_GEN_SCREEN_SET_VIDEO_DRIVER.
@@ -3467,7 +3467,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserGetInitFileCategory
+### UserGetInitFileCategory
 Utility routine to fetch .ini category for an object. Test application 
 optimization flag for single category, to avoid recursive search if possible.
 
@@ -3484,7 +3484,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserGetKbdAcceleratorMode
+### UserGetKbdAcceleratorMode
 Returns keyboard accelerator mode status.
 
 **Pass:**  
@@ -3499,7 +3499,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserGetOverstrikeMode
+### UserGetOverstrikeMode
 Returns overstrike mode status.
 
 **Pass:**  
@@ -3514,7 +3514,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserGetSpecUIProtocolRequirement
+### UserGetSpecUIProtocolRequirement
 Returns any protocol number that should be passed to **GeodeUseLibrary** in 
 any attempt to load a specific user interface for use with this geode.
 
@@ -3531,7 +3531,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserHaveProcessCopyChunkIn
+### UserHaveProcessCopyChunkIn
 This routine figures out which process runs the destination block and sends 
 MSG_PROCESS_COPY_CHUNK_IN to it.
 
@@ -3550,7 +3550,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserHaveProcessCopyChunkOut
+### UserHaveProcessCopyChunkOut
 This routine figures out which process runs the source block and sends 
 MSG_PROCESS_COPY_CHUNK_OUT to it. The source optr must be in an 
 object block (the **otherInfo** field must be a thread handle).
@@ -3570,7 +3570,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserHaveProcessCopyChunkOver
+### UserHaveProcessCopyChunkOver
 This routine figures out which process runs the destination block and sends 
 MSG_PROCESS_COPY_CHUNK_OVER to it.
 
@@ -3589,7 +3589,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserLoadApplication
+### UserLoadApplication
 Loads a GEOS application. Changes to standard application directory before 
 attempting GeodeLoad on filename passed. Stores the filename being 
 launched into the **AppLaunchBlock**, so that information needed to restore 
@@ -3654,7 +3654,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserLoadExtendedDriver
+### UserLoadExtendedDriver
 Load an extended driver given the category of the .INI file in which to find the 
 "device" and "driver" keys for the thing.
 
@@ -3677,7 +3677,7 @@ cx, dx, di, si.
 **Library:** ui.def
 
 ----------
-#### UserMessageIM
+### UserMessageIM
 Send a message to the input manager.
 
 **Pass:**  
@@ -3696,7 +3696,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserRegisterForTextContext
+### UserRegisterForTextContext
 Registers the passed object to receive context data.
 
 **Pass:**  
@@ -3711,7 +3711,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserRemoveAutoExec
+### UserRemoveAutoExec
 Remove an application from the list of those to be launched on start-up.
 
 **Pass:**  
@@ -3726,7 +3726,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserScreenRegister
+### UserScreenRegister
 Register another screen for GenScreen.
 
 **Pass:**  
@@ -3742,7 +3742,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserSendToApplicationViaProcess
+### UserSendToApplicationViaProcess
 Call the application object, but only after a method has been passed fully 
 through the owning application's process.
 
@@ -3761,7 +3761,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserSetDefaultMonikerFont
+### UserSetDefaultMonikerFont
 Set the font and font size to use when drawing UI monikers.
 
 **Pass:**  
@@ -3777,7 +3777,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserSetOverstrikeMode
+### UserSetOverstrikeMode
 Sets the overstrike mode in the initialization file.
 
 **Pass:**  
@@ -3792,7 +3792,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UserStandardSound
+### UserStandardSound
 Play a standard sound.
 
 **Pass:**  
@@ -3814,7 +3814,7 @@ di.
 **Library:** ui.def
 
 ----------
-#### UserUnregisterForTextContext
+### UserUnregisterForTextContext
 Unregisters the passed object to receive context data.
 
 **Pass:**  
@@ -3829,7 +3829,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UtilAsciiToHex32
+### UtilAsciiToHex32
 Converts a null-terminated ASCII string into a dword. The string may be 
 signed or unsigned.
 
@@ -3847,7 +3847,7 @@ Nothing.
 **Library:** ui.def
 
 ----------
-#### UtilHex32ToAscii
+### UtilHex32ToAscii
 Converts 32-bit unsigned number to its ASCII representation. The number 
 may be signed or unsigned.
 

--- a/TechDocs/Markdown/Asmref/asmstrac.md
+++ b/TechDocs/Markdown/Asmref/asmstrac.md
@@ -4,7 +4,7 @@ Global data structures and types are listed alphabetically below. Some data stru
 ## 3.1 Structures A-C
 
 ----------
-#### ActionDescriptor
+### ActionDescriptor
     ActionDescriptor        struct
         AD_OD               optr
         AD_message          word
@@ -16,7 +16,7 @@ optr of the destination for that message.
 **Library:** ui.def
 
 ----------
-#### ActivateCreateFlags
+### ActivateCreateFlags
     ActivateCreateFlags         record
         ACF_NOTIFY      :   1       ;notify selected objects that
                                     ;tool is activating
@@ -25,7 +25,7 @@ optr of the destination for that message.
 **Library:** grobj.def
 
 ----------
-#### ActivationData
+### ActivationData
     ActivationData      struc
         AD_dialog           optr    ; On-screen "Activating..." dialog.
         AD_appLaunchBlock   hptr    ; Initial AppLaunchBlock - not used once 
@@ -41,7 +41,7 @@ optr of the destination for that message.
 **Library:** grobj.def
 
 ----------
-#### ActiveSearchSpellType
+### ActiveSearchSpellType
     ActiveSearchSpellType               etype   byte, 0, 1
         ASST_NOTHING_ACTIVE         enum    ActiveSearchSpellType
         ASST_SPELL_ACTIVE           enum    ActiveSearchSpellType
@@ -50,7 +50,7 @@ optr of the destination for that message.
 **Library:** Objects/vTextC.def
 
 ----------
-#### AddChildRelativeParams
+### AddChildRelativeParams
     AddChildRelativeParams          struct
         ACRP_child          optr            ;the object to add
         ACRP_parent         optr            ;the visual parent to use
@@ -60,7 +60,7 @@ optr of the destination for that message.
 **Library:** Objects/visC.def
 
 ----------
-#### AddUndoActionFlags
+### AddUndoActionFlags
     AddUndoActionFlags          record
         AUAF_NOTIFY_BEFORE_FREEING                      :1  
         AUAF_NOTIFY_IF_FREED_WITHOUT_BEING_PLAYED_BACK  :1
@@ -78,7 +78,7 @@ played back.
 **Library:** Objects/gProcC.def
 
 ----------
-#### AddUndoActionStruct
+### AddUndoActionStruct
     AddUndoActionStruct         struct
         AUAS_data           UndoActionStruct
         AUAS_output         optr
@@ -95,7 +95,7 @@ MSG_META_CLIPBOARD_UNDO.
 **Library:** Objects/gProc.def
 
 ----------
-#### AddVarDataParams
+### AddVarDataParams
     AddVarDataParams            struct
         AVDP_data           fptr;
         AVDP_dataSize       word;
@@ -113,7 +113,7 @@ be initialized to zero.
 **Library:** Objects/metaC.def
 
 ----------
-#### AdjustType
+### AdjustType
     AdjustType      etype   byte, 0, 1
         AT_NORMAL       enum        AdjustType
         AT_PASTE        enum        AdjustType
@@ -122,7 +122,7 @@ be initialized to zero.
 **Library:** Objects/vTextC.def
 
 ----------
-#### AfterAddedToGroupData
+### AfterAddedToGroupData
     AfterAddedToGroupData           struct
         AATGD_group             optr;
         AATGD_centerAdjust      PointDWFixed;
@@ -136,7 +136,7 @@ to position it correctly.
 **Library:** grobj.def
 
 ----------
-#### AfterEditAction
+### AfterEditAction
     AfterEditAction         etype   byte, 0
         DONT_SELECT_AFTER_EDIT      enum        AfterEditAction
         SELECT_AFTER_EDIT           enum        AfterEditAction
@@ -144,7 +144,7 @@ to position it correctly.
 **Library:** grobj.def
 
 ----------
-#### AlignParams
+### AlignParams
     AlignParams             struct
         AP_x            DWFixed
         AP_y            DWFixed
@@ -156,7 +156,7 @@ to position it correctly.
 **Library:** grobj.def
 
 ----------
-#### AlignToGridType
+### AlignToGridType
     AlignToGridType         record
         ATGT_LEFT       :1
         ATGT_H_CENTER   :1
@@ -169,7 +169,7 @@ to position it correctly.
 **Library:** grobj.def
 
 ----------
-#### AlignType
+### AlignType
     AlignType               record
         AT_ALIGN_X      :1
         AT_DISTRIBUTE_X :1
@@ -182,7 +182,7 @@ to position it correctly.
 **Library:** grobj.def
 
 ----------
-#### AnotherToolActivatedFlags
+### AnotherToolActivatedFlags
     AnotherToolActivatedFlags               record
         ATAF_STANDARD_POINTER       :1
         ATAF_SHAPE                  :1
@@ -206,7 +206,7 @@ A Vis guardian object
 **Library:** grobj.def
 
 ----------
-#### AppAttachFlags
+### AppAttachFlags
     AppAttachFlags                  record
         AAF_RESTORING_FROM_STATE        :1
         AAF_STATE_FILE_PASSED           :1
@@ -242,7 +242,7 @@ AAF_RESTORING_FROM_STATE will also be set.
 **Library:** Objects/gProcC.def
 
 ----------
-#### AppInstanceReference
+### AppInstanceReference
     AppInstanceReference            struct
         AIR_fileName            char PATH_BUFFER_SIZE dup (?)
         AIR_stateFile           char FILE_LONGNAME_BUFFER_SIZE dup (?)
@@ -274,7 +274,7 @@ instance data is saved to state.
 **Library:** Objects/gProcC.def
 
 ----------
-#### AppLaunchBlock
+### AppLaunchBlock
     AppLaunchBlock      struct
         ALB_appRef          AppInstanceReference
         ALB_appMode         word
@@ -349,7 +349,7 @@ handle to a block containing extra arguments).
 **Library:** Objects/gProcC.def
 
 ----------
-#### AppLaunchFlags
+### AppLaunchFlags
     AppLaunchFlags          record
         ALF_SEND_LAUNCH_REQUEST_TO_UI_TO_HANDLE     :1
         ALF_OPEN_IN_BACK                            :1
@@ -397,7 +397,7 @@ to remain open after the IACP connection is closed.
 **Library:** Objects/gProcC.def
 
 ----------
-#### ApplicationStates
+### ApplicationStates
     ApplicationStates           record
                                         :1
         AS_TRANSPARENT                  :1
@@ -478,7 +478,7 @@ Set if the application is in the process of attaching.
 **Library:** Objects/gAppC.def
 
 ----------
-#### AppMeasurementType
+### AppMeasurementType
     AppMeasurementType      etype       byte
         AMT_US      enum        AppMeasurementType, MEASURE_US
         AMT_METRIC  enum        AppMeasurementType, MEASURE_METRIC
@@ -487,7 +487,7 @@ Set if the application is in the process of attaching.
 **Library:** Objects/gAppC.def
 
 ----------
-#### AppNavigationID
+### AppNavigationID
     AppNavigationID     etype       word, NAVIGATION_ID_APP_START
         NAVIGATION_ID_START_OF_RANGE    equ     0x8000
 
@@ -498,7 +498,7 @@ start of a range.
 **Library:** Objects/genC.def
 
 ----------
-#### AppUIData
+### AppUIData
     AppUIData       struct
         AUID_specificUI             hptr            ;handle of specific UI
         AUID_displayScheme          DisplayScheme <>
@@ -516,7 +516,7 @@ This structure stores the UI data stored with each process.
 **Library:** Objects/gAppC.def
 
 ----------
-#### ApplicationOptFlags
+### ApplicationOptFlags
     ApplicationOptFlags         record
         AOF_MULTIPLE_INIT_FILE_CATEGORIES   :1
                                             :7
@@ -529,7 +529,7 @@ application has only one init file category.
 **Library:** Objects/gAppC.def
 
 ----------
-#### ArcCloseType
+### ArcCloseType
     ArcCloseType        etype       word
         ACT_OPEN    enum        ArcCloseType    ; illegal for filled arcs
         ACT_CHORD   enum        ArcCloseType    ; draw/fill as a chord
@@ -538,7 +538,7 @@ application has only one init file category.
 **Library:** graphics.def
 
 ----------
-#### ArcBasicInit
+### ArcBasicInit
     ArcBasicInit        struct
         ABI_arcCloseType        ArcCloseType
         ABI_startAngle          WWFixed
@@ -552,7 +552,7 @@ application has only one init file category.
 **Library:** grobj.def
 
 ----------
-#### ArcParams
+### ArcParams
     ArcParams           struct
         AP_close    ArcCloseTyp     ; how the arc should be closed
         AP_left     sword           ; ellipse bounding box: left
@@ -568,7 +568,7 @@ application has only one init file category.
 **Library:** graphics.def
 
 ----------
-#### AreaAttr
+### AreaAttr
     AreaAttr        struct
         AA_colorFlag    ColorFlag CF_INDEX      ; RGB or INDEX
         AA_color        RGBValue <0,0,0>        ; RGB values or index
@@ -581,7 +581,7 @@ This structure is used with **GrSetAreaAttr**.
 **Library:** graphics.def
 
 ----------
-#### ArgumentStackElement
+### ArgumentStackElement
     ArgumentStackElement            struct
         ASE_type        EvalStackArgumentType   ; The type of argument.
         ASE_data        EvalStackArgumentData   ; The associated data.
@@ -590,7 +590,7 @@ This structure is used with **GrSetAreaAttr**.
 **Library:** parse.def
 
 ----------
-#### BackgroundColors
+### BackgroundColors
     BackgroundColors        struc
         BC_unselectedColor1     byte    ;the two colors to use when unselected
         BC_unselectedColor2     byte
@@ -601,7 +601,7 @@ This structure is used with **GrSetAreaAttr**.
 **Library:** Objects/genC.def
 
 ----------
-#### BasicGrab
+### BasicGrab
     BasicGrab               struct
         BG_OD       optr
         BG_data     word
@@ -616,7 +616,7 @@ may operate on the different structures.
 **Library:** Objects/uiInputC.def
 
 ----------
-#### BasicInit
+### BasicInit
     BasicInit       struct
         BI_center       PointDWFixed
         BI_width        WWFixed
@@ -628,7 +628,7 @@ may operate on the different structures.
 **Library:** grobj.def
 
 ----------
-#### BBFixed
+### BBFixed
     BBFixed     struct
         BBF_frac        byte
         BBF_int         byte
@@ -639,14 +639,14 @@ This structure stores an 8 bit/8 bit fixed point number.
 **Library:** geos.def
 
 ----------
-#### BCCToolboxFeatures
+### BCCToolboxFeatures
     BCCToolboxFeatures          record
     BCCToolboxFeatures          end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### BCFeatures
+### BCFeatures
     BCFeatures              record
         BCF_LIST        :1
         BCF_CUSTOM      :1
@@ -655,14 +655,14 @@ This structure stores an 8 bit/8 bit fixed point number.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### BCToolboxFeatures
+### BCToolboxFeatures
     BCToolboxFeatures       record
     BCToolboxFeatures       end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### Bitmap
+### Bitmap
     Bitmap  struct
         B_width     word
         B_height    word
@@ -682,7 +682,7 @@ This structure stores information about a simple graphics bitmap.
 **Library:** graphics.def
 
 ----------
-#### BitmapGuardianBitmapPointerActiveStatus
+### BitmapGuardianBitmapPointerActiveStatus
     BitmapGuardianBitmapPointerActiveStatus etype byte, 0
         BGBPAS_ACTIVE       enum    BitmapGuardianBitmapPointerActiveStatus
         BGBPAS_INACTIVE     enum    BitmapGuardianBitmapPointerActiveStatus
@@ -690,7 +690,7 @@ This structure stores information about a simple graphics bitmap.
 **Library:** grobj.def
 
 ----------
-#### BitmapGuardianFlags
+### BitmapGuardianFlags
     BitmapGuardianFlags             record
         BGF_POINTER_ACTIVE              :1
         BGF_REAL_ESTATE_RESIZE          :1
@@ -709,7 +709,7 @@ resize.
 **Library:** grobj.def
 
 ----------
-#### BitmapGuardianSpecificInitializationData
+### BitmapGuardianSpecificInitializationData
     BitmapGuardianSpecificInitializationData    struct
         BGSID_toolClass                 fptr.ClassStruct
         BGSID_activeStatus              VisWardToolActiveStatus
@@ -718,7 +718,7 @@ resize.
 **Library:** grobj.def
 
 ----------
-#### BitmapMode
+### BitmapMode
     BitmapMode      record
                                 :14
         BM_EDIT_MASK            :1
@@ -735,7 +735,7 @@ dispersed dither.
 **Library:** graphics.def
 
 ----------
-#### BLTMode
+### BLTMode
     BLTMode etype   word
         BLTM_COPY       enum BLTMode        ; 0 = copy image
         BLTM_MOVE       enum BLTMode        ; 1 = move image
@@ -744,7 +744,7 @@ dispersed dither.
 **Library:** graphics.def
 
 ----------
-#### BMCompact
+### BMCompact
     BMCompact       etype       byte
         BMC_UNCOMPACTED     enum BMCompact          ; 0 = no compaction
         BMC_PACKBITS        enum BMCompact          ; 1 = Mac packbits
@@ -757,7 +757,7 @@ store a graphics bitmap.
 **Library:** graphics.def
 
 ----------
-#### BMDestroy
+### BMDestroy
     BMDestroy       etype       byte
         BMD_KILL_DATA       enum BMDestroy      ; 0 = free bitmap (HugeArray)
         BMD_LEAVE_DATA      enum BMDestroy      ; 1 = leave bitmap data alone
@@ -765,7 +765,7 @@ store a graphics bitmap.
 **Library:** graphics.def
 
 ----------
-#### BMFormat
+### BMFormat
     BMFormat        etype       byte, 0
         BMF_MONO        enum BMFormat       ; 0 = monochrome
         BMF_4BIT        enum BMFormat       ; 1 = 4-bit (EGA,VGA)
@@ -779,7 +779,7 @@ This type determines a graphic bitmap's depth.
 **Library:** graphics.def
 
 ----------
-#### BMType
+### BMType
     BMType      record
         BMT_PALETTE         :1
         BMT_HUGE            :1
@@ -810,7 +810,7 @@ The type of bitmap format (**BMFormat**) is specified here.
 **Library:** graphics.def
 
 ----------
-#### BooleanByte
+### BooleanByte
     BooleanByte             etype       byte
         BB_FALSE    enum        BooleanByte, 0
         BB_TRUE     enum        BooleanByte, 255
@@ -818,7 +818,7 @@ The type of bitmap format (**BMFormat**) is specified here.
 **Library:** geos.def
 
 ----------
-#### BooleanWord
+### BooleanWord
     BooleanWord             etype       word
         BW_FALSE    enum        BooleanWord, 0
         BW_TRUE     enum        BooleanWord, 0ffffh
@@ -826,7 +826,7 @@ The type of bitmap format (**BMFormat**) is specified here.
 **Library:** geos.def
 
 ----------
-#### BoundingRectData
+### BoundingRectData
     BoundingRectData            struct
         BRD_rect            RectDWFixed
         CheckHack           < (offset BRD_rect eq 0) >
@@ -841,7 +841,7 @@ generally ignored except by groups.
 **Library:** grobj.def
 
 ----------
-#### BranchReplaceParams
+### BranchReplaceParams
     BranchReplaceParams                 struct
         BRP_searchParam         dd  (?)
         BRP_replaceParam        dd  (?)
@@ -862,7 +862,7 @@ values should be stored in first word, single byte in first byte.
 **Library:** Objects/genC.def
 
 ----------
-#### BranchReplaceParamType
+### BranchReplaceParamType
     BranchReplaceParamType          etype       word
         BRPT_OUTPUT_OPTR        enum    BranchReplaceParamType
 
@@ -880,7 +880,7 @@ GenView: output optr's.
 **Library:** Objects/genC.def
 
 ----------
-#### Button
+### Button
     Button  etype   byte
         BUTTON_0        enum        Button
         BUTTON_1        enum        Button
@@ -890,7 +890,7 @@ GenView: output optr's.
 **Library:** input.def
 
 ----------
-#### ButtonInfo
+### ButtonInfo
     ButtonInfo          record
         BI_PRESS            :1
         BI_DOUBLE_PRESS     :1
@@ -906,7 +906,7 @@ This record defines the active state of a mouse's buttons.
 **Library:** input.def
 
 ----------
-#### C_CallbackStruct
+### C_CallbackStruct
     C_CallbackStruct        struc
         C_callbackType  CallbackType
         C_params        fptr
@@ -918,7 +918,7 @@ This record defines the active state of a mouse's buttons.
 **Library:** parse.def
 
 ----------
-#### C_CallbackUnion
+### C_CallbackUnion
     C_CallbackUnion     union
         CT_ftt      CT_FFT_CallbackStruct
         CT_ntt      CT_NTT_CallbackStruct
@@ -940,7 +940,7 @@ This record defines the active state of a mouse's buttons.
 **Library:** parse.def
 
 ----------
-#### CallBackMessageData
+### CallBackMessageData
     CallBackMessageData         struct
         CBMD_callBackOD             optr
         CBMD_callBackMessage        word
@@ -953,7 +953,7 @@ This record defines the active state of a mouse's buttons.
 **Library:** grobj.def
 
 ----------
-#### CallbackType
+### CallbackType
     CallbackType        etype       byte, 0, 1
         CT_FUNCTION_TO_TOKEN            enum        CallbackType
             ; Description:
@@ -1140,7 +1140,7 @@ This record defines the active state of a mouse's buttons.
 **Library:** parse.def
 
 ----------
-#### CBitmap
+### CBitmap
     CBitmap struct
         CB_simple       Bitmap <>           ; simple bitmap structure
         CB_startScan    word 0              ; starting row number
@@ -1167,7 +1167,7 @@ and mask data.
 **Library:** graphics.def
 
 ----------
-#### CDependencyStruct
+### CDependencyStruct
     CDependencyStruct       struc
         DP_parameters               DependencyParameters
         DP_callbackPtr              fptr
@@ -1177,7 +1177,7 @@ and mask data.
 **Library:** parse.def
 
 ----------
-#### CellFunctionParameterFlags
+### CellFunctionParameterFlags
     CellFunctionParameterFlags              record
         CFPF_DIRTY          :1  ;If set, the parameter block is dirty.
                             :4  ;Unused.
@@ -1190,7 +1190,7 @@ and mask data.
 **Library:** cell.def
 
 ----------
-#### CellFunctionParameters
+### CellFunctionParameters
     CellFunctionParameters          struct
         CFP_flags           CellFunctionParameterFlags
         CFP_file            word
@@ -1224,7 +1224,7 @@ item in a cell file, you must not have the structure be an ungrouped item.
 **Library:** cell.def
 
 ----------
-#### CellRange
+### CellRange
     CellRange       struct
         CR_start        CellReference <>
         CR_end          CellReference <>
@@ -1235,7 +1235,7 @@ This structure specifies a rectangular range of cells
 **Library:** parse.def
 
 ----------
-#### CellReference
+### CellReference
     CellReference       struct
         CR_row      CellRowColumn <>
         CR_column   CellRowColumn <>
@@ -1248,7 +1248,7 @@ this structure specifies an offset from a previous cell position.
 **Library:** parse.def
 
 ----------
-#### CellRowColumn
+### CellRowColumn
     CellRowColumn       record
         CRC_ABSOLUTE            :1  ; Set if the reference is absolute
         CRC_VALUE               :15 ; The value of the row/column
@@ -1257,7 +1257,7 @@ this structure specifies an offset from a previous cell position.
 **Library:** parse.def
 
 ----------
-#### CenterLeftRightWidth
+### CenterLeftRightWidth
     CenterLeftRightWidth            etype       byte
         CLRW_CENTER         enum    CenterLeftRightWidth
         CLRW_LEFT           enum    CenterLeftRightWidth
@@ -1267,7 +1267,7 @@ this structure specifies an offset from a previous cell position.
 **Library:** grobj.def
 
 ----------
-#### CenterTopBottomHeight
+### CenterTopBottomHeight
     CenterTopBottomHeight           etype       byte
         CTBH_CENTER         enum    CenterTopBottomHeight
         CTBH_TOP            enum    CenterTopBottomHeight
@@ -1277,7 +1277,7 @@ this structure specifies an offset from a previous cell position.
 **Library:** grobj.def
 
 ----------
-#### CEvalStruct
+### CEvalStruct
     CEvalStruct     struc
         CE_parameters           EvalParameters
         CE_callbackPtr          fptr
@@ -1287,7 +1287,7 @@ this structure specifies an offset from a previous cell position.
 **Library:** parse.def
 
 ----------
-#### CFormatStruct
+### CFormatStruct
     CFormatStruct       struc
         CF_parameters           FormatParameters
         CF_callbackPtr          fptr
@@ -1297,7 +1297,7 @@ this structure specifies an offset from a previous cell position.
 **Library:** parse.def
 
 ----------
-#### CharacterSet
+### CharacterSet
     CharacterSet        etype       byte
         CS_BSW      enum CharacterSet, 0x00 ;Extended BSW set (printable) (Chars)
         CS_CONTROL  enum CharacterSet, 0xff ;Control codes (non-printable) (VChar)
@@ -1310,7 +1310,7 @@ this structure specifies an offset from a previous cell position.
 **Library:** input.def
 
 ----------
-#### CharChoiceInformation
+### CharChoiceInformation
     CharChoiceInformation               struct
         CCI_numChoices          word
         CCI_firstPoint          word
@@ -1331,7 +1331,7 @@ to this char.
 **Library:** hwr.def
 
 ----------
-#### CharFlags
+### CharFlags
     CharFlags       record
         CF_STATE_KEY    :1  ;Set if state key (shift/toggle modifier)
             :2
@@ -1349,7 +1349,7 @@ to this char.
 **Library:** input.def
 
 ----------
-#### Chars
+### Chars
     Chars   etype   byte
 
         C_NULL          enum Chars, 0x0         ;NULL
@@ -1670,7 +1670,7 @@ to this char.
 **Library:** char.def
 
 ----------
-#### CharTableData
+### CharTableData
     CharTableData           struct
         CTD_line1       optr
         CTD_line2       optr
@@ -1684,7 +1684,7 @@ This structure is used during notification of the pen object.
 **Library:** Objects/gPenICC.def
 
 ----------
-#### ChunkArrayHeader
+### ChunkArrayHeader
     ChunkArrayHeader            struct
         CAH_count           word
         CAH_elementSize     word
@@ -1713,7 +1713,7 @@ the array.
 **Library:** chunkarr.def
 
 ----------
-#### ChunkMapList
+### ChunkMapList
     ChunkMapList        struc
         CML_source          word
         CML_dest            word
@@ -1722,7 +1722,7 @@ the array.
 **Library:** impex.def
 
 ----------
-#### ClassFlags
+### ClassFlags
     ClassFlags      record
         CLASSF_HAS_DEFAULT      :1  ; Set if dword before the class record
                                     ; contains an fptr of a default method
@@ -1752,7 +1752,7 @@ flags are internal and may not be set or retrieved directly.
 **Library:** object.def
 
 ----------
-#### ClassStruct
+### ClassStruct
     ClassStruct         struct
         Class_superClass            fptr.ClassStruct
         Class_masterOffset          word
@@ -1792,7 +1792,7 @@ presence of method handlers for a given master level.
 **Library:** object.def
 
 ----------
-#### ClipboardItemFlags
+### ClipboardItemFlags
     ClipboardItemFlags          record
         CIF_UNUSED          :1
         CIF_QUICK           :1
@@ -1802,7 +1802,7 @@ presence of method handlers for a given master level.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### ClipboardItemFormat
+### ClipboardItemFormat
     ClipboardItemFormat     etype       word
         CIF_TEXT                enum        ClipboardItemFormat
         CIF_GRAPHICS_STRING     enum        ClipboardItemFormat
@@ -1829,7 +1829,7 @@ direct-manipulation file operations.
 **Library:** geoworks.def
 
 ----------
-#### ClipboardItemFormatID
+### ClipboardItemFormatID
     ClipboardItemFormatID           struct
         CIFID_manufacturer              ManufacturerID
         CIFID_type                      ClipboardItemFormat
@@ -1841,7 +1841,7 @@ other is a manufacturer-specific value that specifies the actual format.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### ClipboardItemFormatInfo
+### ClipboardItemFormatInfo
     ClipboardItemFormatInfo         struct
         ;
         ; two words of format identification
@@ -1873,7 +1873,7 @@ handle of the first VM block in a chain of VM data blocks for the format.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### ClipboardItemHeader
+### ClipboardItemHeader
     ClipboardItemHeader         struct
         CIH_owner           optr
         CIH_flags           ClipboardItemFlags
@@ -1912,7 +1912,7 @@ given transfer item must be in the same VM file).
 **Library:** Objects/clipbrd.def
 
 ----------
-#### ClipboardQuickNotifyFlags
+### ClipboardQuickNotifyFlags
     ClipboardQuickNotifyFlags           record
         CQNF_ERROR              :1
         CQNR_SOURCE_EQUAL_DEST  :1
@@ -1928,7 +1928,7 @@ operation.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### ClipboardQuickTransferFeedback
+### ClipboardQuickTransferFeedback
     ClipboardQuickTransferFeedback              etype word
         CQTF_SET_DEFAULT        enum        ClipboardQuickTransferFeedback
         CQTF_CLEAR_DEFAULT      enum        ClipboardQuickTransferFeedback
@@ -1956,7 +1956,7 @@ Clears any move/copy cursors present.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### ClipboardQuickTransferFlags
+### ClipboardQuickTransferFlags
     ClipboardQuickTransferFlags             record
         CQTF_IN_PROGRESS        :1      ; internal
         CQTF_COPY_ONLY          :1      ; if the source only supports copying
@@ -1970,7 +1970,7 @@ Clears any move/copy cursors present.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### ClipboardQuickTransferRegionInfo
+### ClipboardQuickTransferRegionInfo
     ClipboardQuickTransferRegionInfo            struct
         CQTRI_paramAX               word
         CQTRI_paramBX               word
@@ -1988,7 +1988,7 @@ use include CQTF_USE_REGION.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### Color
+### Color
     Color       etype   byte
         C_BLACK         enum Color      ; black color index
         C_BLUE          enum Color      ; dark blue color index
@@ -2262,7 +2262,7 @@ use include CQTF_USE_REGION.
 **Library:** color.def
 
 ----------
-#### ColoredObjectOrientation
+### ColoredObjectOrientation
     ColoredObjectOrientation        etype       byte
         COO_AREA_ORIENTED               enum        ColoredObjectOrientation
         COO_TEXT_ORIENTED               enum        ColoredObjectOrientation
@@ -2271,7 +2271,7 @@ use include CQTF_USE_REGION.
 **Library:** Objects/colorC.def
 
 ----------
-#### ColorFlag
+### ColorFlag
     ColorFlag           etype       byte
         CF_INDEX    enum    ColorFlag           ; set color with index
         CF_GRAY     enum    ColorFlag           ; set color with gray value
@@ -2287,7 +2287,7 @@ information about how to interpret color specifications using **ColorFlags**.
 **Library:** color.def
 
 ----------
-#### ColorMapMode
+### ColorMapMode
     ColorMapMode            record
         CMM_ON_BLACK    :1                  ; 1 if drawing on black
                         :1
@@ -2297,7 +2297,7 @@ information about how to interpret color specifications using **ColorFlags**.
 **Library:** graphics.def
 
 ----------
-#### ColorMapType
+### ColorMapType
     ColorMapType            etype       byte
         CMT_CLOSEST     enum    ColorMapType    ; Map to closest solid color
         CMT_DITHER      enum    ColorMapType    ; Map to dither pattern
@@ -2305,7 +2305,7 @@ information about how to interpret color specifications using **ColorFlags**.
 **Library:** graphics.def
 
 ----------
-#### ColorModifiedStates
+### ColorModifiedStates
     ColorModifiedStates         record
         CMS_COLOR_CHANGED           :1
         CMS_DRAW_MASK_CHANGED       :1
@@ -2315,7 +2315,7 @@ information about how to interpret color specifications using **ColorFlags**.
 **Library:** colorC.def
 
 ----------
-#### ColorQuad
+### ColorQuad
     ColorQuad       struct
         CQ_redOrIndex   byte
         CQ_info         ColorFlag
@@ -2351,7 +2351,7 @@ are all ignored.
 **Library:** color.def
 
 ----------
-#### ColorScheme
+### ColorScheme
     ColorScheme     record
         CS_lightColor       Color:4
         CS_darkColor        Color:4
@@ -2360,7 +2360,7 @@ are all ignored.
 **Library:** Objects/visC.def
 
 ----------
-#### ColorToolboxPreferences
+### ColorToolboxPreferences
     ColorToolboxPreferences             record
                                     :2
         CTP_INDEX_ORIENTATION       :2      ;ColoredObjectOrientation
@@ -2372,7 +2372,7 @@ are all ignored.
 **Library:** colorC.def
 
 ----------
-#### ColorTransfer
+### ColorTransfer
     ColorTransfer       struct
         CT_data     RGBDelta 5*5*5 dup (?)      ; 375 bytes of data.
     ColorTransfer       ends
@@ -2384,7 +2384,7 @@ correction is done by doing a lookup in the 3D table and applying the
 **Library:** color.def
 
 ----------
-#### ColumnArrayElement
+### ColumnArrayElement
     ColumnArrayElement          struct
         CAE_column      byte        ; The column number in which the cell resides.
         CAE_data        DBaseItem   ; The item containing the cell data.
@@ -2393,7 +2393,7 @@ correction is done by doing a lookup in the 3D table and applying the
 **Library:** cell.def
 
 ----------
-#### ColumnArrayHeader
+### ColumnArrayHeader
     ColumnArrayHeader       struct
         CAH_numEntries          word    ; Number of entries in the array.
         CAH_rowFlags            word    ; Flags that exist for each row.
@@ -2402,7 +2402,7 @@ correction is done by doing a lookup in the 3D table and applying the
 **Library:** cell.def
 
 ----------
-#### CommonParameters
+### CommonParameters
     CommonParameters            struct
         CP_row              word    ; Current row
         CP_column           word    ; Current column
@@ -2419,7 +2419,7 @@ structures.
 **Library:** parse.def
 
 ----------
-#### CommonTransferParams
+### CommonTransferParams
     CommonTransferParams            struct
         CTP_range           VisTextRange
         CTP_pasteFrame      word            ;ptr to frame if quick paste.
@@ -2433,7 +2433,7 @@ This structure stores parameters sent on the stack to all transfer routines.
 **Library:** Objects/vTextC.def
 
 ----------
-#### CompChildFlags
+### CompChildFlags
     CompChildFlags      record
         CCF_MARK_DIRTY  :1,     ; Marks chunk and modified objects as
                                 ; dirty
@@ -2459,7 +2459,7 @@ CCO_LAST specifying the absolute first or last position.
 **Library:** Objects/metaC.def
 
 ----------
-#### CompPart
+### CompPart
     CompPart        struct
         CP_firstChild       optr        ; 0 = no children.
     CompPart        ends
@@ -2467,7 +2467,7 @@ CCO_LAST specifying the absolute first or last position.
 **Library:** Objects/metaC.def
 
 ----------
-#### CompSizeHintArgs
+### CompSizeHintArgs
     CompSizeHintArgs            struct
         CSHA_width      SpecWidth <>    ; Width of the composite.
         CSHA_height     SpecHeight <>   ; Height of each child.
@@ -2480,7 +2480,7 @@ HINT_MAXIMUM_SIZE and HINT_INITIAL_SIZE.
 **Library:** Objects/genC.def
 
 ----------
-#### ContextData
+### ContextData
     ContextData     struct
         CD_object           optr
         CD_numChars         dword
@@ -2502,7 +2502,7 @@ HINT_MAXIMUM_SIZE and HINT_INITIAL_SIZE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### ContextLocation
+### ContextLocation
     ContextLocation     etype       word
         CL_STARTING_AT_POSITION             enum        ContextLocation
         CL_ENDING_AT_POSITION               enum        ContextLocation
@@ -2535,13 +2535,13 @@ Retrieves the selection or surrounding word.
 **Library:** Objects/vTextC.def
 
 ----------
-#### ContextValues
+### ContextValues
     ContextValues       etype word, 0
 
 **Library:** ec.def
 
 ----------
-#### CopyChunkFlags
+### CopyChunkFlags
     CopyChunkFlags          record
         CCF_DIRTY       :1
         CCF_MODE        CopyChunkMode:2
@@ -2556,7 +2556,7 @@ IGNORE_DIRTY
 **Library:** Objects/processC.def
 
 ----------
-#### CopyChunkInFrame
+### CopyChunkInFrame
     CopyChunkInFrame        struct
         CCIF_copyFlags          CopyChunkFlags
         CCIF_source             dword
@@ -2570,7 +2570,7 @@ This structure is passed on the stack to MSG_PROCESS_COPY_CHUNK_IN.
 **Library:** Objects/process.def
 
 ----------
-#### CopyChunkMode
+### CopyChunkMode
     CopyChunkMode           etype       byte
         CCM_OPTR        enum        CopyChunkMode
         CCM_HPTR        enum        CopyChunkMode
@@ -2589,7 +2589,7 @@ The chunk being copied is in the form of a segment and chunk offset.
 **Library:** Objects/processC.def
 
 ----------
-#### CopyChunkOutFrame
+### CopyChunkOutFrame
     CopyChunkOutFrame           struct
         CCOF_copyFlags      CopyChunkFlags
         CCOF_source         optr
@@ -2601,7 +2601,7 @@ This structure is passed on the stack to MSG_PROCESS_COPY_CHUNK_OUT.
 **Library:** Objects/processC.def
 
 ----------
-#### CopyChunkOVerFrame
+### CopyChunkOVerFrame
     CopyChunkOVerFrame          struct
         CCOVF_copyFlags     CopyChunkFlags
         CCOVF_source        dword
@@ -2614,7 +2614,7 @@ MSG_PROCESS_COPY_CHUNK_OVER.
 **Library:** Objects/processC.def
 
 ----------
-#### CountryType
+### CountryType
     CountryType         etype       word, 1, 1
         CT_UNITED_STATE         enum        CountryType
         CT_CANADA               enum        CountryType
@@ -2629,7 +2629,7 @@ MSG_PROCESS_COPY_CHUNK_OVER.
 **Library:** localize.def
 
 ----------
-#### CParserReturnStruct
+### CParserReturnStruct
     CParserReturnStruct struc
         PRS_errorCode               byte
         PRS_textOffsetStart         word
@@ -2640,7 +2640,7 @@ MSG_PROCESS_COPY_CHUNK_OVER.
 **Library:** parse.def
 
 ----------
-#### CParserStruct
+### CParserStruct
     CParserStruct       struc
         C_parameters            ParserParameters
         C_callbackPtr           fptr
@@ -2650,7 +2650,7 @@ MSG_PROCESS_COPY_CHUNK_OVER.
 **Library:** parse.def
 
 ----------
-#### CPUFlags
+### CPUFlags
     CPUFlags        record
                             :4
         CPU_OVERFLOW        :1
@@ -2670,7 +2670,7 @@ MSG_PROCESS_COPY_CHUNK_OVER.
 **Library:** geos.def
 
 ----------
-#### CRangeEnumCallbackParams
+### CRangeEnumCallbackParams
     CRangeEnumCallbackParams            struct
         CRECP_rangeParams       fptr.CRangeEnumParams
         CRECP_row               word            ;current row
@@ -2686,7 +2686,7 @@ called with.
 **Library:** cell.def
 
 ----------
-#### CRangeEnumParams
+### CRangeEnumParams
     CRangeEnumParams            struct
         CREP_params         RangeEnumParams
         CREP_locals         fptr
@@ -2698,7 +2698,7 @@ This structure is a C version of **RangeEnumParams**.
 **Library:** cell.def
 
 ----------
-#### CreateExpressMenuControlItemFeature
+### CreateExpressMenuControlItemFeature
     CreateExpressMenuControlItemFeature etype word
         CEMCIF_GEOS_TASKS_LIST      enum    CreateExpressMenuControlItemFeature
         CEMCIF_DOS_TASKS_LIST       enum    CreateExpressMenuControlItemFeature
@@ -2708,7 +2708,7 @@ This structure is a C version of **RangeEnumParams**.
 **Library:** Objects/eMenuC.def
 
 ----------
-#### CreateExpressMenuControlItemParams
+### CreateExpressMenuControlItemParams
     CreateExpressMenuControlItemParams struct
         CEMCIP_feature              CreateExpressMenuControlItemFeature
         CEMCIP_class                fptr.ClassStruct
@@ -2749,7 +2749,7 @@ GenField the Express Menu Control is associated with doesn't matter.
 **Library:** Objects/eMenuC.def
 
 ----------
-#### CreateExpressMenuControlItemPriority
+### CreateExpressMenuControlItemPriority
     CreateExpressMenuControlItemPriority etype word
         CEMCIP_SPOOL_CONTROL_PANEL  enum CreateExpressMenuControlItemPriority, 100h
         CEMCIP_NETMSG_SEND_MESSAGE  enum CreateExpressMenuControlItemPriority, 200h
@@ -2761,7 +2761,7 @@ GenField the Express Menu Control is associated with doesn't matter.
 **Library:** Objects/eMenuC.def
 
 ----------
-#### CreateExpressMenuControlItemResponseParams
+### CreateExpressMenuControlItemResponseParams
     CreateExpressMenuControlItemResponseParams struct
         CEMCIRP_newItem                 optr
         CEMCIRP_data                    word
@@ -2783,7 +2783,7 @@ object that created the new item.
 **Library:** Objects/eMenuC.def
 
 ----------
-#### CreateVisMonikerFlags
+### CreateVisMonikerFlags
     CreateVisMonikerFlags           record
         CVMF_DIRTY          :1
                             :7
@@ -2792,7 +2792,7 @@ object that created the new item.
 **Library:** Objects/visC.def
 
 ----------
-#### CreateVisMonikerFrame
+### CreateVisMonikerFrame
     CreateVisMonikerFrame           struct
         CVMF_source         dword
         CVMF_sourceType     VisMonikerSourceType
@@ -2838,7 +2838,7 @@ dirty.
 **Library:** Objects/visC.def
 
 ----------
-#### CSFeatures
+### CSFeatures
     CSFeatures      record
         CSF_FILLED_LIST     :1
         CSF_INDEX           :1
@@ -2850,7 +2850,7 @@ dirty.
 **Library:** Objects/colorC.def
 
 ----------
-#### CSToolboxFeatures
+### CSToolboxFeatures
     CSToolboxFeatures           record
         CSTF_INDEX          :1
         CSTF_DRAW_MASK      :1
@@ -2860,7 +2860,7 @@ dirty.
 **Library:** colorC.def
 
 ----------
-#### CT_CC_CallbackStruct
+### CT_CC_CallbackStruct
     CT_CC_CallbackStruct        struc       ; Structure for CT_CREATE_CELL
         CC_row              word
         CC_column           word
@@ -2871,7 +2871,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_CNE_CallbackStruct
+### CT_CNE_CallbackStruct
     CT_CNE_CallbackStruct       struc   ; Structure for CT_CHECK_NAME_EXISTS
         CNE_text            fptr
         CNE_length          word
@@ -2881,7 +2881,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_CNS_CallbackStruct
+### CT_CNS_CallbackStruct
     CT_CNS_CallbackStruct   struc       ; Structure for CT_CHECK_NAME_SPACE
         CNS_numToAllocate       word
         CNS_enoughSpace         byte
@@ -2892,7 +2892,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_DC_CallbackStruct
+### CT_DC_CallbackStruct
     CT_DC_CallbackStruct            struc   ;Structure for CT_DEREF_CELL
         DC_argStack             fptr
         DC_opFnStack            fptr
@@ -2907,7 +2907,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_EC_CallbackStruct
+### CT_EC_CallbackStruct
     CT_EC_CallbackStruct            struc   ; Structure for CT_EMPTY_CELL
         EC_row                  word
         EC_column               word
@@ -2918,7 +2918,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_EF_CallbackStruct
+### CT_EF_CallbackStruct
     CT_EF_CallbackStruct            struc   ; Structure for CT_EVAL_FUNCTION
         EF_numArgs              word
         EF_funcID               word
@@ -2931,7 +2931,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_FF_CallbackStruct
+### CT_FF_CallbackStruct
     CT_FF_CallbackStruct        struc   ; Structure for CT_FORMAT_FUNCTION
     FF_funcID               word
     FF_maxChars             word
@@ -2942,7 +2942,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_FN_CallbackStruct
+### CT_FN_CallbackStruct
     CT_FN_CallbackStruct            struc   ; Structure for CT_FORMAT_NAME
         FN_textPtr              fptr
         FN_nameToken            word
@@ -2954,7 +2954,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_FTC_CallbackStruct
+### CT_FTC_CallbackStruct
     CT_FTC_CallbackStruct       struc   ; Structure for CT_FUNCTION_TO_CELL
         FTC_funcID          word
         FTC_row             word
@@ -2966,7 +2966,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_FTT_CallbackStruct
+### CT_FTT_CallbackStruct
     CT_FTT_CallbackStruct   struc   ; Structure for CT_FUNCTION_TO_TOKEN
         FTT_text                fptr
         FTT_length              word
@@ -2977,7 +2977,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_LN_CallbackStruct
+### CT_LN_CallbackStruct
     CT_LN_CallbackStruct            struc   ; Structure for CT_LOCK_NAME
         LN_nameToken            word
         LN_defPtr               dword
@@ -2988,7 +2988,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_NTC_CallbackStruct
+### CT_NTC_CallbackStruct
     CT_NTC_CallbackStruct       struc   ; Structure for CT_NAME_TO_CELL
         NTC_nameToken       word
         NTC_row             word
@@ -2998,7 +2998,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_NTT_CallbackStruct
+### CT_NTT_CallbackStruct
     CT_NTT_CallbackStruct           struc   ; Structure for CT_NAME_TO_TOKEN
         NTT_text                fptr
         NTT_length              word
@@ -3010,7 +3010,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_SF_CallbackStruct
+### CT_SF_CallbackStruct
     CT_SF_CallbackStruct        struc   ; Structure for CT_SPECIAL_FUNCTION
         SF_argStack         fptr
         SF_opFnStack        fptr
@@ -3023,7 +3023,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CT_UL_CallbackStruct
+### CT_UL_CallbackStruct
     CT_UL_CallbackStruct            struc   ; Structure for CT_UNLOCK
         UL_dataPtr              fptr
     CT_UL_CallbackStruct            ends
@@ -3031,7 +3031,7 @@ dirty.
 **Library:** parse.def
 
 ----------
-#### CurrencyFormatFlags
+### CurrencyFormatFlags
     CurrencyFormatFlags         record
                                             :2
         CFF_LEADING_ZERO                    :1
@@ -3047,7 +3047,7 @@ dirty.
 **Library:** localize.def
 
 ----------
-#### CustomDialogBoxFlags
+### CustomDialogBoxFlags
     CustomDialogBoxFlags            record
         CDBF_SYSTEM_MODAL               :1
         CDBF_DIALOG_TYPE                CustomDialogType:2
@@ -3064,7 +3064,7 @@ dirty.
 **Library:** uDialog.def
 
 ----------
-#### CustomDialogType
+### CustomDialogType
     CustomDialogType            etype       byte
         CDT_QUESTION        enum    CustomDialogType
         CDT_WARNING         enum    CustomDialogType

--- a/TechDocs/Markdown/Asmref/asmstrdf.md
+++ b/TechDocs/Markdown/Asmref/asmstrdf.md
@@ -1,7 +1,7 @@
 ## 3.2 Structures D-F
 
 ----------
-#### DACPlayFlags
+### DACPlayFlags
     DACPlayFlags        record
         DACPF_CATENATE          :1
                                 :7
@@ -10,7 +10,7 @@
 **Library:** sound.def
 
 ----------
-#### DACReferenceByte
+### DACReferenceByte
     DACReferenceByte        etype       word, 0, 1
         DACRB_NO_REFERENCE_BYTE     enum        DACReferenceByte
         DACRB_WITH_REFERENCE_BYTE   enum        DACReferenceByte
@@ -18,7 +18,7 @@
 **Library:** sound.def
 
 ----------
-#### DACSampleFormat
+### DACSampleFormat
     DACSampleFormat     etype       word, 0, 1
         DACSF_8_BIT_PCM         enum        DACSampleFormat
         DACSF_2_TO_1_ADPCM      enum        DACSampleFormat
@@ -28,7 +28,7 @@
 **Library:** sound.def
 
 ----------
-#### DateTimeFormat
+### DateTimeFormat
     DateTimeFormat      etype       word
         DTF_LONG                    enum    DateTimeFormat ; Sunday, March 5th, 1990
         DTF_LONG_CONDENSED          enum    DateTimeFormat ; Sun, Mar 5, 1990
@@ -66,7 +66,7 @@ substantially different.
 **Library:** localize.def
 
 ----------
-#### DBaseItem
+### DBaseItem
     DBaseItem       struct
         DBI_group       word    ; The group in which the data resides.
         DBI_item        word    ; The item within that group.
@@ -77,7 +77,7 @@ This structure defines a dbase item.
 **Library:** cell.def
 
 ----------
-#### DBGroupAndItem
+### DBGroupAndItem
     DBGroupAndItem          struct
         DBGI_item       word
         DBGI_group      word
@@ -86,7 +86,7 @@ This structure defines a dbase item.
 **Library:** dbase.def
 
 ----------
-#### dbptr
+### dbptr
     dbptr   struct
         dbitem  word
         dbgroup word
@@ -95,7 +95,7 @@ This structure defines a dbase item.
 **Library:** config.def
 
 ----------
-#### DCCFeatures
+### DCCFeatures
     DCCFeatures     record
         DCCF_DROP_CAP       :1
     DCCFeatures     end
@@ -106,14 +106,14 @@ ATTR_GEN_CONTROL_PROHIBIT_UI.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### DCCToolboxFeatures
+### DCCToolboxFeatures
     DCCToolboxFeatures      record
     DCCToolboxFeatures      end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### DDFixed
+### DDFixed
     DDFixed struct
         DDF_frac        dword
         DDF_int     sdword
@@ -124,7 +124,7 @@ This structure defines a 32 bit/32 bit fixed point number.
 **Library:** geos.def
 
 ----------
-#### DebugObjDuplicateResourceInfo
+### DebugObjDuplicateResourceInfo
     DebugObjDuplicateResourceInfo   struct
         DODRI_tempOwner char    GEODE_NAME_SIZE dup(?)
         ; The permanent name of the geode owning the template that this block
@@ -147,7 +147,7 @@ symbol, uses this to be able to show a reference like:
 **Library:** metaC.def
 
 ----------
-#### DefaultFieldNameUsage
+### DefaultFieldNameUsage
     DefaultFieldNameUsage   etype   byte,   0
         DFNU_FIELD      enum    DefaultFieldNameUsage
         DFNU_COLUMN     enum    DefaultFieldNameUsage
@@ -156,7 +156,7 @@ symbol, uses this to be able to show a reference like:
 **Library:** impex.def
 
 ----------
-#### Dependency
+### Dependency
     Dependency      struct
         D_row           word        ; Row of the dependency.
         D_column        byte        ; Column of the dependency.
@@ -165,7 +165,7 @@ symbol, uses this to be able to show a reference like:
 **Library:** parse.def
 
 ----------
-#### DependencyBlock
+### DependencyBlock
     DependencyBlock     struct
         DB_size     word    ; Size of the block containing the dependency.
     DependencyBlock     ends
@@ -173,7 +173,7 @@ symbol, uses this to be able to show a reference like:
 **Library:** parse.def
 
 ----------
-#### DependencyListHeader
+### DependencyListHeader
     DependencyListHeader            struct
         DLH_next        dword   ; DBase item containing next block in the list.
     DependencyListHeader            ends
@@ -185,7 +185,7 @@ start of the cell data).
 **Library:** parse.def
 
 ----------
-#### DependencyParameters
+### DependencyParameters
     DependencyParameters            struct
         DP_common           CommonParameters <>
         ;
@@ -210,7 +210,7 @@ This structure is passed to the dependency code.
 **Library:** parse.def
 
 ----------
-#### DerefFlags
+### DerefFlags
     DerefFlags      record
         DF_DONT_POP_ARGUMENT    :1      ; Set = don't pop arg from arg stack.
     DerefFlags      end
@@ -218,7 +218,7 @@ This structure is passed to the dependency code.
 **Library:** parse.def
 
 ----------
-#### DestinationClassArgs
+### DestinationClassArgs
     DestinationClassArgs            struct
         DCA_class       fptr.ClassStruct
     DestinationClassArgs            ends
@@ -226,7 +226,7 @@ This structure is passed to the dependency code.
 **Library:** Objects/genC.def
 
 ----------
-#### DetachDataEntry
+### DetachDataEntry
     DetachDataEntry     struct
         DDE_ackCount        word
         DDE_callerID        word
@@ -237,7 +237,7 @@ This structure is passed to the dependency code.
 **Library:** Objects/metaC.def
 
 ----------
-#### DevicePresent
+### DevicePresent
     DevicePresent       etype       word
         DP_NOT_PRESENT          enum        DevicePresent, 0xffff   
         DP_CANT_TELL            enum        DevicePresent, 0    
@@ -259,7 +259,7 @@ An unknown device string was passed.
 **Library:** driver.def
 
 ----------
-#### DirPathInfo
+### DirPathInfo
     DirPathInfo     record
         DPI_EXISTS_LOCALLY          :1
         DPI_ENTRY_NUMBER_IN_PATH    :7
@@ -273,7 +273,7 @@ server-based one).
 **Library:** file.def
 
 ----------
-#### DiskCopyCallback
+### DiskCopyCallback
     DiskCopyCallback        etype       word, 0
         DCC_GET_SOURCE_DISK                 enum DiskCopyCallback
             ;   Desc:   prompt the user to insert the source disk.
@@ -341,7 +341,7 @@ callback operation to use with this routine.
 **Library:** disk.def
 
 ----------
-#### DiskCopyError
+### DiskCopyError
     DiskCopyError       etype       word, FormatError
         ERR_INVALID_SOURCE_DRIVE                            enum DiskCopyError
         ERR_INVALID_DEST_DRIVE                              enum DiskCopyError
@@ -386,7 +386,7 @@ it and the registration failed.
 **Library:** disk.def
 
 ----------
-#### DiskCopyFlags
+### DiskCopyFlags
     DiskCopyFlags           record
         DCF_GREEDY      :1
                         :7
@@ -400,7 +400,7 @@ drives are the same.
 **Library:** disk.def
 
 ----------
-#### DiskFindResult
+### DiskFindResult
     DiskFindResult      etype       word
         DFR_UNIQUE              enum    DiskFindResult
         DFR_NOT_UNIQUE          enum    DiskFindResult
@@ -409,7 +409,7 @@ drives are the same.
 **Library:** disk.def
 
 ----------
-#### DiskFormatFlags
+### DiskFormatFlags
     DiskFormatFlags     record
                                     :13
         DFF_CALLBACK_PCT_DONE       :1
@@ -431,7 +431,7 @@ This flag is set if we wish to force erasure of the entire disk.
 **Library:** disk.def
 
 ----------
-#### DiskInfoStruct
+### DiskInfoStruct
     DiskInfoStruct      struct
         DIS_blockSize   word    ; number of bytes in which file system allocations
                                 ; are performed. Useful as an efficient
@@ -445,7 +445,7 @@ This flag is set if we wish to force erasure of the entire disk.
 **Library:** disk.def
 
 ----------
-#### DiskRestoreError
+### DiskRestoreError
     DiskRestoreError        etype       word, 0, 1
         DRE_DISK_IN_DRIVE                       enum DiskRestoreError
              ;  This is the value returned by DiskRestore itself and the callback 
@@ -481,7 +481,7 @@ This flag is set if we wish to force erasure of the entire disk.
 **Library:** disk.def
 
 ----------
-#### DisplayAspectRatio
+### DisplayAspectRatio
     DisplayAspectRatio      etype       byte
         DAR_NORMAL              enum        DisplayAspectRatio  ;VGA, MCGA
         DAR_SQUISHED            enum        DisplayAspectRatio  ;EGA, HGCA
@@ -490,7 +490,7 @@ This flag is set if we wish to force erasure of the entire disk.
 **Library:** win.def
 
 ----------
-#### DisplayClass
+### DisplayClass
     DisplayClass        etype       byte
         DC_TEXT     enum        DisplayClass    ;denotes that display is 
                                                 ;character only (Not implemented)
@@ -506,7 +506,7 @@ This flag is set if we wish to force erasure of the entire disk.
 **Library:** win.def
 
 ----------
-#### DisplayScheme
+### DisplayScheme
     DisplayScheme       struct
         DS_colorScheme          ColorScheme     ;passed in al
         DS_displayType          DisplayType     ;passed in ah
@@ -521,7 +521,7 @@ This flag is set if we wish to force erasure of the entire disk.
 **Library:** Objects/visC.def
 
 ----------
-#### DisplaySize
+### DisplaySize
     DisplaySize     etype       byte
         DS_TINY         enum    DisplaySize ;tiny screens: CGA, 256x320
         DS_STANDARD     enum    DisplaySize ;standard screens: EGA,VGA,HGC,MCGA
@@ -531,7 +531,7 @@ This flag is set if we wish to force erasure of the entire disk.
 **Library:** win.def
 
 ----------
-#### DisplayType
+### DisplayType
     DisplayType     record
         DT_DISP_SIZE                DisplaySize:2
         DT_DISP_ASPECT_RATIO        DisplayAspectRatio:2
@@ -550,7 +550,7 @@ Class of driver (or closest match).
 **Library:** win.def
 
 ----------
-#### DistanceUnit
+### DistanceUnit
     DistanceUnit        etype       byte
         DU_POINTS                   enum DistanceUnit
             ;U.S. points (72 per inch)
@@ -584,7 +584,7 @@ Class of driver (or closest match).
 **Library:** localize.def
 
 ----------
-#### DocQuitStatus
+### DocQuitStatus
     DocQuitStatus       etype       word
         DQS_OK              enum    DocQuitStatus
         DQS_CANCEL          enum    DocQuitStatus
@@ -594,7 +594,7 @@ Class of driver (or closest match).
 **Library:** Objects/gDocGrpC.def
 
 ----------
-#### DocumentCommonParams
+### DocumentCommonParams
     DocumentCommonParams            struct
         DCP_name            FileLongName
         DCP_diskHandle      word
@@ -612,7 +612,7 @@ simplify passing the flags around.
 **Library:** Objects/gDocC.def
 
 ----------
-#### DocumentFileChangedParams
+### DocumentFileChangedParams
     DocumentFileChangedParams               struct
         DFCP_name               FileLongName
         DFCP_diskHandle         hptr
@@ -624,7 +624,7 @@ simplify passing the flags around.
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### DocumentOpenFlags
+### DocumentOpenFlags
     DocumentOpenFlags       record
         DOF_CREATE_FILE_IF_FILE_DOES_NOT_EXIST      :1
         DOF_FORCE_TEMPLATE_BEHAVIOR                 :1
@@ -676,7 +676,7 @@ Internal.
 **Library:** Objects/gDocC.def
 
 ----------
-#### DosCodePage
+### DosCodePage
     DosCodePage     etype       word
         CODE_PAGE_US                enum        DosCodePage, 437
         CODE_PAGE_MULTILINGUAL      enum        DosCodePage, 850
@@ -689,7 +689,7 @@ Internal.
 **Library:** localize.def
 
 ----------
-#### DosExecFlags
+### DosExecFlags
     DosExecFlags        record
         DEF_PROMPT                  :1
         DEF_FORCED_SHUTDOWN         :1
@@ -726,7 +726,7 @@ Set if a **DosExecArgAndMemReqStruct** is passed to
 **Library:** system.def
 
 ----------
-#### DosExecMemReq
+### DosExecMemReq
     DosExecMemReq   struct
         DEMR_minimum    word        ; minimum memory requirement
         DEMR_optimal    word        ; optimal memory requirement
@@ -735,7 +735,7 @@ Set if a **DosExecArgAndMemReqStruct** is passed to
 **Library:** 
 
 ----------
-#### DosExecMemReqsStruct
+### DosExecMemReqsStruct
     DosExecMemReqsStruct        struct
         DEMRS_tsr           BooleanByte     BB_FALSE    ; program is a TSR
         DEMRS_conventional  DosExecMemReq   <0,0>       ; conventional
@@ -748,7 +748,7 @@ Set if a **DosExecArgAndMemReqStruct** is passed to
 **Library:** 
 
 ----------
-#### DrawFlags
+### DrawFlags
     DrawFlags       record
         DF_EXPOSED              :1
         DF_OBJECT_SPECIFIC      :1
@@ -789,7 +789,7 @@ This flag is set to **DisplayClass** (*not* **DisplayType**).
 **Library:** Objects/visC.def
 
 ----------
-#### DrawMonikerFlags
+### DrawMonikerFlags
     DrawMonikerFlags        record
         DMF_TEXT_ONLY               :1
         DMF_UNDERLINE_ACCELERATOR   :1
@@ -821,7 +821,7 @@ Horizontal justification.
 **Library:** Objects/visC.def
 
 ----------
-#### DriveExtendedStatus
+### DriveExtendedStatus
     DriveExtendedStatus             record
         DES_LOCAL_ONLY      :1
         DES_READ_ONLY       :1
@@ -854,7 +854,7 @@ Externally-visible status flags.
 **Library:** drive.def
 
 ----------
-#### DriverAttrs
+### DriverAttrs
     DriverAttrs         record
         DA_FILE_SYSTEM              :1
         DA_CHARACTER                :1
@@ -875,7 +875,7 @@ functions.
 **Library:** driver.def
 
 ----------
-#### DriverEscCode
+### DriverEscCode
     DriverEscCode       etype   word, 8000h, 1
         DRV_ESC_QUERY_ESC   enum    DriverEscCode   ; query for escape cpde 
                                                     ; support
@@ -883,7 +883,7 @@ functions.
 **Library:** driver.def
 
 ----------
-#### DriverExtendedFunction
+### DriverExtendedFunction
     DriverExtendedFunction      etype   word, DriverFunction, 2
         DRE_TEST_DEVICE     enum    DriverExtendedFunction
         ;   PASS:       dx:si   = pointer to null-terminated device name string
@@ -905,7 +905,7 @@ functions.
 **Library:** driver.def
 
 ----------
-#### DriverExtendedInfoStruct
+### DriverExtendedInfoStruct
     DriverExtendedInfoStruct            struct
         DEIS_common             DriverInfoStruct
         DEIS_resource           hptr.DriverExtendedInfoTable
@@ -929,7 +929,7 @@ resource to keep the amount of fixed memory required to a minimum.
 **Library:** driver.def
 
 ----------
-#### DriverExtendedInfoTable
+### DriverExtendedInfoTable
     DriverExtendedInfoTable         struct
         DEIT_common             LMemBlockHeader
         DEIT_numDevices         word
@@ -954,7 +954,7 @@ stored here is specified by the driver-type-specific interface .def file (e.g.
 **Library:** driver.def
 
 ----------
-#### DriverFunction
+### DriverFunction
     DriverFunction      etype       word, 0, 2
         DR_INIT             enum DriverFunction ;Initialize driver
         ;   PASS:   cx  = di passed to GeodeLoad. Garbage if loaded via
@@ -1011,7 +1011,7 @@ stored here is specified by the driver-type-specific interface .def file (e.g.
 **Library:** driver.def
 
 ----------
-#### DriverInfoStruct
+### DriverInfoStruct
     DriverInfoStruct            struct
         DIS_strategy                fptr.far
         DIS_driverAttributes        DriverAttrs
@@ -1032,7 +1032,7 @@ driver.
 **Library:** driver.def
 
 ----------
-#### DriverType
+### DriverType
     DriverType      etype       word, 1
         DRIVER_TYPE_VIDEO               enum        DriverType
         DRIVER_TYPE_INPUT               enum        DriverType
@@ -1055,7 +1055,7 @@ driver.
 **Library:** driver.def
 
 ----------
-#### DriveStatus
+### DriveStatus
     DriveStatus     record
         DS_PRESENT          :1          ; Set if physical drive exists
         DS_MEDIA_REMOVABLE  :1          ; Set if disk can be removed from 
@@ -1071,7 +1071,7 @@ driver.
 **Library:** drive.def
 
 ----------
-#### DriveType
+### DriveType
     DriveType       etype       byte
         DRIVE_5_25          enum    DriveType
         DRIVE_3_5           enum    DriveType
@@ -1085,7 +1085,7 @@ driver.
 **Library:** drive.def
 
 ----------
-#### DTCFeatures
+### DTCFeatures
     DTCFeatures     record
         DTCF_LIST       :1
         DTCF_CUSTOM     :1
@@ -1097,14 +1097,14 @@ ATTR_GEN_CONTROL_PROHIBIT_UI).
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### DTCToolboxFeatures
+### DTCToolboxFeatures
     DTCToolboxFeatures      record
     DTCToolboxFeatures      end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### DWFixed
+### DWFixed
     DWFixed     struct
         DWF_frac        word
         DWF_int         sdword
@@ -1115,7 +1115,7 @@ This structure stores a 32 bit/16 bit fixed point number.
 **Library:** geos.def
 
 ----------
-#### ElementArrayHeader
+### ElementArrayHeader
     ElementArrayHeader      struct
         EAH_meta        ChunkArrayHeader
         EAH_freePtr     word
@@ -1133,7 +1133,7 @@ Applications should not examine or change this field.
 **Library:** chunkarr.def
 
 ----------
-#### EMCDetachData
+### EMCDetachData
     EMCDetachData   struct
         EMCDD_ackEvent      hptr 
         EMCDD_childBlock    hptr 
@@ -1154,7 +1154,7 @@ MSG_META_DETACH.
 **Library:** eMenuC.def
 
 ----------
-#### EMCFeatures
+### EMCFeatures
     EMCFeatures     record
         EMCF_GEOS_TASKS_LIST        :1
         EMCF_DESK_ACCESSORY_LIST    :1
@@ -1169,7 +1169,7 @@ MSG_META_DETACH.
 **Library:** eMenuC.def
 
 ----------
-#### EmptyRowBlock
+### EmptyRowBlock
     EmptyRowBlock       struct
         ERB_header          LMemBlockHeader <>
         ERB_handles         word N_ROWS_PER_ROW_BLOCK dup (0)
@@ -1180,7 +1180,7 @@ An empty row block is an LMem block with space for several handles.
 **Library:** cell.def
 
 ----------
-#### EndCreatePassFlags
+### EndCreatePassFlags
     EndCreatePassFlags      record
         ECPF_ADJUSTED_CREATE                :1
     EndCreatePassFlags      end
@@ -1192,7 +1192,7 @@ the object creation.
 **Library:** grobj.def
 
 ----------
-#### EndCreateReturnFlags
+### EndCreateReturnFlags
     EndCreateReturnFlags            record
         ECRF_NOT_CREATING       :1      ;object was not in create mode.
         ECRF_DESTROYED          :1      ;object was destroyed
@@ -1201,7 +1201,7 @@ the object creation.
 **Library:** grobj.def
 
 ----------
-#### EndOfSongFlags
+### EndOfSongFlags
     EndOfSongFlags      record
         EOSF_UNLOCK             :1 = 0  ; unlock block at EOS?
         EOSF_DESTROY            :1 = 0  ; destroy sound at EOS?
@@ -1211,7 +1211,7 @@ the object creation.
 **Library:** sound.def
 
 ----------
-#### EnsureActiveFTPriorityPreferenceData
+### EnsureActiveFTPriorityPreferenceData
     EnsureActiveFTPriorityPreferenceData    struct
         EAFTPPD_priority        word
         EAFTPPD_avoidOptr       optr
@@ -1220,7 +1220,7 @@ the object creation.
 **Library:** 
 
 ----------
-#### EnsureNoMenusInStayUpModeParams
+### EnsureNoMenusInStayUpModeParams
     EnsureNoMenusInStayUpModeParams struc
         ENMISUMP_menuCount      word    ;Number of menus released so far
     EnsureNoMenusInStayUpModeParams ends
@@ -1228,7 +1228,7 @@ the object creation.
 **Library:** ui.def
 
 ----------
-#### EntryPointRelocation
+### EntryPointRelocation
     EntryPointRelocation            struct
         EPR_geodeName           char GEODE_NAME_SIZE dup (?)
         EPR_entryNumber         word
@@ -1239,7 +1239,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** object.def
 
 ----------
-#### EnvelopeOrientation
+### EnvelopeOrientation
     EnvelopeOrientation         etype       byte, 0, 1
         EO_PORTAIT                  enum            EnvelopeOrientation
         EO_LANDSCAPE                enum            EnvelopeOrientation
@@ -1247,7 +1247,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** print.def
 
 ----------
-#### ErrorCheckingFlags
+### ErrorCheckingFlags
     ErrorCheckingFlags      record
         ECF_UNUSED_1:1 
         ECF_UNUSED_2:1 
@@ -1270,7 +1270,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** ec.def
 
 ----------
-#### EvalErrorData
+### EvalErrorData
     EvalErrorData       struct
         EED_errorCode           ParserScannerEvaluatorError
     EvalErrorData       ends
@@ -1278,7 +1278,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** parse.def
 
 ----------
-#### EvalFlags
+### EvalFlags
     EvalFlags       record
         EF_MAKE_DEPENDENCIES    :1  ; Make dependencies instead of 
                                     ; recalculating
@@ -1297,7 +1297,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** parse.def
 
 ----------
-#### EvalFunctionData
+### EvalFunctionData
     EvalFunctionData        struct
         EFD_functionID          FunctionID  ; Function ID if a function
         EFD_nArgs               word        ; Number of arguments
@@ -1306,7 +1306,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** parse.def
 
 ----------
-#### EvalNameData
+### EvalNameData
     EvalNameData        struct
         END_name            word
     EvalNameData        ends
@@ -1314,7 +1314,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** parse.def
 
 ----------
-#### EvalOperatorData
+### EvalOperatorData
     EvalOperatorData        struct
         EOD_opType      OperatorType            ; Type of operator
     EvalOperatorData        ends
@@ -1322,7 +1322,7 @@ This structure is passed to **ObjRelocateEntryPoint**.
 **Library:** parse.def
 
 ----------
-#### EvalParameters
+### EvalParameters
     EvalParameters      struct
         EP_common               CommonParameters <>
         ;
@@ -1348,7 +1348,7 @@ structure is passed in a stack frame.
 **Library:** parse.def
 
 ----------
-#### EvalRangeData
+### EvalRangeData
     EvalRangeData       struct
         ERD_firstCell           CellReference <>
         ERD_lastCell            CellReference <>
@@ -1357,7 +1357,7 @@ structure is passed in a stack frame.
 **Library:** parse.def
 
 ----------
-#### EvalStackArgumentData
+### EvalStackArgumentData
     EvalStackArgumentData           union
         ESAD_string         EvalStringData
         ESAD_range          EvalRangeData
@@ -1367,7 +1367,7 @@ structure is passed in a stack frame.
 **Library:** parse.def
 
 ----------
-#### EvalStackArgumentType
+### EvalStackArgumentType
     EvalStackArgumentType           record
         ESAT_EMPTY      :1          ; Set: Argument came from an empty cell
         ;
@@ -1388,7 +1388,7 @@ structure is passed in a stack frame.
 **Library:** parse.def
 
 ----------
-#### EvalStackOperatorData
+### EvalStackOperatorData
     EvalStackOperatorData           union
         ESOD_operator           EvalOperatorData
         ESOD_function           EvalFunctionData
@@ -1397,7 +1397,7 @@ structure is passed in a stack frame.
 **Library:** parse.def
 
 ----------
-#### EvalStackOperatorType
+### EvalStackOperatorType
     EvalStackOperatorType           etype       byte, 0, 1
         ESOT_OPERATOR           enum        EvalStackOperatorType
         ESOT_FUNCTION           enum        EvalStackOperatorType
@@ -1407,7 +1407,7 @@ structure is passed in a stack frame.
 **Library:** parse.def
 
 ----------
-#### EvalStringData
+### EvalStringData
     EvalStringData          struct
         ESD_length      word    ; Length of the string. (String data follows.)
     EvalStringData          ends
@@ -1415,7 +1415,7 @@ structure is passed in a stack frame.
 **Library:** parse.def
 
 ----------
-#### EvaluatePositionNotes
+### EvaluatePositionNotes
     EvaluatePositionNotes       record
         EPN_PADDING                 :14
         EPN_SELECTION_LOCK_SET      :1  ;Object's selection lock is set.
@@ -1427,7 +1427,7 @@ structure is passed in a stack frame.
 **Library:** grobj.def
 
 ----------
-#### EvaluatePositionRating
+### EvaluatePositionRating
     EvaluatePositionRating          etype       byte, 0
         EVALUATE_NONE               enum        EvaluatePositionRating
         EVALUATE_SUB_LOW            enum        EvaluatePositionRating
@@ -1461,7 +1461,7 @@ Point is on a line or a filled - or partially filled - area.
 **Library:** grobj.def
 
 ----------
-#### ExitFlags
+### ExitFlags
     ExitFlags       record
         EF_PANIC        :1  ; Set if the exit is unstable; in this case we 
                             ; choose not to write out the .ini file.
@@ -1476,7 +1476,7 @@ Point is on a line or a filled - or partially filled - area.
 **Library:** system.def
 
 ----------
-#### ExportControlAttrs
+### ExportControlAttrs
     ExportControlAttrs      record
         ECA_IGNORE_INPUT        :1      ; ignore input while export occurs
                                 :15
@@ -1485,7 +1485,7 @@ Point is on a line or a filled - or partially filled - area.
 **Library:** impex.def
 
 ----------
-#### ExportControlFeatures
+### ExportControlFeatures
     ExportControlFeatures       record
         EXPORTCF_EXPORT_TRIGGER :1  ; export trigger
         EXPORTCF_FORMAT_OPTIONS :1  ; export format UI parent, under which is 
@@ -1504,7 +1504,7 @@ ATTR_GEN_CONTROL_PROHIBIT_UI.
 **Library:** impex.def
 
 ----------
-#### ExportControlToolboxFeatures
+### ExportControlToolboxFeatures
     ExportControlToolboxFeatures                record
         EXPORTCTF_DIALOG_BOX                :1
     ExportControlToolboxFeatures                end
@@ -1512,7 +1512,7 @@ ATTR_GEN_CONTROL_PROHIBIT_UI.
 **Library:** impex.def
 
 ----------
-#### ExtSelFlags
+### ExtSelFlags
     ExtSelFlags     record
         ESF_INITIAL_SELECTION       :1  ;set if initial selection -- will update
                                         ; all items between anchor and extent
@@ -1529,7 +1529,7 @@ ATTR_GEN_CONTROL_PROHIBIT_UI.
 **Library:** Objects/gItemGC.def
 
 ----------
-#### FACFeatures
+### FACFeatures
     FACFeatures         record
         FACF_FONT_WEIGHT            :1
         FACF_FONT_WIDTH             :1
@@ -1539,14 +1539,14 @@ ATTR_GEN_CONTROL_PROHIBIT_UI.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### FACToolboxFeatures
+### FACToolboxFeatures
     FACToolboxFeatures      record
     FACToolboxFeatures      end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### FatalErrors
+### FatalErrors
     FatalErrors     etype   word, 0
         CAN_NOT_USE_CHUNKSIZEPTR_MACRO_ON_EMPTY_CHUNKS      enum FatalErrors
         CHUNK_ARRAY_BAD_ELEMENT                             enum FatalErrors
@@ -1565,7 +1565,7 @@ bounds if Swat is to receive the type unmolested.
 **Library:** ec.def
 
 ----------
-#### FCFeatures
+### FCFeatures
     FCFeatures      record
         FCF_SHORT_LIST          :1
         FCF_LONG_LIST           :1
@@ -1574,7 +1574,7 @@ bounds if Swat is to receive the type unmolested.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### FCToolboxFeatures
+### FCToolboxFeatures
     FCToolboxFeatures           record
         FCTF_TOOL_LIST      :1
     FCToolboxFeatures           end
@@ -1582,7 +1582,7 @@ bounds if Swat is to receive the type unmolested.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### FEDosInfo
+### FEDosInfo
     FEDosInfo       struct
         FEDI_attributes     FileAttrs           ; file's attributes
         FEDI_modified       FileDateAndTime     ; file's modification timestamp
@@ -1598,7 +1598,7 @@ This structure is used with FileEnum.
 **Library:** fileEnum.def
 
 ----------
-#### FENameAndAttr
+### FENameAndAttr
     FENameAndAttr       struct
         FENAA_attr          FileAttrs
         FENAA_name          FileLongName
@@ -1609,7 +1609,7 @@ This structure is used with FileEnum.
 **Library:** fileEnum.def
 
 ----------
-#### FFA_stackFrame
+### FFA_stackFrame
     FFA_stackFrame      union
         FFA_float               FloatFloatToAsciiData
         FFA_dateTime            FloatFloatToDateTimeData
@@ -1618,7 +1618,7 @@ This structure is used with FileEnum.
 **Library:** math.def
 
 ----------
-#### FFCFeatures
+### FFCFeatures
     FFCFeatures     record
                                     :14
         FCF_FORMAT_LIST             :1
@@ -1628,7 +1628,7 @@ This structure is used with FileEnum.
 **Library:** math.def
 
 ----------
-#### FieldBGFormatType
+### FieldBGFormatType
     FieldBGFormatType       etype   word
         FBGFT_STANDARD_GSTRING              enum FieldBGFormatType
         ;Just a standard graphics string.
@@ -1638,7 +1638,7 @@ This structure is used with FileEnum.
 **Library:** backgrnd.def
 
 ----------
-#### FieldInfo
+### FieldInfo
     FieldInfo       struct
         FI_nChars       word            ; Number of characters in the field
         FI_position     word            ; X position of field on line
@@ -1649,7 +1649,7 @@ This structure is used with FileEnum.
 **Library:** text.def
 
 ----------
-#### FileAccess
+### FileAccess
     FileAccess      etype   byte, 0
         FA_READ_ONLY            enum FileAccess
         FA_WRITE_ONLY           enum FileAccess
@@ -1658,7 +1658,7 @@ This structure is used with FileEnum.
 **Library:** file.def
 
 ----------
-#### FileAccessFlags
+### FileAccessFlags
     FileAccessFlags         record
                         :1=0,           ; Must be 0.
         FAF_EXCLUDE     FileExclude:3,  ; What others may not do.
@@ -1669,7 +1669,7 @@ This structure is used with FileEnum.
 **Library:** file.def
 
 ----------
-#### FileAddStandardPathFlags
+### FileAddStandardPathFlags
     FileAddStandardPathFlags        record
                                 :16
     FileAddStandardPathFlags        end
@@ -1677,7 +1677,7 @@ This structure is used with FileEnum.
 **Library:** 
 
 ----------
-#### FileAttrs
+### FileAttrs
     FileAttrs       record
         :1=0,
         FA_LINK     :1      ; File is a link
@@ -1693,7 +1693,7 @@ This structure is used with FileEnum.
 **Library:** file.def
 
 ----------
-#### FileChangeBatchNotificationData
+### FileChangeBatchNotificationData
     FileChangeBatchNotificationData                 struct
         FCBND_end           nptr
         FCBND_items         label FileChangeBatchNotificationItem
@@ -1705,7 +1705,7 @@ This structure is used with FileEnum.
 **Library:** gcnlist.def
 
 ----------
-#### FileChangeBatchNotificationItem
+### FileChangeBatchNotificationItem
     FileChangeBatchNotificationItem                 struct
         FCBNI_type      FileChangeNotificationType
         FCBNI_disk      word
@@ -1716,7 +1716,7 @@ This structure is used with FileEnum.
 **Library:** gcnlist.def
 
 ----------
-#### FileChangeNotificationData
+### FileChangeNotificationData
     FileChangeNotificationData              struct
         FCND_disk   word            ; handle for disk on which the change occurred
         FCND_id     FileID          ; 32-bit identifier for the directory in 
@@ -1730,7 +1730,7 @@ This structure is used with FileEnum.
 **Library:** gcnlist.def
 
 ----------
-#### FileChangeNotificationType
+### FileChangeNotificationType
     FileChangeNotificationType              etype word
         FCNT_CREATE             enum FileChangeNotificationType
             ; File or directory created. FCND_id is the id of the containing
@@ -1787,7 +1787,7 @@ This structure is used with FileEnum.
 **Library:** gcnlist.def
 
 ----------
-#### FileCreateFlags
+### FileCreateFlags
     FileCreateFlags     record
         FCF_NATIVE                  :1
         FCF_NATIVE_WITH_EXT_ATTRS   :1
@@ -1812,7 +1812,7 @@ How the file should be created.
 **Library:** file.def
 
 ----------
-#### FileCreateMode
+### FileCreateMode
     FileCreateMode      etype   byte, 0
         FILE_CREATE_TRUNCATE            enum FileCreateMode
         FILE_CREATE_NO_TRUNCATE         enum FileCreateMode
@@ -1821,7 +1821,7 @@ How the file should be created.
 **Library:** file.def
 
 ----------
-#### FileDate
+### FileDate
     FileDate        record
         FD_YEAR         :7,     ; year since 1980   
         FD_MONTH        :4,     ; month (1-12)
@@ -1831,7 +1831,7 @@ How the file should be created.
 **Library:** file.def
 
 ----------
-#### FileDateAndTime
+### FileDateAndTime
     FileDateAndTime     struct
         FDAT_date           FileDate
         FDAT_time           FileTime
@@ -1839,7 +1839,7 @@ How the file should be created.
 
 **Library:** file.def
 ----------
-#### FileEnumCallbackData
+### FileEnumCallbackData
     FileEnumCallbackData            struct
         FECD_attrs      label FileExtAttrDesc
     FileEnumCallbackData            ends
@@ -1854,7 +1854,7 @@ attribute, in which case *FEAD_value*.segment will be 0.
 **Library:** fileEnum.def
 
 ----------
-#### FileEnumParams
+### FileEnumParams
     FileEnumParams      struct
         FEP_searchFlags         FileEnumSearchFlags 0
         FEP_returnAttrs         fptr.FileExtAttrDesc 0
@@ -1996,7 +1996,7 @@ block if FESF_LEAVE_HEADER set.
 **Library:** fileEnum.def
 
 ----------
-#### FileEnumSearchFlags
+### FileEnumSearchFlags
     FileEnumSearchFlags             record
         FESF_DIRS               :1  ; accept directories
         FESF_NON_GEOS           :1  ; accept non-GEOS files
@@ -2020,7 +2020,7 @@ block if FESF_LEAVE_HEADER set.
 **Library:** fileEnum.def
 
 ----------
-#### FileEnumStandardCallback
+### FileEnumStandardCallback
     FileEnumStandardCallback            etype       word, 0
         FESC_WILDCARD           enum    FileEnumStandardCallback
             ;FEP_cbData1 is a far pointer to a null-terminated string 
@@ -2038,7 +2038,7 @@ block if FESF_LEAVE_HEADER set.
 **Library:** fileEnum.def
 
 ----------
-#### FileEnumStandardReturnType
+### FileEnumStandardReturnType
     FileEnumStandardReturnType              etype word, 0
         FESRT_COUNT_ONLY                enum FileEnumStandardReturnType
         FESRT_DOS_INFO                  enum FileEnumStandardReturnType
@@ -2048,7 +2048,7 @@ block if FESF_LEAVE_HEADER set.
 **Library:** fileEnum.def
 
 ----------
-#### FileError
+### FileError
     FileError       etype word
         ERROR_UNSUPPORTED_FUNCTION      enum FileError, 1   ;MS-DOS error
         ERROR_FILE_NOT_FOUND            enum FileError, 2   ;MS-DOS error
@@ -2150,7 +2150,7 @@ block if FESF_LEAVE_HEADER set.
 **Library:** file.def
 
 ----------
-#### FileExclude
+### FileExclude
     FileExclude     etype   byte, 0
         FE_COMPAT           enum FileExclude
         FE_EXCLUSIVE        enum FileExclude
@@ -2161,7 +2161,7 @@ block if FESF_LEAVE_HEADER set.
 **Library:** file.def
 
 ----------
-#### FileExtAttrDesc
+### FileExtAttrDesc
     FileExtAttrDesc     struct
         FEAD_attr           FileExtendedAttribute
         FEAD_value          fptr
@@ -2188,7 +2188,7 @@ should have its *FEAD_attr* field set to FEA_END_OF_LIST.
 **Library:** file.def
 
 ----------
-#### FileExtendedAttribute
+### FileExtendedAttribute
     FileExtendedAttribute           etype word, 0
         FEA_MODIFICATION enum FileExtendedAttribute ; FileDateAndTime
         FEA_FILE_ATTR   enum FileExtendedAttribute  ; FileAttrs
@@ -2249,7 +2249,7 @@ should have its *FEAD_attr* field set to FEA_END_OF_LIST.
 **Library:** file.def
 
 ----------
-#### FileOpenAndReadFlags
+### FileOpenAndReadFlags
     FileOpenAndReadFlags            record
         ; These three flags are processed in order:
 
@@ -2270,7 +2270,7 @@ should have its *FEAD_attr* field set to FEA_END_OF_LIST.
 **Library:** file.def
 
 ----------
-#### FilePathID
+### FilePathID
     FilePathID      struct
         FPID_disk           word        ; disk handle
         FPID_id             FileID      ; ID for path on that disk.
@@ -2282,7 +2282,7 @@ These structures act as elements of arrays returned by
 **Library:** file.def
 
 ----------
-#### FilePosMode
+### FilePosMode
     FilePosMode     etype   byte, 0
         FILE_POS_START              enum FilePosMode
         FILE_POS_RELATIVE           enum FilePosMode
@@ -2291,7 +2291,7 @@ These structures act as elements of arrays returned by
 **Library:** file.def
 
 ----------
-#### FileSelectorAttrs
+### FileSelectorAttrs
     FileSelectorAttrs           record
         FSA_ALLOW_CHANGE_DIRS           :1
                     :1
@@ -2343,7 +2343,7 @@ changing variable data).
 **Library:** Objects/gFSelC.def
 
 ----------
-#### FileSelectorFileCriteria
+### FileSelectorFileCriteria
     FileSelectorFileCriteria            record
         ;
         ; Types of files to include in the listing
@@ -2400,7 +2400,7 @@ Also use ATTR_GEN_FILE_SELECTOR_NAME_MASK attribute for directories.
 **Library:** Objects/gFSelC.def
 
 ----------
-#### FileTime
+### FileTime
     FileTime            record
         FT_HOUR     :5,     ; hour (24-hour clock)
         FT_MIN      :6,     ; minute (0-59)
@@ -2411,7 +2411,7 @@ Also use ATTR_GEN_FILE_SELECTOR_NAME_MASK attribute for directories.
 **Library:** file.def
 
 ----------
-#### FindNoteHeader
+### FindNoteHeader
     FindNoteHeader      struct
         FNH_count   word            ; The number of matching notes.
         FNH_data    label dword
@@ -2420,7 +2420,7 @@ Also use ATTR_GEN_FILE_SELECTOR_NAME_MASK attribute for directories.
 **Library:** pen.def
 
 ----------
-#### FloatAsciiToFloatFlags
+### FloatAsciiToFloatFlags
     FloatAsciiToFloatFlags          record
                                 :6
         FAF_PUSH_RESULT         :1
@@ -2441,7 +2441,7 @@ passed in **FloatFloatToAscii**.
 **Library:** math.def
 
 ----------
-#### FloatCtrlInfoStruc
+### FloatCtrlInfoStruc
     FloatCtrlInfoStruc          struc
         ;
         ; passed values
@@ -2481,7 +2481,7 @@ returned by the routine.
 **Library:** math.def
 
 ----------
-#### FloatErrorType
+### FloatErrorType
     FloatErrorType      etype   byte, FLOAT_ERROR_CODES_ENUM_START, 1
         FLOAT_POS_INFINITY              enum FloatErrorType
         FLOAT_NEG_INFINITY              enum FloatErrorType
@@ -2490,7 +2490,7 @@ returned by the routine.
 **Library:** math.def
 
 ----------
-#### FloatExponent
+### FloatExponent
     FloatExponent           record
         FE_SIGN         :1      ; set if number is negative
         FE_EXPONENT     :15     ; the exponent is biased by 3fffh
@@ -2505,7 +2505,7 @@ FE_EXPONENT against FP_NAN.
 **Library:** math.def
 
 ----------
-#### FloatFloatToAsciiData
+### FloatFloatToAsciiData
     FloatFloatToAsciiData           struct
         ;
         ; Fields for caller to set up. All fields must be initialized.
@@ -2563,7 +2563,7 @@ if the exponent format was used.
 **Library:** math.def
 
 ----------
-#### FloatFloatToAsciiFormatFlags
+### FloatFloatToAsciiFormatFlags
     FloatFloatToAsciiFormatFlags                record
         FFAF_FLOAT_RESERVED                 :1
         FFAF_FROM_ADDR                      :1
@@ -2627,7 +2627,7 @@ This flag indicates the position of the sign character(s).
 **Library:** math.def
 
 ----------
-#### FloatFloatToAsciiParams
+### FloatFloatToAsciiParams
     FloatFloatToAsciiParams         struct
         ;
         ;Fields for caller to set up. All fields must be initialized.
@@ -2722,7 +2722,7 @@ the sign is determined by FFAF_SIGN_CHAR_TO_PRECEDE_TRAILER.
 **Library:** math.def
 
 ----------
-#### FloatFloatToAsciiParams_Union
+### FloatFloatToAsciiParams_Union
     FloatFloatToAsciiParams         union
         FFAP_FLOAT          FloatFloatToAsciiParams
         FFAP_DATE_TIME      FloatFloatToDateTimeParams
@@ -2734,7 +2734,7 @@ should be converted into ASCII text or into a date-time.
 **Library:** math.def
 
 ----------
-#### FloatFloatToDateTimeData
+### FloatFloatToDateTimeData
     FloatFloatToDateTimeData            struct
         FFA_dateTimeParams          FloatFloatToDateTimeParams
     FloatFloatToDateTimeData            ends
@@ -2746,7 +2746,7 @@ future. This structure exists as a member of the *FFA_stackFrame* union.
 **Library:** math.def
 
 ----------
-#### FloatFloatToDateTimeFlags
+### FloatFloatToDateTimeFlags
     FloatFloatToDateTimeFlags               record
         ; these first 2 bits must not move
         FFDT_DATE_TIME_OP           :1
@@ -2767,7 +2767,7 @@ FFDT_FORMAT stores the **DateTimeFormat** format to use.
 **Library:** math.def
 
 ----------
-#### FloatFloatToDateTimeParams
+### FloatFloatToDateTimeParams
     FloatFloatToDateTimeParams              struct
         FFA_dateTimeFlags           FloatFloatToDateTimeFlags
         FFA_year                    word
@@ -2790,7 +2790,7 @@ The **FloatFloatToDateTimeParams** is part of the
 **Library:** math.def
 
 ----------
-#### FloatFormatErrors
+### FloatFormatErrors
     FloatFormatErrors       etype   byte, 0
         FLOAT_FORMAT_NO_ERROR                   enum FloatFormatErrors
         FLOAT_FORMAT_TOO_MANY_FORMATS           enum FloatFormatErrors
@@ -2805,7 +2805,7 @@ The **FloatFloatToDateTimeParams** is part of the
 **Library:** math.def
 
 ----------
-#### FloatNum
+### FloatNum
     FloatNum        struct
         F_mantissa_wd0      word                ; offset 0
         F_mantissa_wd1      word                ; offset 2
@@ -2819,7 +2819,7 @@ This structure defines a GEOS 80 bit floating point number.
 **Library:** math.def
 
 ----------
-#### FloatStackType
+### FloatStackType
     FloatStackType      etype   byte, 0
         FLOAT_STACK_GROW                enum FloatStackType
         FLOAT_STACK_WRAP                enum FloatStackType
@@ -2842,7 +2842,7 @@ whenever it reaches its maximum size.
 **Library:** math.def
 
 ----------
-#### FloatingKeyboardInfo
+### FloatingKeyboardInfo
     FloatingKeyboardInfo    struct
         FKI_defaultPosition     word
             ; If set, the keyboard will be moved to the default position before
@@ -2855,7 +2855,7 @@ whenever it reaches its maximum size.
 **Library:** gAppC.def
 
 ----------
-#### FontAttrs
+### FontAttrs
     FontAttrs       record
         FA_USEFUL           FontUseful:1        ;TRUE: "useful" font
         FA_FIXED_WIDTH      FontPitch:1         ;TRUE: fixed width
@@ -2867,7 +2867,7 @@ whenever it reaches its maximum size.
 **Library:** font.def
 
 ----------
-#### FontEnumFlags
+### FontEnumFlags
     FontEnumFlags       record
         FEF_ALPHABETIZE     :1  ;TRUE: alphabetize list
         FEF_USEFUL          :1  ;TRUE: find "useful" fonts only
@@ -2882,7 +2882,7 @@ whenever it reaches its maximum size.
 **Library:** font.def
 
 ----------
-#### FontEnumStruct
+### FontEnumStruct
     FontEnumStruct      struct
         FES_ID      FontID
         FES_name    char FONT_NAME_LEN dup (?)  ; null terminated string
@@ -2893,7 +2893,7 @@ This structure is returned by **GrEnumFonts**.
 **Library:** font.def
 
 ----------
-#### FontFamily
+### FontFamily
     FontFamily          etype   byte
         FF_SERIF            enum FontFamily
         FF_SANS_SERIF       enum FontFamily
@@ -2907,7 +2907,7 @@ This structure is returned by **GrEnumFonts**.
 **Library:** fontID.def
 
 ----------
-#### FontGroup
+### FontGroup
     FontGroup       etype   word, 0, FID_FAMILY_DIVISIONS
         FG_SERIF        enum FontGroup, FF_SERIF        *FID_FAMILY_DIVISIONS
         FG_SANS_SERIF   enum FontGroup, FF_SANS_SERIF   *FID_FAMILY_DIVISIONS
@@ -2921,7 +2921,7 @@ This structure is returned by **GrEnumFonts**.
 **Library:** fontID.def
 
 ----------
-#### FontID
+### FontID
     FontID  etype   word
         FID_INVALID                         enum FontID, 0x0000 ; invalid font ID
         FID_PRINTER_PROP_SANS               enum FontID,  0xf200
@@ -4097,7 +4097,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** fontID.def
 
 ----------
-#### FontIDRecord
+### FontIDRecord
     FontIDRecord            record
         FIDR_maker      :4
         FIDR_ID         :12
@@ -4106,7 +4106,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** font.def
 
 ----------
-#### FontMaker
+### FontMaker
     FontMaker       etype       word, 0, FID_MAKER_DIVISIONS
         FM_BITMAP           enum FontMaker
         FM_NIMBUSQ          enum FontMaker
@@ -4121,7 +4121,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** fontID.def
 
 ----------
-#### FontMap
+### FontMap
     FontMap etype   byte, 0
         FM_EXACT        enum FontMap, 0
         FM_DONT_USE     enum FontMap, 0xff
@@ -4129,7 +4129,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** fontID.def
 
 ----------
-#### FontOrientation
+### FontOrientation
     FontOrientation     etype   byte
         FO_NORMAL       enum FontOrientation    ; normal straight up & down font
         FO_LANDSCAPE    enum FontOrientation    ; rotated 90 degrees.
@@ -4137,7 +4137,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** font.def
 
 ----------
-#### FontPitch
+### FontPitch
     FontPitch       etype       byte
         FP_PROPORTIONAL     enum FontPitch  ; proportional font.
         FP_FIXED            enum FontPitch  ; Fixed pitch font.
@@ -4145,7 +4145,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** font.def
 
 ----------
-#### FontSource
+### FontSource
     FontSource      etype   byte
         FS_BITMAP       enum FontSource     ; bitmap data
         FS_OUTLINE      enum FontSource     ; outline data
@@ -4153,7 +4153,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** font.def
 
 ----------
-#### FontUseful
+### FontUseful
     FontUseful      etype   byte
         FU_NOT_USEFUL   enum FontUseful     ; not useful for menus
         FU_USEFUL       enum FontUseful     ; useful for menus
@@ -4161,7 +4161,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** font.def
 
 ----------
-#### FontWeight
+### FontWeight
     FontWeight      etype   byte
         FW_MINIMUM      enum FontWeight, 75
         FW_NORMAL       enum FontWeight, 100
@@ -4170,7 +4170,7 @@ fonts, and FID_INVALID, which is a special case and is set to all zeros.
 **Library:** font.def
 
 ----------
-#### FontWidth
+### FontWidth
     FontWidth       etype       byte
         FWI_MINIMUM         enum FontWidth, 25
         FWI_NARROW          enum FontWidth, 75
@@ -4185,7 +4185,7 @@ This type defines the width of the font as a percentage of its normal width.
 **Library:** font.def
 
 ----------
-#### FormatArrayHeader
+### FormatArrayHeader
     FormatArrayHeader       struc
         FAH_signature           word
         FAH_numFormatEntries    word    ; format array entries that have
@@ -4197,7 +4197,7 @@ This type defines the width of the font as a percentage of its normal width.
 **Library:** math.def
 
 ----------
-#### FormatEntry
+### FormatEntry
     FormatEntry     struc
         FE_params           FormatParams
         FE_listEntryNumber  word        ; list entry number
@@ -4210,7 +4210,7 @@ This type defines the width of the font as a percentage of its normal width.
 **Library:** math.def
 
 ----------
-#### FormatError
+### FormatError
     FormatError     etype   word
         FMT_DONE                            enum FormatError, 0
         FMT_READY                           enum FormatError
@@ -4239,7 +4239,7 @@ This type defines the width of the font as a percentage of its normal width.
 **Library:** disk.def
 
 ----------
-#### FormatInfoStruc
+### FormatInfoStruc
     FormatInfoStruc     struc
         FIS_signature                   word
         FIS_userDefFmtArrayFileHan      word
@@ -4292,7 +4292,7 @@ in with the matching **FormatParams**.
 **Library:** math.def
 
 ----------
-#### FormatNameParams
+### FormatNameParams
     FormatNameParams        struct
         FNP_listEntry   word                ; the entry number in the defined 
                                             ; list
@@ -4305,7 +4305,7 @@ in with the matching **FormatParams**.
 **Library:** math.def
 
 ----------
-#### FormatOption
+### FormatOption
     FormatOption        record
                                 :2
         FO_COMMA                :1
@@ -4319,7 +4319,7 @@ in with the matching **FormatParams**.
 **Library:** math.def
 
 ----------
-#### FormatParams
+### FormatParams
     FormatParams        struc
         FP_params           FloatFloatToAsciiParams_Union
         FP_formatName       char FORMAT_NAME_LENGTH+1 dup (?)
@@ -4348,7 +4348,7 @@ within the dynamic list.
 **Library:** parse.def
 
 ----------
-#### FormatParameters
+### FormatParameters
     FormatParameters        struct
         FP_common       CommonParameters <>
         FP_nChars       word                ; Number of bytes left in the buffer.
@@ -4357,7 +4357,7 @@ within the dynamic list.
 **Library:** parse.def
 
 ----------
-#### FRSPFlags
+### FRSPFlags
     FRSPFlags       record
                                         :14
         FRSPF_ADD_DRIVE_NAME            :1
@@ -4376,7 +4376,7 @@ directory along the standard path.
 **Library:** file.def
 
 ----------
-#### FTVMCGrab
+### FTVMCGrab
     FTVMCGrab       struct
         FTVMC_OD            optr
         FTVMC_flags         MetaAlterFTVMCExclFlags
@@ -4388,7 +4388,7 @@ record, adding the optr of the Focus/Target/Model hierarchical grab.
 **Library:** uiInputC.def
 
 ----------
-#### FunctionID
+### FunctionID
     FunctionID      etype   word, 0, 2
         FUNCTION_ID_ABS                 enum FunctionID
         FUNCTION_ID_ACOS                enum FunctionID
@@ -4497,7 +4497,7 @@ record, adding the optr of the Focus/Target/Model hierarchical grab.
 **Library:** parse.def
 
 ----------
-#### FunctionType
+### FunctionType
     FunctionType        record
             :7
         FT_PRINT            :1

--- a/TechDocs/Markdown/Asmref/asmstrgg.md
+++ b/TechDocs/Markdown/Asmref/asmstrgg.md
@@ -1,7 +1,7 @@
 ## 3.3 Structures G-G
 
 ----------
-#### GadgetSizeHintArgs
+### GadgetSizeHintArgs
     GadgetSizeHintArgs          struct
         GSHA_width          SpecWidth <>        ;Width of the composite
         GSHA_height         SpecHeight <>       ;Height of each child
@@ -10,7 +10,7 @@
 **Library:** Objects/genC.def
 
 ----------
-#### GCCFeatures
+### GCCFeatures
     GCCFeatures     record
         GCCF_HORIZONTAL_GUIDES          :1
         GCCF_VERTICAL_GUIDES            :1
@@ -19,7 +19,7 @@
 **Library:** ruler.def
 
 ----------
-#### GCMIcon
+### GCMIcon
     GCMIcon etype   byte, 0
         GCMI_NONE       enum GCMIcon
         GCMI_EXIT       enum GCMIcon
@@ -28,7 +28,7 @@
 **Library:** Objects/genC.def
 
 ----------
-#### GCM_info
+### GCM_info
     GCM_info    etype   word, 0, 2
         GCMI_MIN_X      enum GCM_info   ;min x (left side bearing)
         GCMI_MIN_Y      enum GCM_info   ;min y (descent)
@@ -38,7 +38,7 @@
 **Library:** font.def
 
 ----------
-#### GCNDriveChangeNotificationType
+### GCNDriveChangeNotificationType
     GCNDriveChangeNotificationType          etype word
         GCNDCNT_CREATED         enum GCNDriveChangeNotificationType
         GCNDCNT_DESTROYED       enum GCNDriveChangeNotificationType
@@ -46,7 +46,7 @@
 **Library:** gcnlist.def
 
 ----------
-#### GCNExpressMenuNotificationType
+### GCNExpressMenuNotificationType
     GCNExpressMenuNotificationType          etype word
         GCNEMNT_CREATED         enum GCNExpressMenuNotificationType
         GCNEMNT_DESTROYED       enum GCNExpressMenuNotificationType
@@ -54,7 +54,7 @@
 **Library:** gcnlist.def
 
 ----------
-#### GCNListBlockHeader
+### GCNListBlockHeader
     GCNListBlockHeader      struct
         GCNLBH_lmemHeader           LMemBlockHeader
         GCNLBH_listOfLists          lptr.GCNListOfListsHeader
@@ -65,7 +65,7 @@ This structure begins a kernel's GCN list block.
 **Library:** gcnlist.def
 
 ----------
-#### GCNListElement
+### GCNListElement
     GCNListElement      struct
         GCNLE_item          optr
     GCNListElement      ends
@@ -75,7 +75,7 @@ This structure stores an element within a GCN list.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListHeader
+### GCNListHeader
     GCNListHeader       struct
         GCNLH_meta              ChunkArrayHeader
         GCNLH_statusEvent       hptr
@@ -103,7 +103,7 @@ process's queue when an object loses the target.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListMessageParams
+### GCNListMessageParams
     GCNListMessageParams            struct
         GCNLMP_ID               GCNListType
         GCNLMP_block            hptr.GCNDataBlockHeader
@@ -132,7 +132,7 @@ primitive routine.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListOfListsElement
+### GCNListOfListsElement
     GCNListOfListsElement           struct
         GCNLOLE_ID              GCNListType
         GCNLOLE_list            lptr.GCNListHeader
@@ -143,7 +143,7 @@ This structure defines an element in a GCN list of lists.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListOfListsHeader
+### GCNListOfListsHeader
     GCNListOfListsHeader            struct
         GCNLOL_meta             ChunkArrayHeader
         GCNLH_data              label GCNListOfListsElement
@@ -155,7 +155,7 @@ marks the start of multiple **GCNListOfListsElement** structures.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListParams
+### GCNListParams
     GCNListParams       struct
         GCNLP_ID            GCNListType
         GCNLP_optr          optr
@@ -169,7 +169,7 @@ and its associated Manufacturer list type.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListSendFlags
+### GCNListSendFlags
     GCNListSendFlags        record
         GCNLSF_SET_STATUS                       :1
         GCNLSF_IGNORE_IF_STATUS_TRANSITIONING   :1
@@ -208,7 +208,7 @@ sending the message.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListType
+### GCNListType
     GCNListType     struct
         GCNLT_manuf         ManufacturerID
         GCNLT_type          word
@@ -221,7 +221,7 @@ type defined for that manufactuer ID.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNListTypeFlags
+### GCNListTypeFlags
     GCNListTypeFlags        record
         ; high bits hold the list type.
                                 :15
@@ -232,7 +232,7 @@ type defined for that manufactuer ID.
 **Library:** Objects/metaC.def
 
 ----------
-#### GCNShutdownControlType
+### GCNShutdownControlType
     GCNShutdownControlType          etype word
         GCNSCT_SUSPEND          enum GCNShutdownControlType
         ; Task-switcher wishes to suspend the system.
@@ -244,7 +244,7 @@ type defined for that manufactuer ID.
 **Library:** gcnlist.def
 
 ----------
-#### GCNStandardListType
+### GCNStandardListType
     GCNStandardListType         etype word, 0, 2
         GCNSLT_FILE_SYSTEM          enum GCNStandardListType
         ; This notification is sent out when the file system changes.
@@ -252,7 +252,7 @@ type defined for that manufactuer ID.
 **Library:** gcnlist.def
 
 ----------
-#### GDCFeatures
+### GDCFeatures
     GDCFeatures     record
         GDCF_NEW                    :1  ;replaced with switch documents in
                                         ;transparent mode
@@ -275,7 +275,7 @@ type defined for that manufactuer ID.
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### GDCTask
+### GDCTask
     GDCTask etype byte
         GDCT_NONE               enum GDCTask
         GDCT_NEW                enum GDCTask
@@ -290,7 +290,7 @@ type defined for that manufactuer ID.
 **Library:** gDocCtrl.def
 
 ----------
-#### GDCToolboxFeatures
+### GDCToolboxFeatures
     GDCToolboxFeatures      record
         GDCTF_NEW_EMPTY         :1
         GDCTF_USE_TEMPLATE      :1
@@ -303,7 +303,7 @@ type defined for that manufactuer ID.
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### GDF_saved
+### GDF_saved
     GDF_saved       struct
         GDFS_nChars     word        ; Number of characters to draw
         GDFS_drawPos    PointWBFixed ; X/Y position to draw at
@@ -319,7 +319,7 @@ This structure stores information about a graphics string and is used in the
 **Library:** text.def
 
 ----------
-#### GDF_vars
+### GDF_vars
     GDF_vars        struct
         GDFV_saved              GDF_saved
         GDFV_styleCallback      fptr.far
@@ -357,7 +357,7 @@ Nothing
 **Library:** text.def
 
 ----------
-#### GDICFeatures
+### GDICFeatures
     GDICFeatures        record
         GDCF_OVERLAPPING_MAXIMIZED      :1
         GDCF_TILE                       :1
@@ -367,7 +367,7 @@ Nothing
 **Library:** Objects/gDCtrlC.def
 
 ----------
-#### GDICToolboxFeatures
+### GDICToolboxFeatures
     GDICToolboxFeatures         record
         GDCTF_OVERLAPPING_MAXIMIZED     :1
         GDCTF_TILE                      :1
@@ -377,7 +377,7 @@ Nothing
 **Library:** Objects/gDCtrlC.def
 
 ----------
-#### GECFeatures
+### GECFeatures
     GECFeatures     record
         GECF_UNDO           :1
         GECF_CUT            :1
@@ -390,7 +390,7 @@ Nothing
 **Library:** Objects/gEditCC.def
 
 ----------
-#### GECToolboxFeatures
+### GECToolboxFeatures
     GECToolboxFeatures      record
         GECTF_UNDO              :1
         GECTF_CUT               :1
@@ -403,7 +403,7 @@ Nothing
 **Library:** Objects/gEditCC.def
 
 ----------
-#### GenAppDoDialogParams
+### GenAppDoDialogParams
     GenAppDoDialogParams            struct
         GADDP_dialog        StandardDialogParams
         GADDP_finishOD      optr                ; OD to send method to.
@@ -413,7 +413,7 @@ Nothing
 **Library:** Objects/gAppC.def
 
 ----------
-#### GenAppIACPConnection
+### GenAppIACPConnection
     GenAppIACPConnection    struc
         GAIACPC_connection      IACPConnection
         ; The IACP connection
@@ -425,7 +425,7 @@ Nothing
 **Library:** 
 
 ----------
-#### GenAppUpdateFeaturesParams
+### GenAppUpdateFeaturesParams
     GenAppUpdateFeaturesParams              struct
         GAUFP_featuresOn        word
         GAUFP_featuresChanged   word
@@ -442,7 +442,7 @@ Nothing
 **Library:** Objects/gAppC.def
 
 ----------
-#### GenAppUsabilityCommand
+### GenAppUsabilityCommand
     GenAppUsabilityCommand          etype byte
         GAUC_USABILITY              enum GenAppUsabilityCommand
         GAUC_RECALC_CONTROLLER      enum GenAppUsabilityCommand
@@ -478,7 +478,7 @@ not-usable and then setting it usable.
 **Library:** gAppC.def
 
 ----------
-#### GenAppUsabilityTuple
+### GenAppUsabilityTuple
     GenAppUsabilityTuple            struct
         GAUT_flags              GenAppUsabilityTupleFlags
         GAUT_objChunk           lptr
@@ -488,7 +488,7 @@ not-usable and then setting it usable.
 **Library:** Objects/gAppC.def
 
 ----------
-#### GenAppUsabilityTupleFlags
+### GenAppUsabilityTupleFlags
     GenAppUsabilityTupleFlags               record
                                     :2
         GAUTF_END_OF_LIST           :1
@@ -499,7 +499,7 @@ not-usable and then setting it usable.
 **Library:** Objects/gAppC.def
 
 ----------
-#### GenAttrs
+### GenAttrs
     GenAttrs        record
         GA_SIGNAL_INTERACTION_COMPLETE          :1
         GA_INITIATES_BUSY_STATE                 :1
@@ -599,7 +599,7 @@ ATTR_GEN_VISIBILITY_DATA for more details.
 **Library:** Objects/genC.def
 
 ----------
-#### GenBranchInfo
+### GenBranchInfo
     GenBranchInfo       record
         GBI_USABLE              :1
         GBI_BRANCH_MINIMIZED    :1
@@ -616,7 +616,7 @@ SA_BRANCH_MINIMIZED in. (This flag is only valid if GBI_USABLE is set.)
 **Library:** Objects/visC.def
 
 ----------
-#### GenControlBuildFlags
+### GenControlBuildFlags
     GenControlBuildFlags            record
         GCBF_SUSPEND_ON_APPLY                               :1
         GCBF_USE_GEN_DESTROY                                :1
@@ -698,7 +698,7 @@ closed.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlBuildInfo
+### GenControlBuildInfo
     GenControlBuildInfo         struct
         ;
         ; General information
@@ -739,7 +739,7 @@ closed.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlChildFlags
+### GenControlChildFlags
     GenControlChildFlags            record
         GCCF_NOTIFY_WHEN_ADDING         :1
         GCCF_ALWAYS_ADD                 :1
@@ -749,7 +749,7 @@ closed.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlChildInfo
+### GenControlChildInfo
     GenControlChildInfo             struct
         GCCI_object             lptr
         GCCI_featureMask        word
@@ -762,7 +762,7 @@ a bitmask of the combination of tools that compose this object.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlFeatureFlags
+### GenControlFeatureFlags
     GenControlFeatureFlags          record
                                 :8
     GenControlFeatureFlags          end
@@ -770,7 +770,7 @@ a bitmask of the combination of tools that compose this object.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlFeaturesInfo
+### GenControlFeaturesInfo
     GenControlFeaturesInfo          struct
         GCFI_object             lptr
         GCFI_name               optr
@@ -785,7 +785,7 @@ reference to the name of the feature (if the feature is allowed be changed).
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlInteractableFlags
+### GenControlInteractableFlags
     GenControlInteractableFlags             record
         GCIF_CONTROLLER     :1  ;Controller object itself is interactable and
                                 ;may need to be enabled/disabled
@@ -797,7 +797,7 @@ reference to the name of the feature (if the feature is allowed be changed).
 **Library:** Objects/gCtlC.def
 
 ----------
-#### GenControlScalableUICommand
+### GenControlScalableUICommand
     GenControlScalableUICommand             etype byte
         CSUIC_SET_NORMAL_FEATURES_IF_APP_FEATURE_ON enum GenControlScalableUICommand
         ; if (GCSUIE_appFeature is ON)
@@ -887,7 +887,7 @@ GCSUIC_SET_TOOLBOX_FEATURES_IF_APP_FEATURE_ON.
 **Library:** gCtlC.def
 
 ----------
-#### GenControlScalableUIEntry
+### GenControlScalableUIEntry
     GenControlScalableUIEntry               struct
         GCSUIE_command          GenControlScalableUICommand
         GCSUIE_appFeature       word            ;feature bit to check.
@@ -897,7 +897,7 @@ GCSUIC_SET_TOOLBOX_FEATURES_IF_APP_FEATURE_ON.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlScanInfo
+### GenControlScanInfo
     GenControlScanInfo          struct
         GCSI_userAdded              word
         GCSI_userRemoved            word
@@ -908,7 +908,7 @@ GCSUIC_SET_TOOLBOX_FEATURES_IF_APP_FEATURE_ON.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlStatusChange
+### GenControlStatusChange
     GenControlStatusChange          record
                                                 :13
         GCSF_HIGHLIGHTED_TOOLGROUP_SELECTED     :1
@@ -930,7 +930,7 @@ This flag is set if normal features have been added or removed.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlUIType
+### GenControlUIType
     GenControlUIType        etype word
         GCUIT_NORMAL            enum    GenControlUIType
         GCUIT_TOOLBOX           enum    GenControlUIType
@@ -946,7 +946,7 @@ consists of "Tiny" sized triggers or items within popup lists.
 **Library:** gCtlC.def
 
 ----------
-#### GenControlUpdateUIParams
+### GenControlUpdateUIParams
     GenControlUpdateUIParams        struct
         GCUUIP_manufacturer             ManufacturerID
         GCUUIP_changeType               word
@@ -971,7 +971,7 @@ TEMP_GEN_CONTROL_INSTANCE).
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlUserData
+### GenControlUserData
     GenControlUserData          struc
         GCUD_flags                      GenControlUserFlags
         GCUD_userAddedUI                word
@@ -983,7 +983,7 @@ TEMP_GEN_CONTROL_INSTANCE).
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenControlUserFlags
+### GenControlUserFlags
     GenControlUserFlags         record
                                     :14
         GCUF_USER_TOOLBOX_UI        :1
@@ -993,7 +993,7 @@ TEMP_GEN_CONTROL_INSTANCE).
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### GenDefaultMonikerType
+### GenDefaultMonikerType
     GenDefaultMonikerType       etype word
         ; monikers used for various levels in the Set User Level dialog box.
         GDMT_LEVEL_0                enum GenDefaultMonikerType
@@ -1010,7 +1010,7 @@ TEMP_GEN_CONTROL_INSTANCE).
 **Library:** Objects/genC.def
 
 ----------
-#### GenDisplayAttrs
+### GenDisplayAttrs
     GenDisplayAttrs     record
         GDA_USER_DISMISSABLE        :1
                                     :7
@@ -1027,7 +1027,7 @@ system menu.
 **Library:** Objects/gDispC.def
 
 ----------
-#### GenDisplayControlAttributes
+### GenDisplayControlAttributes
     GenDisplayControlAttributes             record
         GDCA_MAXIMIZED_NAME_ON_PRIMARY          :1
                                                 :7
@@ -1040,7 +1040,7 @@ of the primary.
 **Library:** Objects/gDCtrlC.def
 
 ----------
-#### GenDocumentAttrs
+### GenDocumentAttrs
     GenDocumentAttrs        record
         ;
         ; These bits reflect permanent attributes of the document
@@ -1075,7 +1075,7 @@ of the primary.
 **Library:** Objects/gDocC.def
 
 ----------
-#### GenDocumentChangePasswordParams
+### GenDocumentChangePasswordParams
     GenDocumentChangePasswordParams                 struct
         GDCPP_password          char (MAX_PASSWORD_SIZE+2) dup (?)
     GenDocumentChangePasswordParams                 ends
@@ -1083,7 +1083,7 @@ of the primary.
 **Library:** Objects/gDocC.def
 
 ----------
-#### GenDocumentControlAttrs
+### GenDocumentControlAttrs
     GenDocumentControlAttrs         record
         ;
         ; File attributes
@@ -1112,7 +1112,7 @@ of the primary.
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### GenDocumentControlFeatures
+### GenDocumentControlFeatures
     GenDocumentControlFeatures              record
         ; File features
         GDCF_READ_ONLY_SUPPORTS_SAVE_AS_REVERT          :1
@@ -1139,7 +1139,7 @@ If set, the document control supports template documents.
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### GenDocumentControlMode
+### GenDocumentControlMode
     GenDocumentControlMode      etype byte
         GDCM_VIEWER                 enum GenDocumentControlMode
         GDCM_SHARED_SINGLE          enum GenDocumentControlMode
@@ -1148,7 +1148,7 @@ If set, the document control supports template documents.
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### GenDocumentGetVariableParams
+### GenDocumentGetVariableParams
     GenDocumentGetVariableParams                struct
         GDGVP_position          PointDWord              ;object position
         GDGVP_buffer            fptr.char               ;buffer for result
@@ -1159,7 +1159,7 @@ If set, the document control supports template documents.
 **Library:** Objects/gDocC.def
 
 ----------
-#### GenDocumentGroupAttrs
+### GenDocumentGroupAttrs
     GenDocumentGroupAttrs           record
         GDGA_VM_FILE                            :1  ;Documents stored in VM files
         GDGA_NATIVE                             :1  ;If document not in VM file,
@@ -1186,7 +1186,7 @@ If set, the document control supports template documents.
 **Library:** Objects/gDocGrpC.def
 
 ----------
-#### GenDocumentOperation
+### GenDocumentOperation
     GenDocumentOperation            etype word
         GDO_NORMAL              enum GenDocumentOperation
         GDO_SAVE_AS             enum GenDocumentOperation
@@ -1203,7 +1203,7 @@ If set, the document control supports template documents.
 **Library:** Objects/gDocC.def
 
 ----------
-#### GenDocumentType
+### GenDocumentType
     GenDocumentType     etype word
         GDT_NORMAL                  enum GenDocumentType
         GDT_READ_ONLY               enum GenDocumentType
@@ -1215,7 +1215,7 @@ If set, the document control supports template documents.
 **Library:** Objects/gDocC.def
 
 ----------
-#### GenDynamicListPosition
+### GenDynamicListPosition
     GenDynamicListPosition          etype word
         GDLP_FIRST          enum GenDynamicListPosition, 00000h
         GDLP_LAST           enum GenDynamicListPosition, 0ffffh
@@ -1223,7 +1223,7 @@ If set, the document control supports template documents.
 **Library:** Objects/gDListC.def
 
 ----------
-#### GeneralConsumerModeFlags
+### GeneralConsumerModeFlags
     GeneralConsumerModeFlags        record
                                         :2
         GCMF_LEFT_ICON      GCMIcon:3   ; Indicates which icon to show on 
@@ -1235,7 +1235,7 @@ If set, the document control supports template documents.
 **Library:** Objects/genC.def
 
 ----------
-#### GeneralEvent
+### GeneralEvent
     GeneralEvent        etype word, 0, 2
         GE_NO_EVENT                 enum GeneralEvent
         GE_END_OF_SONG              enum GeneralEvent
@@ -1274,7 +1274,7 @@ This event causes the stream to V the semaphore handle.
 **Library:** sound.def
 
 ----------
-#### GenFieldFlags
+### GenFieldFlags
     GenFieldFlags       record
         GFF_DETACHING               :1
         GFF_LOAD_BITMAP             :1
@@ -1325,7 +1325,7 @@ system was too busy - wait until a process exits, then try again.
 **Library:** Objects/gFieldC.def
 
 ----------
-#### GenFilePath
+### GenFilePath
     GenFilePath     struct
         GFP_disk        word SP_TOP
         GFP_path        PathName
@@ -1340,7 +1340,7 @@ be initialized to a **StandardPath** constant.
 **Library:** Objects/genC.def
 
 ----------
-#### GenFileSelectorEntryFlags
+### GenFileSelectorEntryFlags
     GenFileSelectorEntryFlags               record
         GFSEF_TYPE              GenFileSelectorEntryType:2
         GFSEF_OPEN              :1
@@ -1389,7 +1389,7 @@ entry (first entry).
 **Library:** Objects/gFSelC.def
 
 ----------
-#### GenFileSelectorEntryType
+### GenFileSelectorEntryType
     GenFileSelectorEntryType            etype byte, 0
         GFSET_FILE              enum GenFileSelectorEntryType
         GFSET_SUBDIR            enum GenFileSelectorEntryType
@@ -1398,7 +1398,7 @@ entry (first entry).
 **Library:** Objects/gFSelC.def
 
 ----------
-#### GenFileSelectorFileAttrs
+### GenFileSelectorFileAttrs
     GenFileSelectorFileAttrs                struct
         GFSFA_match         FileAttrs   ; Attributes that must match
         GFSFA_mismatch      FileAttrs   ; Attributes that must not match
@@ -1407,7 +1407,7 @@ entry (first entry).
 **Library:** Object/gFSelC.def
 
 ----------
-#### GenFileSelectorGeodeAttrs
+### GenFileSelectorGeodeAttrs
     GenFileSelectorGeodeAttrs               struct
         GFSGA_match         GeodeAttrs  ; Attributes that must match
         GFSGA_mismatch      GeodeAttrs  ; Attributes that must not match
@@ -1416,7 +1416,7 @@ entry (first entry).
 **Library:** Objects/gFSelC.def
 
 ----------
-#### GenFileSelectorScalableUICommand
+### GenFileSelectorScalableUICommand
     GenFileSelectorScalableUICommand                    etype byte
         GFSSUIC_SET_FEATURES_IF_APP_FEATURE_ON      enum 
         GenFileSelectorScalableUICommand
@@ -1432,7 +1432,7 @@ entry (first entry).
 **Library:** Objects/gFSelcC.def
 
 ----------
-#### GenFileSelectorScalableUIEntry
+### GenFileSelectorScalableUIEntry
     GenFileSelectorScalableUIEntry                  struct
         GFSSUIE_command             GenFileSelectorScalableUICommand
         GFSSUIE_appFeature          word
@@ -1442,7 +1442,7 @@ entry (first entry).
 **Library:** Objects/gFSelC.def
 
 ----------
-#### GenFileSelectorType
+### GenFileSelectorType
     GenFileSelectorType         etype byte
         GFST_DOCUMENTS              enum GenFileSelectorType
         GFST_EXECUTABLES            enum GenFileSelectorType
@@ -1452,7 +1452,7 @@ entry (first entry).
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### GenFindObjectWithMonikerFlags
+### GenFindObjectWithMonikerFlags
     GenFindObjectWithMonikerFlags               record
         GFOWMF_EXACT_MATCH              :1
         GFOWMF_SKIP_THIS_NODE           :1
@@ -1471,7 +1471,7 @@ it in the generic tree.
 **Library:** Objects/genC.def
 
 ----------
-#### GenGadgetAttributes
+### GenGadgetAttributes
     GenGadgetAttributes         record
         GGA_COMPOSITE       :1
                             :7
@@ -1484,7 +1484,7 @@ generic children will become visual children.
 **Library:** Objects/gGadgetC.def
 
 ----------
-#### GenInteractionAttrs
+### GenInteractionAttrs
     GenInteractionAttrs         record
         GIA_NOT_USER_INITIATABLE            :1
         GIA_INITIATED_VIA_USER_DO_DIALOG    :1
@@ -1525,7 +1525,7 @@ the system.
 **Library:** Objects/gInterC.def
 
 ----------
-#### GenInteractionDiscardInfo
+### GenInteractionDiscardInfo
     GenInteractionDiscardInfo       struct
         GIDI_inUse              word
         ; If non-zero, the interaction is onscreen, or is about to go
@@ -1538,7 +1538,7 @@ the system.
 **Library:** gInterC.def
 
 ----------
-#### GenInteractionGroupType
+### GenInteractionGroupType
     GenInteractionGroupType         etype byte
     GIGT_FILE_MENU          enum        GenInteractionGroupType
     ; Set to indicate that this GenInteraction is the File menu. Can
@@ -1603,7 +1603,7 @@ commands.
 **Library:** Objects/gInterC.def
 
 ----------
-#### GenInteractionType
+### GenInteractionType
     GenInteractionType      etype byte
         GIT_ORGANIZATIONAL          enum GenInteractionType
         GIT_PROPERTIES              enum GenInteractionType
@@ -1724,7 +1724,7 @@ with modal implementations of this type of GenInteraction.
 **Library:** Objects/gInterC.def
 
 ----------
-#### GenInteractionVisibility
+### GenInteractionVisibility
     GenInteractionVisibility            etype byte
         GIV_NO_PREFERENCE       enum GenInteractionVisibility
         GIV_POPUP               enum GenInteractionVisibility
@@ -1780,7 +1780,7 @@ interaction will be popped out upon startup.
 **Library:** Objects/gInterC.def
 
 ----------
-#### GenItemGroupBehaviorType
+### GenItemGroupBehaviorType
 GenItemGroupBehaviorType            etype byte, 0
 GIGBT_EXCLUSIVE                 enum GenItemGroupBehaviorType
 GIGBT_EXCLUSIVE_NONE            enum GenItemGroupBehaviorType
@@ -1824,7 +1824,7 @@ handle multiple selections.
 **Library:** Objects/gItemGC.def
 
 ----------
-#### GenItemGroupStateFlags
+### GenItemGroupStateFlags
     GenItemGroupStateFlags          record
         GIGSF_INDETERMINATE     :1
         GIGSF_MODIFIED          :1
@@ -1870,7 +1870,7 @@ this bit will be the value passed in that message.
 **Library:** Objects/gItemGC.def
 
 ----------
-#### GenItemGroupUpdateExtSelParams
+### GenItemGroupUpdateExtSelParams
     GenItemGroupUpdateExtSelParams                  struc
         GIGUESP_anchorItem      word        ;anchor item
         GIGUESP_extentItem      word        ;extent item
@@ -1886,7 +1886,7 @@ this bit will be the value passed in that message.
 **Library:** Objects/gItemGC.def
 
 ----------
-#### GenMonikerMessageFrame
+### GenMonikerMessageFrame
     GenMonikerMessageFrame          struct
         GMMF_xInset             word
         GMMF_yInset             word
@@ -1922,7 +1922,7 @@ for drawing the moniker.
 **Library:** Objects/genC.def
 
 ----------
-#### GenOptionsParams
+### GenOptionsParams
     GenOptionsParams        struct
         GOP_category    char INI_CATEGORY_BUFFER_SIZE dup (?)
         GOP_key         char INI_CATEGORY_BUFFER_SIZE dup (?)
@@ -1931,7 +1931,7 @@ for drawing the moniker.
 **Library:** Objects/genC.def
 
 ----------
-#### GenPathDiskRestoreArgs
+### GenPathDiskRestoreArgs
     GenPathDiskRestoreArgs      struct
         GPDRA_pathType              word
         GPDRA_savedDiskType         word
@@ -1956,7 +1956,7 @@ with a trailing ':'.
 **Library:** Objects/genC.def
 
 ----------
-#### GenSaveWindowInfo
+### GenSaveWindowInfo
     GenSaveWindowInfo       struct
         GSWI_winPosition            SpecWinSizePair
         GSWI_winSize                SpecWinSizePair
@@ -1966,7 +1966,7 @@ with a trailing ':'.
 **Library:** Objects/genC.def
 
 ----------
-#### GenScanItemsFlags
+### GenScanItemsFlags
     GenScanItemsFlags       record
         GSIF_FROM_START                         :1
         GSIF_FORWARD                            :1
@@ -2010,7 +2010,7 @@ list rather than returning the first or last item.
 **Library:** Objects/gItemGC.def
 
 ----------
-#### GenStates
+### GenStates
     GenStates       record
         GS_USABLE       :1
         GS_ENABLED      :1
@@ -2033,7 +2033,7 @@ is typically represented by "greying out" the object's moniker.
 **Library:** Objects/genC.def
 
 ----------
-#### GenTextAttrs
+### GenTextAttrs
     GenTextAttrs        record
         GTA_SINGLE_LINE_TEXT                :1
         GTA_USE_TAB_FOR_NAVIGATION          :1
@@ -2083,7 +2083,7 @@ automatically scrolling there.
 **Library:** Objects/gTextC.def
 
 ----------
-#### GenTextCustomMargins
+### GenTextCustomMargins
     GenTextCustomMargins            struc
         GTCM_lrMargin       byte    ;margin on the left and right of the text.
         GTCM_rbMargin       byte    ;margin on the top and bottom of the text.
@@ -2092,7 +2092,7 @@ automatically scrolling there.
 **Library:** Objects/gTextC.def
 
 ----------
-#### GenTextStateFlags
+### GenTextStateFlags
     GenTextStateFlags       record
         GTSF_INDETERMINATE      :1
         GTSF_MODIFIED           :1
@@ -2132,7 +2132,7 @@ will be passed in that message.
 **Library:** Objects/gTextC.def
 
 ----------
-#### GenUpwardQueryType
+### GenUpwardQueryType
     GenUpwardQueryType      etype word
         GUQT_UI_FOR_APPLICATION         enum GenUpwardQueryType
         GUQT_UI_FOR_SCREEN              enum GenUpwardQueryType
@@ -2142,7 +2142,7 @@ will be passed in that message.
 **Library:** Objects/genC.def
 
 ----------
-#### GenValueDisplayFormat
+### GenValueDisplayFormat
     GenValueDisplayFormat           etype byte
         GVDF_INTEGER                    enum GenValueDisplayFormat
         GVDF_DECIMAL                    enum GenValueDisplayFormat
@@ -2253,7 +2253,7 @@ ATTR_GEN_VALUE_DECIMAL_PLACES.
 **Library:** Objects/gValueC.def
 
 ----------
-#### GenValueIntervals
+### GenValueIntervals
     GenValueIntervals       struc
         GVI_numMajorIntervals   word    ; Total number of major intervals
                                         ; to display over the range.
@@ -2264,7 +2264,7 @@ ATTR_GEN_VALUE_DECIMAL_PLACES.
 **Library:** Objects/gValueC.def
 
 ----------
-#### GenValueStateFlags
+### GenValueStateFlags
     GenValueStateFlags      record
         GVSF_INDETERMINATE      :1
         GVSF_MODIFIED           :1
@@ -2332,7 +2332,7 @@ the GenValue has been modified.
 **Library:** Objects/gValueC.def
 
 ----------
-#### GenValueType
+### GenValueType
     GenValueType        etype word
         GVT_VALUE           enum GenValueType   ; The current value 
         GVT_MINIMUM         enum GenValueType   ; The minimum value
@@ -2352,7 +2352,7 @@ the GenValue has been modified.
 **Library:** Objects/gValueC.def
 
 ----------
-#### GenViewAttrs
+### GenViewAttrs
     GenViewAttrs        record
         ;
         ; General GenView Attributes
@@ -2510,7 +2510,7 @@ screen.
 **Library:** Objects/gViewC.def
 
 ----------
-#### GenViewControlAttrs
+### GenViewControlAttrs
     GenViewControlAttrs         record
         GVCA_ADJUST_ASPECT_RATIO        :1
         GVCA_APPLY_TO_ALL               :1
@@ -2522,14 +2522,14 @@ screen.
 **Library:** Objects/gViewCC.def
 
 ----------
-#### GenViewControlSpecialScaleFactor
+### GenViewControlSpecialScaleFactor
     GenViewControlSpecialScaleFactor            etype word
         GVCSSF_TO_FIT           enum GenViewControlSpecialScaleFactor
 
 **Library:** Objects/gViewCC.def
 
 ----------
-#### GenViewDimensionAttrs
+### GenViewDimensionAttrs
     GenViewDimensionAttrs           record
         GVDA_SCROLLABLE                     :1
         GVDA_SPLITTABLE                     :1
@@ -2589,7 +2589,7 @@ calculate the height; and vice versa for horizAttrs.
 **Library:** Objects/gViewC.def
 
 ----------
-#### GenViewInkType
+### GenViewInkType
     GenViewInkType      etype byte
         GVIT_PRESSES_ARE_NOT_INK            enum GenViewInkType
         GVIT_INK_WITH_STANDARD_OVERRIDE     enum GenViewInkType
@@ -2627,7 +2627,7 @@ output.
 **Library:** Objects/gViewC.def
 
 ----------
-#### GeodeAttrs
+### GeodeAttrs
     GeodeAttrs      record
         GA_PROCESS                      :1  ; Has initial thread
         GA_LIBRARY                      :1  ; Exports routines
@@ -2652,7 +2652,7 @@ output.
 **Library:** geode.def
 
 ----------
-#### GeodeDefaultDriverType
+### GeodeDefaultDriverType
     GeodeDefaultDriverType          etype word, 0, 2
         GDDT_FILE_SYSTEM        enum GeodeDefaultDriverType
         GDDT_KEYBOARD           enum GeodeDefaultDriverType
@@ -2665,7 +2665,7 @@ output.
 **Library:** driver.def
 
 ----------
-#### GeodeGetInfoType
+### GeodeGetInfoType
     GeodeGetInfoType        etype word, 0, 2
         GGIT_ATTRIBUTES             enum GeodeGetInfoType
         GGIT_TYPE                   enum GeodeGetInfoType
@@ -2678,7 +2678,7 @@ output.
 **Library:** geode.def
 
 ----------
-#### GeodeGrab
+### GeodeGrab
     GeodeGrab       struct
         GG_OD           optr
         GG_geode        hptr
@@ -2689,7 +2689,7 @@ This structure stores a top-level grab for controlling input flow to the geode.
 **Library:** Objects/uiInputC.def
 
 ----------
-#### GeodeHeapVars
+### GeodeHeapVars
     GeodeHeapVars   struc
         GHV_heapSpace           word
         ;
@@ -2701,7 +2701,7 @@ This structure stores a top-level grab for controlling input flow to the geode.
 
 **Library:** geode.def
 ----------
-#### GeodeLoadError
+### GeodeLoadError
     GeodeLoadError      etype word
         GLE_PROTOCOL_IMPORTER_TOO_RECENT        enum GeodeLoadError
         GLE_PROTOCOL_IMPORTER_TOO_OLD           enum GeodeLoadError
@@ -2723,7 +2723,7 @@ This structure stores a top-level grab for controlling input flow to the geode.
 
 **Library:** geode.def
 ----------
-#### GeodeToken
+### GeodeToken
     GeodeToken      struct
         GT_chars            TokenChars
         GT_manufID          ManufacturerID
@@ -2739,7 +2739,7 @@ fields uniquely identify the application.
 **Library:** geode.def
 
 ----------
-#### GeosFileHeaderFlags
+### GeosFileHeaderFlags
     GeosFileHeaderFlags             record
         GFHF_TEMPLATE           :1
         GFHF_SHARED_MULTIPLE    :1  ; Also called "multi-user"
@@ -2757,7 +2757,7 @@ fields uniquely identify the application.
 **Library:** file.def
 
 ----------
-#### GeosFileType
+### GeosFileType
     GeosFileType        etype word
         GFT_NOT_GEOS_FILE   enum GeosFileType   ; Not a geos file. defined as 
                                                 ; 0 so one can reasonably 
@@ -2775,7 +2775,7 @@ fields uniquely identify the application.
 **Library:** file.def
 
 ----------
-#### GeoWorksGenAppGCNListType
+### GeoWorksGenAppGCNListType
     GeoWorksGenAppGCNListType               etype word, FIRST_GEN_APP_GCN_LIST_TYPE,2
         ;
         ; GenToolControl/GenControl communication related
@@ -3164,7 +3164,7 @@ changes within the application.
 **Library:** geoworks.def
 
 ----------
-#### GeoWorksMetaGCNListType
+### GeoWorksMetaGCNListType
     GeoWorksMetaGCNListType         etype word, FIRST_META_GCN_LIST_TYPE, 2
         MGCNLT_ACTIVE_LIST              enum GeoWorksMetaGCNListType
         MGCNLT_APP_STARTUP              enum GeoWorksMetaGCNListType
@@ -3208,7 +3208,7 @@ MSG_META_APP_SHUTDOWN are defined for MetaClass.
 **Library:** geoworks.def
 
 ----------
-#### GeoWorksNotificationType
+### GeoWorksNotificationType
     GeoWorksNotificationType            etype word
         GWNT_INK                                enum GeoWorksNotificationType
         GWNT_GEN_CONTROL_NOTIFY_STATUS_CHANGE   enum GeoWorksNotificationType
@@ -3641,7 +3641,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** geoworks.def
 
 ----------
-#### GeoWorksPrefDialogGCNListType
+### GeoWorksPrefDialogGCNListType
     GeoWorksPrefDialogGCNListType   etype word, first PrefDialogMessages, 2
         PDGCNLT_DIALOG_CHANGE           enum GeoWorksPrefDialogGCNListType
         ; MSG_PREF_NOTIFY_DIALOG_CHANGE sent out.
@@ -3649,7 +3649,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** config.def
 
 ----------
-#### GeoWorksVisContentGCNListType
+### GeoWorksVisContentGCNListType
     GeoWorksVisContentGCNListType               etype word , 
         FIRST_VIS_CONTENT_GCN_LIST_TYPE, 2
         VCGCNLT_TARGET_NOTIFY_TEXT_PARA_ATTR_CHANGE enum 
@@ -3659,7 +3659,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** geoworks.def
 
 ----------
-#### GestureType
+### GestureType
     GestureType     etype word
         GT_NO_GESTURE               enum GestureType
         GT_DELETE_CHARS             enum GestureType
@@ -3671,7 +3671,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** hwr.def
 
 ----------
-#### GetContextParams
+### GetContextParams
     GetContextParams        struct
         GCP_replyObj        optr    ;Output to reply to via MSG_META_CONTEXT
         GCP_numCharsToGet   word    ;Maximum number of characters to return
@@ -3682,7 +3682,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** Objects/vTextC.def
 
 ----------
-#### GetItemMonikerParams
+### GetItemMonikerParams
     GetItemMonikerParams        struct
         GIMP_identifier             word
         GIMP_bufferSize             word
@@ -3692,7 +3692,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** config.def
 
 ----------
-#### GetMaskType
+### GetMaskType
     GetMaskType     etype byte
         GMT_ENUM        enum GetMaskType
         GMT_BUFFER      enum GetMaskType
@@ -3700,7 +3700,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** graphics.def
 
 ----------
-#### GetPalType
+### GetPalType
     GetPalType      etype byte
         GPT_ACTIVE          enum GetPalType
         GPT_DEFAULT         enum GetPalType
@@ -3708,7 +3708,7 @@ Data type: **PCComReturnType** from the call to PCCOMEXIT.
 **Library:** color.def
 
 ----------
-#### GetPathType
+### GetPathType
     GetPathType     etype   word
         GPT_CURRENT     enum GetPathType    ; current path
         GPT_CLIP        enum GetPathType    ; clip path
@@ -3719,7 +3719,7 @@ Use this type with **GrGetPath** to determine which sort of path to get.
 **Library:** 
 
 ----------
-#### GetSearchSpellObjectParam
+### GetSearchSpellObjectParam
     GetSearchSpellObjectParam               record
         GSSOP_RELAYED_FLAG      :1
                                 :11
@@ -3729,7 +3729,7 @@ Use this type with **GrGetPath** to determine which sort of path to get.
 **Library:** Objects/vTextC.def
 
 ----------
-#### GetSearchSpellObjectType
+### GetSearchSpellObjectType
     GetSearchSpellObjectType            etype word
         GSSOT_FIRST_OBJECT              enum GetSearchSpellObjectType
         GSSOT_LAST_OBJECT               enum GetSearchSpellObjectType
@@ -3760,7 +3760,7 @@ of the chain, it should return 0:0.
 **Library:** Objects/vTextC.def
 
 ----------
-#### GetVarDataParams
+### GetVarDataParams
     GetVarDataParams        struct
         GVDP_buffer             fptr
         GVDP_bufferSize         word
@@ -3778,7 +3778,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** Objects/metaC.def
 
 ----------
-#### GFM_info
+### GFM_info
     GFM_info        etype word, 0, 2
         GFMI_HEIGHT                 enum GFM_info   ;height of font box
         GFMI_MEAN                   enum GFM_info   ;top of lowers
@@ -3805,7 +3805,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** font.def
 
 ----------
-#### GFSTempDataEntry
+### GFSTempDataEntry
     GFSTempDataEntry        struct
         GFSTDE_selectionNumber      word
         GFSTDE_selectionFlags       GenFileSelectorEntryFlags
@@ -3814,7 +3814,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** Objects/gFSelC.def
 
 ----------
-#### GOAACFeatures
+### GOAACFeatures
     GOAACFeatures       record
         GOAACF_MM_CLEAR             :1
         GOAACF_MM_COPY              :1
@@ -3830,7 +3830,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOArcCFeatures
+### GOArcCFeatures
     GOArcCFeatures      record
         GOACF_START_ANGLE           :1
         GOACF_END_ANGLE             :1
@@ -3841,7 +3841,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOATGCFeatures
+### GOATGCFeatures
     GOATGCFeatures      record
         GOATGCF_ALIGN_TO_GRID       :1
     GOATGCFeatures      end
@@ -3849,7 +3849,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOCCFeatures
+### GOCCFeatures
     GOCCFeatures        record
         GOCCF_CONVERT_TO_BITMAP         :1
         GOCCF_CONVERT_TO_GRAPHIC        :1
@@ -3859,7 +3859,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOCDCFeatures
+### GOCDCFeatures
     GOCDCFeatures       record
         GOCDCF_REPITITIONS      :1
         GOCDCF_MOVE             :1
@@ -3871,7 +3871,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOCSCFeatures
+### GOCSCFeatures
     GOCSCFeatures       record
         GOCSCF_NUM_POLYGON_SIDES        :1
         GOCSCF_POLYGON_RADIUS           :1
@@ -3882,7 +3882,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GODACFeatures
+### GODACFeatures
     GODACFeatures       record
         GODACF_SET_DEFAULT_ATTRIBUTES       :1
     GODACFeatures       end
@@ -3890,7 +3890,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GODepthCFeatures
+### GODepthCFeatures
     GODepthCFeatures        record
         GODepthCF_BRING_TO_FRONT            :1
         GoDepthCF_SEND_TO_BACK              :1
@@ -3901,7 +3901,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GODMCFeatures
+### GODMCFeatures
     GODMCFeatures       record
         GODMCF_DRAFT_MODE               :1
     GODMCFeatures       end
@@ -3909,7 +3909,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOFCFeatures
+### GOFCFeatures
     GOFCFeatures        record
         GOFCF_FLIP_HORIZONTALLY             :1
         GOFCF_FLIP_VERTICALLY               :1
@@ -3918,7 +3918,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOGCFeatures
+### GOGCFeatures
     GOGCFeatures        record
         GOGCF_GROUP             :1
         GOGCF_UNGROUP           :1
@@ -3927,7 +3927,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOHCFeatures
+### GOHCFeatures
     GOHCFeatures        record
         GOHCF_SMALL_HANDLES             :1
         GOHCF_MEDIUM_HANDLES            :1
@@ -3938,7 +3938,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOHSCFeatures
+### GOHSCFeatures
     GOHSCFeatures       record
         GOHSCF_HIDE         :1
         GOHSCF_SHOW         :1
@@ -3947,7 +3947,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOLACFeatures
+### GOLACFeatures
     GOLACFeatures       record
         GOLACF_WIDTH_INDEX          :1
         GOLACF_WIDTH_VALUE          :1
@@ -3959,7 +3959,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOLACToolboxFeatures
+### GOLACToolboxFeatures
     GOLACToolboxFeatures            record
         GOLACTF_WIDTH_INDEX             :1
         GOLACTF_STYLE                   :1
@@ -3968,7 +3968,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOPICFeatures
+### GOPICFeatures
     GOPICFeatures   record
         GOPICF_PASTE_INSIDE             :1
         GOPICF_BREAKOUT_PASTE_INSIDE    :1
@@ -3977,7 +3977,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOPICToolboxFeatures
+### GOPICToolboxFeatures
     GOPICToolboxFeatures    record
         GOPICTF_PASTE_INSIDE            :1
         GOPICTF_BREAKOUT_PASTE_INSIDE   :1
@@ -3986,7 +3986,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOTCFeatures
+### GOTCFeatures
     GOTCFeatures        record
         GOTCF_PTR               :1
         GOTCF_ROTATE_PTR        :1
@@ -4005,7 +4005,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GOTransformCFeatures
+### GOTransformCFeatures
     GOTransformCFeatures            record
         GOTCF_UNTRANSFORM               :1
     GOTransformCFeatures            end
@@ -4013,7 +4013,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GPCFeatures
+### GPCFeatures
     GPCFeatures         record
         GPCF_GOTO_PAGE              :1
         GPCF_NEXT_PAGE              :1
@@ -4023,7 +4023,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** gPageCC.def
 
 ----------
-#### GPCToolboxFeatures
+### GPCToolboxFeatures
     GPCToolboxFeatures      record
         GPCTF_PREVIOUS_PAGE         :1
         GPCTF_GOTO_PAGE             :1
@@ -4033,7 +4033,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** gPageCC.def
 
 ----------
-#### GPICFeatures
+### GPICFeatures
     GPICFeatures            record
         GPICF_KEYBOARD                      :1
         GPICF_CHAR_TABLE                    :1
@@ -4047,7 +4047,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** gPenICC.def
 
 ----------
-#### GPICToolboxFeatures
+### GPICToolboxFeatures
     GPICToolboxFeatures         record
         GPICTF_INITIATE     :1
     GPICToolboxFeatures         end
@@ -4055,7 +4055,7 @@ overflow). This must be set to zero if no buffer is passed.
 **Library:** grobj.def
 
 ----------
-#### GraphicPattern
+### GraphicPattern
     GraphicPattern      struct
         GP_type     PatternType
         GP_data     byte
@@ -4066,7 +4066,7 @@ This structure stores a system hatch pattern.
 **Library:** graphics.def
 
 ----------
-#### Grid
+### Grid
     Grid    struct
         G_x WWFixed         ;pixels between horiz gridlines
         G_y WWFixed         ;pixels between vert gridlines
@@ -4075,7 +4075,7 @@ This structure stores a system hatch pattern.
 **Library:** ruler.def
 
 ----------
-#### GridOptions
+### GridOptions
     GridOptions     record
         GO_SHOW_GRID            :1
         GO_SNAP_TO_GRID         :1
@@ -4085,7 +4085,7 @@ This structure stores a system hatch pattern.
 **Library:** ruler.def
 
 ----------
-#### GrInfoType
+### GrInfoType
     GrInfoType      etype word, 0, 2
         GIT_PRIVATE_DATA        enum GrInfoType
         GIT_WINDOW              enum GrInfoType
@@ -4093,7 +4093,7 @@ This structure stores a system hatch pattern.
 **Library:** graphics.def
 
 ----------
-#### GrObjActionModes
+### GrObjActionModes
     GrObjActionModes        record
         GOAM_RESIZE                 :1
         GOAM_MOVE                   :1
@@ -4108,7 +4108,7 @@ This structure stores a system hatch pattern.
 **Library:** grobj.def
 
 ----------
-#### GrObjActionNotificationStruct
+### GrObjActionNotificationStruct
     GrObjActionNotificationStruct               struct
         GOANS_suspendCount      word    ; If non-zero, then defer sending out 
                                         ; action notification.
@@ -4118,7 +4118,7 @@ This structure stores a system hatch pattern.
 **Library:** grobj.def
 
 ----------
-#### GrObjActionNotificationType
+### GrObjActionNotificationType
     GrObjActionNotificationType             etype word
         GOANT_NULL              enum GrObjActionNotificationType
                 ; Reserve zero as a special value
@@ -4150,7 +4150,7 @@ This structure stores a system hatch pattern.
 **Library:** grobj.def
 
 ----------
-#### GrObjAlignDistributeControlFeatures
+### GrObjAlignDistributeControlFeatures
     GrObjAlignDistributeControlFeatures record
         GOADCF_ALIGN_LEFT                               :1
         GOADCF_ALIGN_CENTER_HORIZONTALLY                :1
@@ -4173,7 +4173,7 @@ This structure stores a system hatch pattern.
 **Library:** grobj.def
 
 ----------
-#### GrObjAnchoredScaleData
+### GrObjAnchoredScaleData
     GrObjAnchoredScaleData          struct
         GOASD_scale             GrObjScaleData
         GOASD_scaleAnchor       GrObjHandleSpecification
@@ -4183,7 +4183,7 @@ This structure stores a system hatch pattern.
 **Library:** grobj.def
 
 ----------
-#### GrObjAnchoredSkewData
+### GrObjAnchoredSkewData
     GrObjAnchoredSkewData           struct
         GOASD_degrees           GrObjSkewData
         GOASD_skewAnchor        GrObjHandleSpecification
@@ -4193,7 +4193,7 @@ This structure stores a system hatch pattern.
 **Library:** grobj.def
 
 ----------
-#### GrObjAreaAttrElementType
+### GrObjAreaAttrElementType
     GrObjAreaAttrElementType            etype byte
         GOAAET_BASE             enum GrObjAreaAttrElementType
         ;GrObjBaseAreaAttrElement
@@ -4203,7 +4203,7 @@ This structure stores a system hatch pattern.
 **Library:** grobj.def
 
 ----------
-#### GrObjAreaAttrInfoRecord
+### GrObjAreaAttrInfoRecord
     GrObjAreaAttrInfoRecord         record
         GOAAIR_TRANSPARENT              :1
     GrObjAreaAttrInfoRecord         end
@@ -4215,7 +4215,7 @@ is no need to redraw the background behind the object.
 **Library:** grobj.def
 
 ----------
-#### GrObjAttrFlags
+### GrObjAttrFlags
     GrObjAttrFlags      record
                                                 :6
         GOAF_DONT_COPY_LOCKS                    :1
@@ -4271,7 +4271,7 @@ This type indicates how to wrap text with respect to the object.
 **Library:** grobj.def
 
 ----------
-#### GrObjAttributeManagerArrayDesc
+### GrObjAttributeManagerArrayDesc
     GrObjAttributeManagerArrayDesc                  struct
         GOAMAD_areaAttrArrayHandle          word
         GOAMAD_areaDefaultElement           word
@@ -4357,7 +4357,7 @@ created.
 **Library:** grobj.def
 
 ----------
-#### GrObjBaseAreaAttrDiffs
+### GrObjBaseAreaAttrDiffs
     GrObjBaseAreaAttrDiffs          record
         GOBAAD_MULTIPLE_ELEMENT_TYPES           :1
         GOBAAD_MULTIPLE_STYLE_ELEMENTS          :1
@@ -4381,7 +4381,7 @@ This flag indicates that this GrObj is the first one to receive this data buffer
 **Library:** grobj.def
 
 ----------
-#### GrObjBaseAreaAttrElement
+### GrObjBaseAreaAttrElement
     GrObjBaseAreaAttrElement            struct
         GOBAAE_styleElement     StyleSheetElementHeader
         GOBAAE_r                byte
@@ -4402,7 +4402,7 @@ This flag indicates that this GrObj is the first one to receive this data buffer
 **Library:** grobj.def
 
 ----------
-#### GrObjBaseLineAttrDiffs
+### GrObjBaseLineAttrDiffs
     GrObjBaseLineAttrDiffs          record
         GOBLAD_MULTIPLE_STYLE_ELEMENTS                  :1
         GOBLAD_MULTIPLE_ELEMENT_TYPES                   :1
@@ -4425,7 +4425,7 @@ This flag indicates that this GrObj is the first one to receive this data buffer
 **Library:** grobj.def
 
 ----------
-#### GrObjBaseLineAttrElement
+### GrObjBaseLineAttrElement
     GrObjBaseLineAttrElement            struct
         GOBLAE_styleElement         StyleSheetElementHeader
         GOBLAE_r                    byte
@@ -4447,7 +4447,7 @@ This flag indicates that this GrObj is the first one to receive this data buffer
 **Library:** grobj.def
 
 ----------
-#### GrObjBlockHandleElement
+### GrObjBlockHandleElement
     GrObjBlockHandleElement         struct
         GOBHE_blockHandle               hptr
         GOBHE_potentialSize             word
@@ -4456,7 +4456,7 @@ This flag indicates that this GrObj is the first one to receive this data buffer
 **Library:** grobj.def
 
 ----------
-#### GrObjBodyAddGrObjFlags
+### GrObjBodyAddGrObjFlags
     GrObjBodyAddGrObjFlags          record
         GOBAGOF_DRAW_LIST_POSITION          :1
         GOBAGOF_REFERENCE                   :15
@@ -4470,7 +4470,7 @@ the reverse draw list.
 **Library:** grobj.def
 
 ----------
-#### GrObjBodyCreateGrObjParams
+### GrObjBodyCreateGrObjParams
     GrObjBodyCreateGrObjParams              struct
         GBCGP_class     fptr.ClassStruct
         padding1        word        ; This padding ensures that width and 
@@ -4485,7 +4485,7 @@ the reverse draw list.
 **Library:** grobj.def
 
 ----------
-#### GrObjBodyCustomDuplicateParams
+### GrObjBodyCustomDuplicateParams
     GrObjBodyCustomDuplicateParams                  struct
         GBCDP_repetitions       word
         GBCDP_move              PointDWFixed
@@ -4499,7 +4499,7 @@ the reverse draw list.
 **Library:** grobj.def
 
 ----------
-#### GrObjBodyFlags
+### GrObjBodyFlags
     GrObjBodyFlags          record
         GBF_HAS_ACTION_NOTIFICATION     :1
         GBF_DEFAULT_TARGET              :1
@@ -4521,7 +4521,7 @@ upon a MSG_VIS_OPEN.
 **Library:** grobj.def
 
 ----------
-#### GrObjBodyNotifyInstructionFlags
+### GrObjBodyNotifyInstructionFlags
     GrObjBodyNotifyInstructionFlags             struct
         GBNIF_flags             GrObjDrawFlags
         GBNIF_handleSize        byte    ;this field added post-Zoomer
@@ -4531,7 +4531,7 @@ upon a MSG_VIS_OPEN.
 **Library:** grobj.def
 
 ----------
-#### GrObjBodyPasteCallBackStruct
+### GrObjBodyPasteCallBackStruct
     GrObjBodyPasteCallBackStruct            struct
         GOBPCBS_message             word
         GOBPCBS_optr                optr
@@ -4540,7 +4540,7 @@ upon a MSG_VIS_OPEN.
 **Library:** grobj.def
 
 ----------
-#### GrObjBodyUnsuspendOps
+### GrObjBodyUnsuspendOps
     GrObjBodyUnsuspendOps           record
         GBUO_UI_NOTIFY  GrObjUINotificationTypes: width GrObjUINotificationTypes
     GrObjBodyUnsuspendOps           end
@@ -4552,7 +4552,7 @@ suspend counts returns to zero.
 **Library:** grobj.def
 
 ----------
-#### GrObjCreateControlFeatures
+### GrObjCreateControlFeatures
     GrObjCreateControlFeatures              record
         GOCCF_RECTANGLE             :1
         GOCCF_ELLIPSE               :1
@@ -4569,7 +4569,7 @@ suspend counts returns to zero.
 **Library:** grobj.def
 
 ----------
-#### GrObjCreateGStateType
+### GrObjCreateGStateType
     GrObjCreateGStateType           etype word
         BODY_GSTATE     enum GrObjCreateGStateType,0    
                                 ;Has only translation to body upper left 
@@ -4583,7 +4583,7 @@ suspend counts returns to zero.
 **Library:** grobj.def
 
 ----------
-#### GrObjDefiningData
+### GrObjDefiningData
     GrObjDefiningData       struct
         GODD_attrFlags          GrObjAttrFlags
         GODD_locks              GrObjLocks
@@ -4598,7 +4598,7 @@ recover the object from a transfer item.
 **Library:** grobj.def
 
 ----------
-#### GrObjDrawFlags
+### GrObjDrawFlags
     GrObjDrawFlags              record
                                                 :7
         GODF_DRAW_QUICK_VIEW                    :1
@@ -4651,7 +4651,7 @@ If this flag is set, instructions should be printed.
 **Library:** grobj.def
 
 ----------
-#### GrObjDuplicateControlFeatures
+### GrObjDuplicateControlFeatures
     GrObjDuplicateControlFeatures       record
         GODCF_DUPLICATE             :1
         GODCF_DUPLICATE_IN_PLACE    :1
@@ -4660,7 +4660,7 @@ If this flag is set, instructions should be printed.
 **Library:** grobj.def
 
 ----------
-#### GrObjDuplicateControlToolboxFeatures
+### GrObjDuplicateControlToolboxFeatures
     GrObjDuplicateControlToolboxFeatures    record
         GODCTF_DUPLICATE                :1
         GODCTF_DUPLICATE_IN_PLACE       :1
@@ -4669,7 +4669,7 @@ If this flag is set, instructions should be printed.
 **Library:** 
 
 ----------
-#### GrObjEntryPointRelocation
+### GrObjEntryPointRelocation
     GrObjEntryPointRelocation               struct
         GOEPR_fullRelocation            EntryPointRelocation
         GOEPR_grObjEntryPoint           word
@@ -4678,7 +4678,7 @@ If this flag is set, instructions should be printed.
 **Library:** grobj.def
 
 ----------
-#### GrObjFileStatus
+### GrObjFileStatus
     GrObjFileStatus     record
         GOFS_MOUSE_GRAB     :1      ;True if body has mouse grab
         GOFS_SYS_TARGETED   :1      ;Body has the system target excl
@@ -4689,7 +4689,7 @@ If this flag is set, instructions should be printed.
 **Library:** grobj.def
 
 ----------
-#### GrObjFullAreaAttrElement
+### GrObjFullAreaAttrElement
     GrObjFullAreaAttrElement                struct
         GOFAAE_base     GrObjBaseAreaAttrElement
         GOFAAE_future   byte FUTURE_AREA_ATTR_ELEMENT_DATA_SIZE dup (?)
@@ -4701,7 +4701,7 @@ GrObjBaseAreaAttrElement structures.
 **Library:** grobj.def
 
 ----------
-#### GrObjFullLineAttrElement
+### GrObjFullLineAttrElement
     GrObjFullLineAttrElement                struct
         GOFLAE_base     GrObjBaseLineAttrElement
         GOFLAE_future   byte FUTURE_LINE_ATTR_ELEMENT_DATA_SIZE dup (?)
@@ -4713,7 +4713,7 @@ GrObjBaseLineAttrElement structures.
 **Library:** grobj.def
 
 ----------
-#### GrObjFunctionsActive
+### GrObjFunctionsActive
     GrObjFunctionsActive                record
         GOFA_RULER_HAS_SEEN_EVENT   :1
         GOFA_VIEW_ZOOMED            :1
@@ -4758,7 +4758,7 @@ Same as UIFA_EXTEND.
 **Library:** grobj.def
 
 ----------
-#### GrObjGradientAreaAttrElement
+### GrObjGradientAreaAttrElement
     GrObjGradientAreaAttrElement            struct
         GOGAAE_base             GrObjBaseAreaAttrElement
         GOGAAE_type             GrObjGradientType
@@ -4772,7 +4772,7 @@ Same as UIFA_EXTEND.
 **Library:** grobj.def
 
 ----------
-#### GrObjGradientAttrDiffs
+### GrObjGradientAttrDiffs
     GrObjGradientAttrDiffs              record
         GGAD_MULTIPLE_END_COLORS    :1
         GGAD_MULTIPLE_TYPES         :1
@@ -4788,7 +4788,7 @@ should clear it).
 **Library:** grobj.def
 
 ----------
-#### GrObjGradientFillControlFeatures
+### GrObjGradientFillControlFeatures
     GrObjGradientFillControlFeatures                record
         GOGFCF_HORIZONTAL_GRADIENT              :1
         GOGFCF_VERTICAL_GRADIENT                :1
@@ -4800,7 +4800,7 @@ should clear it).
 **Library:** grobj.def
 
 ----------
-#### GrObjGradientType
+### GrObjGradientType
     GrObjGradientType       etype byte
         GOGT_NONE                   enum GrObjGradientType
         GOGT_LEFT_TO_RIGHT          enum GrObjGradientType
@@ -4811,7 +4811,7 @@ should clear it).
 **Library:** grobj.def
 
 ----------
-#### GrObjHandleAnchorData
+### GrObjHandleAnchorData
     GrObjHandleAnchorData           struct
         GOHAD_anchor            PointDWFixed
         GOHAD_handle            GrObjHandleSpecification
@@ -4821,7 +4821,7 @@ should clear it).
 **Library:** grobj.def
 
 ----------
-#### GrObjHandleSpecification
+### GrObjHandleSpecification
     GrObjHandleSpecification            record
         GOHS_HANDLE_LEFT            :1
         GOHS_HANDLE_TOP             :1
@@ -4832,7 +4832,7 @@ should clear it).
 **Library:** grobj.def
 
 ----------
-#### GrObjInitializeData
+### GrObjInitializeData
     GrObjInitializeData         struct
         GOID_position       PointDWFixed
         GOID_width          WWFixed
@@ -4849,7 +4849,7 @@ parent coordinates.
 **Library:** grobj.def
 
 ----------
-#### GrObjInstructionControlFeatures
+### GrObjInstructionControlFeatures
     GrObjInstructionControlFeatures         record
         GOICF_DRAW                  :1
         GOICF_PRINT                 :1
@@ -4861,7 +4861,7 @@ parent coordinates.
 **Library:** grobj.def
 
 ----------
-#### GrObjLineAttrElementType
+### GrObjLineAttrElementType
     GrObjLineAttrElementType            etype byte
         GOLAET_BASE             enum GrObjLineAttrElementType
         ;GrObjBaseLineAttrElement
@@ -4869,7 +4869,7 @@ parent coordinates.
 **Library:** grobj.def
 
 ----------
-#### GrObjLineAttrInfoRecord
+### GrObjLineAttrInfoRecord
     GrObjLineAttrInfoRecord         record
         GOLAIR_ARROWHEAD_ON_START                       :1
         GOLAIR_ARROWHEAD_ON_END                         :1
@@ -4881,7 +4881,7 @@ parent coordinates.
 **Library:** grobj.def
 
 ----------
-#### GrObjLocks
+### GrObjLocks
     GrObjLocks      record
         GOL_COPY        :1  ;True if object may not be transferred to the 
                             ;clipboard
@@ -4907,7 +4907,7 @@ parent coordinates.
 **Library:** grobj.def
 
 ----------
-#### GrObjMessageOptimizationFlags
+### GrObjMessageOptimizationFlags
     GrObjMessageOptimizationFlags               record
         GOMOF_GET_DWF_SELECTION_HANDLE_BOUNDS_FOR_TRIVIAL_REJECT :1
         GOMOF_SPECIAL_RESIZE_CONSTRAIN                          :1
@@ -4977,7 +4977,7 @@ If set, sends MSG_GO_DRAW_BG.
 **Library:** grobj.def
 
 ----------
-#### GrObjMouseData
+### GrObjMouseData
     GrObjMouseData      struct
         GOMD_point          PointDWFixed        ; This field must be first.
         GOMD_buttonInfo     ButtonInfo          ; Copy of ButtonInfo
@@ -4989,7 +4989,7 @@ If set, sends MSG_GO_DRAW_BG.
 **Library:** grobj.def
 
 ----------
-#### GrObjMouseReturnType
+### GrObjMouseReturnType
     GrObjMouseReturnType            etype byte
         GOMRF_HANDLE    enum GrObjMouseReturnType   ;Mouse position is over a handle 
                                                     ;of a selected object.
@@ -5005,7 +5005,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjNotifyAreaAttrChange
+### GrObjNotifyAreaAttrChange
     GrObjNotifyAreaAttrChange           struct
         GNAAC_areaAttr              GrObjBaseAreaAttrElement
         GNAAC_areaAttrDiffs         GrObjBaseAreaAttrDiffs
@@ -5014,7 +5014,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjNotifyCurrentTool
+### GrObjNotifyCurrentTool
     GrObjNotifyCurrentTool          struct
         GONCT_toolClass         fptr.ClassStruct
         GONCT_specInitData      word
@@ -5023,7 +5023,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjNotifyGradientAttrChange
+### GrObjNotifyGradientAttrChange
     GrObjNotifyGradientAttrChange                   struct
         GONGAC_type             GrObjGradientType
         GONGAC_endR             byte                ;ending color red byte
@@ -5037,7 +5037,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjNotifyLineAttrChange
+### GrObjNotifyLineAttrChange
     GrObjNotifyLineAttrChange           struct
         GNLAC_lineAttr              GrObjBaseLineAttrElement
         GNLAC_lineAttrDiffs         GrObjBaseLineAttrDiffs
@@ -5046,7 +5046,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjNotifySelectionStateChange
+### GrObjNotifySelectionStateChange
     GrObjNotifySelectionStateChange             struct
         GONSSC_selectionState           GrObjSelectionState
         GONSSC_selectionStateDiffs      GrObjSelectionStateDiffs
@@ -5060,7 +5060,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjNudgeControlFeatures
+### GrObjNudgeControlFeatures
     GrObjNudgeControlFeatures               record
         GONCF_NUDGE_LEFT                :1
         GONCF_NUDGE_RIGHT               :1
@@ -5072,7 +5072,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjObjManipData
+### GrObjObjManipData
     GrObjObjManipData           struct
         GOOMD_actionGrObj               optr
         GOOMD_origMousePt               PointDWFixed
@@ -5086,7 +5086,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjObscureAttrControlFeatures
+### GrObjObscureAttrControlFeatures
     GrObjObscureAttrControlFeatures             record
         GOOACF_INSTRUCTIONS                 :1
         GOOACF_INSERT_OR_DELETE_MOVE        :1
@@ -5101,7 +5101,7 @@ remaining types.
 **Library:** grobj.def
 
 ----------
-#### GrObjOptimizationFlags
+### GrObjOptimizationFlags
     GrObjOptimizationFlags          record
         GOOF_ADDED_TO_BODY                      :1
         GOOF_IN_GROUP                           :1
@@ -5145,7 +5145,7 @@ dimensions.
 **Library:** grobj.def
 
 ----------
-#### GrObjPointerImageSituation
+### GrObjPointerImageSituation
     GrObjPointerImageSituation          etype byte
         GOPIS_NORMAL            enum GrObjPointerImageSituation
         GOPIS_EDIT              enum GrObjPointerImageSituation
@@ -5156,7 +5156,7 @@ dimensions.
 **Library:** grobj.def
 
 ----------
-#### GrObjResizeMouseData
+### GrObjResizeMouseData
     GrObjResizeMouseData            struct
         GORSMD_point        PointDWFixed            ; Must be first.
         GORSMD_anchor       GrObjHandleSpecification
@@ -5169,7 +5169,7 @@ dimensions.
 **Library:** grobj.def
 
 ----------
-#### GrObjRotateControlFeatures
+### GrObjRotateControlFeatures
     GrObjRotateControlFeatures              record
         GORCF_45_DEGREES_CW             :1
         GORCF_90_DEGREES_CW             :1
@@ -5184,7 +5184,7 @@ dimensions.
 **Library:** grobj.def
 
 ----------
-#### GrObjRotateMouseData
+### GrObjRotateMouseData
     GrObjRotateMouseData            struct
         GORMD_degrees           WWFixed
         GORMD_anchor            GrObjHandleSpecification
@@ -5198,7 +5198,7 @@ This structure is the stack frame passed with rotate message.
 **Library:** grobj.def
 
 ----------
-#### GrObjScaleControlFeatures
+### GrObjScaleControlFeatures
     GrObjScaleControlFeatures               record
         GOSCF_HALF_WIDTH                :1
         GOSCF_HALF_HEIGHT               :1
@@ -5210,7 +5210,7 @@ This structure is the stack frame passed with rotate message.
 **Library:** grobj.def
 
 ----------
-#### GrObjScaleData
+### GrObjScaleData
     GrObjScaleData      struct
         GOSD_xScale         WWFixed
         GOSD_yScale         WWFixed
@@ -5219,7 +5219,7 @@ This structure is the stack frame passed with rotate message.
 **Library:** grobj.def
 
 ----------
-#### GrObjSelectionState
+### GrObjSelectionState
     GrObjSelectionState     struct
         GSS_numSelected         word
         GSS_classSelected       fptr.ClassStruct
@@ -5232,7 +5232,7 @@ This structure is the stack frame passed with rotate message.
 **Library:** grobj.def
 
 ----------
-#### GrObjSelectionStateDiffs
+### GrObjSelectionStateDiffs
     GrObjSelectionStateDiffs            record
         GSSD_MULTIPLE_CLASSES               :1
         GSSD_MULTIPLE_ARC_CLOSE_TYPES       :1
@@ -5244,7 +5244,7 @@ This structure is the stack frame passed with rotate message.
 **Library:** grobj.def
 
 ----------
-#### GrObjSelectionStateFlags
+### GrObjSelectionStateFlags
     GrObjSelectionStateFlags            record
         GSSF_EDITING            :1  ;True if an object is being edited.
         GSSF_UNGROUPABLE        :1  ;True if at least one of the objects
@@ -5262,7 +5262,7 @@ This structure is the stack frame passed with rotate message.
 **Library:** grobj.def
 
 ----------
-#### GrObjsInRectData
+### GrObjsInRectData
     GrObjsInRectData        struct
         GOIRD_tempMessage           word
         GOIRD_tempMessageDX         word
@@ -5293,7 +5293,7 @@ resides within.
 **Library:** grobj.def
 
 ----------
-#### GrObjsInRectSpecial
+### GrObjsInRectSpecial
     GrObjsInRectSpecial         record
         GOIRS_IGNORE_TEMP           :1
         GOIRS_IGNORE_RECT           :1
@@ -5316,7 +5316,7 @@ Message will always be sent first.)
 **Library:** grobj.def
 
 ----------
-#### GrObjSkewControlFeatures
+### GrObjSkewControlFeatures
     GrObjSkewControlFeatures        record
         GOSCF_LEFT              :1
         GOSCF_RIGHT             :1
@@ -5328,7 +5328,7 @@ Message will always be sent first.)
 **Library:** grobj.def
 
 ----------
-#### GrObjSkewData
+### GrObjSkewData
     GrObjSkewData       struct
         GOSD_xDegrees           WWFixed
         GOSD_yDegress           WWFixed
@@ -5337,7 +5337,7 @@ Message will always be sent first.)
 **Library:** grobj.def
 
 ----------
-#### GrObjStyleElement
+### GrObjStyleElement
     GrObjStyleElement       struct
         GSE_meta                NameArrayElement
         GSE_baseStyle           word
@@ -5352,7 +5352,7 @@ Message will always be sent first.)
 **Library:** grobj.def
 
 ----------
-#### GrObjStyleFlags
+### GrObjStyleFlags
     GrObjStyleFlags             record
         GSF_AREA_COLOR_RELATIVE         :1
         GSF_AREA_MASK_RELATIVE          :1
@@ -5365,7 +5365,7 @@ Message will always be sent first.)
 **Library:** grobj.def
 
 ----------
-#### GrObjStylePrivateData
+### GrObjStylePrivateData
     GrObjStylePrivateData           struct
         GSPD_flags          GrObjStyleFlags
         GSPD_unused         byte 2 dup (0)
@@ -5374,7 +5374,7 @@ Message will always be sent first.)
 **Library:** grobj.def
 
 ----------
-#### GrObjTempModes
+### GrObjTempModes
     GrObjTempModes      record
         GOTM_SELECTED               :1
         GOTM_EDITED                 :1
@@ -5425,7 +5425,7 @@ the application target.)
 **Library:** grobj.def
 
 ----------
-#### GrObjTextArrays
+### GrObjTextArrays
     GrObjTextArrays         struct
         GOTA_charAttrArray          word
         GOTA_paraAttrArray          word
@@ -5438,7 +5438,7 @@ the application target.)
 **Library:** grobj.def
 
 ----------
-#### GrObjTiledDataFlags
+### GrObjTiledDataFlags
     GrObjTiledDataFlags     record
                                 :7
         GOTDF_VAR_DATA          :1
@@ -5447,7 +5447,7 @@ the application target.)
 **Library:** grobj.def
 
 ----------
-#### GrObjTransferBlockHeader
+### GrObjTransferBlockHeader
     GrObjTransferBlockHeader                struct
         GOTBH_meta              VMChainTree
         GOTBH_size              PointDWord  ; Width and height of the cut.
@@ -5468,7 +5468,7 @@ Cut/Copy/Paste operations.
 **Library:** grobj.def
 
 ----------
-#### GrObjTransferDataDirectory
+### GrObjTransferDataDirectory
     GrObjTransferDataDirectory              struct
         GOTDD_tiledDataFlags        GrObjTiledDataFlags
         GOTDD_protocol              byte
@@ -5477,7 +5477,7 @@ Cut/Copy/Paste operations.
 **Library:** grobj.def
 
 ----------
-#### GrObjTransferParams
+### GrObjTransferParams
     GrObjTransferParams         struct
         GTP_ssp                         StyleSheetParams
         GTP_textSSP                     VisTextSaveStyleSheetParams
@@ -5493,7 +5493,7 @@ Cut/Copy/Paste operations.
 **Library:** grobj.def
 
 ----------
-#### GrObjTransMatrix
+### GrObjTransMatrix
     GrObjTransMatrix        struct
         GTM_e11         WWFixed
         GTM_e12         WWFixed
@@ -5504,7 +5504,7 @@ Cut/Copy/Paste operations.
 **Library:** grobj.def
 
 ----------
-#### GrObjUINotificationTypes
+### GrObjUINotificationTypes
     GrObjUINotificationTypes            record
         GOUINT_STYLE        :1  ;True if style notification needs to be 
                                 ;sent
@@ -5522,7 +5522,7 @@ Cut/Copy/Paste operations.
 **Library:** grobj.def
 
 ----------
-#### GrObjUndoAppType
+### GrObjUndoAppType
     GrObjUndoAppType        struct
         GOUAT_freeMessage           word
         GOUAT_undoMessage           word
@@ -5531,7 +5531,7 @@ Cut/Copy/Paste operations.
 **Library:** grobj.def
 
 ----------
-#### GrObjVisGuardianCreateMode
+### GrObjVisGuardianCreateMode
     GrObjVisGuardianCreateMode              etype byte, 0
         GOVGCM_NO_CREATE            enum GrObjVisGuardianCreateMode
         GOVGCM_GUARDIAN_CREATE      enum GrObjVisGuardianCreateMode
@@ -5553,7 +5553,7 @@ sent to the ward.
 **Library:** grobj.def
 
 ----------
-#### GrObjVisGuardianFlags
+### GrObjVisGuardianFlags
     GrObjVisGuardianFlags           record
         GOVGF_VIS_BOUNDS_HAVE_CHANGED       :1
         GOVGF_LARGE                         :1
@@ -5585,7 +5585,7 @@ If set, the floater can edit existing objects in the document.
 **Library:** grobj.def
 
 ----------
-#### GrObjWrapTextType
+### GrObjWrapTextType
     GrObjWrapTextType       etype byte, 0
         GOWTT_DONT_WRAP             enum GrObjWrapTextType
         GOWTT_WRAP_AROUND_RECT      enum GrObjWrapTextType
@@ -5595,7 +5595,7 @@ If set, the floater can edit existing objects in the document.
 **Library:** grobj.def
 
 ----------
-#### GroupAddGrObjFlags
+### GroupAddGrObjFlags
     GroupAddGrObjFlags      record
         GAGOF_RELATIVE          :1
         GAGOF_REFERENCE         :15
@@ -5609,7 +5609,7 @@ and must be adjusted when it is added.
 **Library:** grobj.def
 
 ----------
-#### GroupUnsuspendOps
+### GroupUnsuspendOps
     GroupUnsuspendOps       record
         GUO_EXPAND      :1
     GroupUnsuspendOps       end
@@ -5621,7 +5621,7 @@ count reaches zero.
 **Library:** grobj.def
 
 ----------
-#### GSControl
+### GSControl
     GSControl       record
                         :6,
         GSC_PARTIAL     :1  ; Just do one element. If element is a complex
@@ -5641,7 +5641,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GSElemInfo
+### GSElemInfo
     GSElemInfo      struct
         GSEI_size           word
         GSEI_play           nptr
@@ -5651,7 +5651,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GSRefCountAndFlags
+### GSRefCountAndFlags
     GSRefCountAndFlags          record
         GSRCAF_USE_DOC_CLIP_REGION  :1  ;If set, then use GrSetDocClipRect
                                         ;instead of GrSetClipRect
@@ -5661,7 +5661,7 @@ count reaches zero.
 **Library:** Objects/vTextC.def
 
 ----------
-#### GSRetType
+### GSRetType
     GSRetType       etype word
         GSRT_COMPLETE   enum GSRetType
         GSRT_ONE        enum GSRetType
@@ -5678,7 +5678,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GStringElement
+### GStringElement
     GStringElement      etype byte, 0, 1
 
     DefGSElement    macro   \
@@ -5866,7 +5866,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GStringErrorType
+### GStringErrorType
     GStringErrorType        etype word
         GSET_NO_ERROR   enum GStringErrorType   ; there was no error
         GSET_DISK_FULL  enum GStringErrorType   ; disk became full, file truncated
@@ -5874,7 +5874,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GStringKillType
+### GStringKillType
     GStringKillType     etype byte
         GSKT_KILL_DATA      enum GStringKillType    ; delete the data too
         GSKT_LEAVE_DATA     enum GStringKillType    ; leave the data alone
@@ -5882,7 +5882,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GStringSetPosType
+### GStringSetPosType
     GStringSetPosType       etype byte
         GSSPT_SKIP_1    enum GStringSetPosType  ; advance 1 element
         GSSPT_RELATIVE  enum GStringSetPosType  ; advance N elements
@@ -5892,7 +5892,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GStringType
+### GStringType
     GStringType     etype byte
         GST_CHUNK   enum GStringType    ; write to a memory chunk
         GST_STREAM  enum GStringType    ; write to a stream
@@ -5904,7 +5904,7 @@ count reaches zero.
 **Library:** gstring.def
 
 ----------
-#### GTCFeatures
+### GTCFeatures
     GTCFeatures     record
         GTCF_TOOL_DIALOG        :1
     GTCFeatures     end
@@ -5912,7 +5912,7 @@ count reaches zero.
 **Library:** Objects/gToolCC.def
 
 ----------
-#### GTP_vars
+### GTP_vars
     GTP_vars        struct
         GTPL_style          TextMetricStyles    ; Must be first
         GTPL_object         dword               ; Object segment address
@@ -5926,7 +5926,7 @@ This structure is passed to **GrTextPosition**.
 **Library:** text.def
 
 ----------
-#### Guide
+### Guide
     Guide   struct
         Guide_location      DWFixed
     Guide   ends
@@ -5934,7 +5934,7 @@ This structure is passed to **GrTextPosition**.
 **Library:** ruler.def
 
 ----------
-#### GVCFeatures
+### GVCFeatures
     GVCFeatures     record
         GVCF_MAIN_100               :1
         GVCF_MAIN_SCALE_TO_FIT      :1
@@ -5956,7 +5956,7 @@ This structure is passed to **GrTextPosition**.
 **Library:** Objects/gViewCC.def
 
 ----------
-#### GVCToolboxFeatures
+### GVCToolboxFeatures
     GVCToolboxFeatures      record
         GVCTF_100                   :1
         GVCTF_SCALE_TO_FIT          :1

--- a/TechDocs/Markdown/Asmref/asmstrhm.md
+++ b/TechDocs/Markdown/Asmref/asmstrhm.md
@@ -1,7 +1,7 @@
 ## 3.4 Structures H-M
 
 ----------
-#### HandleUpdateMode
+### HandleUpdateMode
     HandleUpdateMode        etype byte, 0
         HUM_NOW         enum HandleUpdateMode
         HUM_MANUAL      enum HandleUpdateMode
@@ -9,7 +9,7 @@
 **Library:** grobj.def
 
 ----------
-#### HatchDash
+### HatchDash
     HatchDash           struct
         HD_on       WWFixed     ; length of dash to be drawn
         HD_off      WWFixed     ; space to skip until next dash
@@ -21,7 +21,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** graphics.def
 
 ----------
-#### HatchLine
+### HatchLine
     HatchLine       struct
         HL_origin           PointWWFixed            ; origin of line
         HL_deltaX           WWFixed         ; X offset to next line
@@ -35,7 +35,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** graphics.def
 
 ----------
-#### HatchPattern
+### HatchPattern
     HatchPattern            struct
         HP_numLines     word            ; number of line records in this pattern
         HP_lineData     label HatchLine ; array of 1 or more hatch lines
@@ -47,7 +47,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** graphics.def
 
 ----------
-#### HCFeatures
+### HCFeatures
     HCFeatures      record
         HCF_LIST        :1
     HCFeatures      end
@@ -55,7 +55,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### HCToolboxFeatures
+### HCToolboxFeatures
     HCToolboxFeatures       record
         HCTF_TOGGLE     :1
     HCToolboxFeatures       end
@@ -63,7 +63,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### HeapAllocFlags
+### HeapAllocFlags
     HeapAllocFlags      record
         HAF_ZERO_INIT           :1  ; Initialize new memory to 0
         HAF_LOCK                :1  ; Return with block locked
@@ -82,7 +82,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** heap.def
 
 ----------
-#### HeapCongestion
+### HeapCongestion
     HeapCongestion          etype word, 0, 2
         HC_SCRUBBING    enum HeapCongestion ;Heap is being scrubbed. Might be a 
                                             ;good idea to free some things.
@@ -95,7 +95,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** heap.def
 
 ----------
-#### HeapFlags
+### HeapFlags
     HeapFlags       record
         HF_FIXED        :1  ; Block won't ever move
         HF_SHARABLE     :1  ; May be locked by other than owner
@@ -113,7 +113,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** heap.def
 
 ----------
-#### HeightJustification
+### HeightJustification
     HeightJustification         etype byte
         HJ_TOP_JUSTIFY_CHILDREN             enum HeightJustification
         HJ_BOTTOM_JUSTIFY_CHILDREN          enum HeightJustification
@@ -123,7 +123,7 @@ turn may contain zero or more **HatchDash** structures.
 **Library:** Objects/vCompC.def
 
 ----------
-#### HelpEntry
+### HelpEntry
     HelpEntry       struct
         HE_string       byte
     HelpEntry       ends
@@ -133,7 +133,7 @@ This structure defines a help chunk.
 **Library:** Objects/genC.def
 
 ----------
-#### HierarchicalGrab
+### HierarchicalGrab
     HierarchicalGrab        struct
         HG_OD           optr
         HG_flags        HierarchicalGrabFlags <>
@@ -142,7 +142,7 @@ This structure defines a help chunk.
 **Library:** Objects/uiInputC.def
 
 ----------
-#### HierarchicalGrabFlags
+### HierarchicalGrabFlags
     HierarchicalGrabFlags           record
         HGF_SYS_EXCL            :1
         HGF_APP_EXCL            :1
@@ -176,7 +176,7 @@ for an object.
 **Library:** uiInputC.def
 
 ----------
-#### HoldUpInputFlags
+### HoldUpInputFlags
     HoldUpInputFlags        record
         HUIF_FLUSHING_QUEUE             :1
         HUIF_HOLD_UP_MODE_DISABLED      :1
@@ -197,7 +197,7 @@ that user can interact with it.
 **Library:** uiInputC.def
 
 ----------
-#### HugeArrayDirectory
+### HugeArrayDirectory
     HugeArrayDirectory          struct
         HAD_header      LMemBlockHeader <>      ; 
         HAD_data        word                    ; VM block link to first data block
@@ -212,7 +212,7 @@ This structure is allocated at the beginning of the directory block.
 **Library:** hugearr.def
 
 ----------
-#### HWRBoxData
+### HWRBoxData
     HWRBoxData      struct
         HWRBD_mode          HWRMode
         HWRBD_top           sword
@@ -222,7 +222,7 @@ This structure is allocated at the beginning of the directory block.
 **Library:** hwr.def
 
 ----------
-#### HWRContext
+### HWRContext
     HWRContext      union
         HWRC_none       HWRNoneData
         HWRC_lined      HWRLineData
@@ -233,7 +233,7 @@ This structure is allocated at the beginning of the directory block.
 **Library:** hwr.def
 
 ----------
-#### HWRGridData
+### HWRGridData
     HWRGridData     struct
         HWRGD_mode          HWRMode
         HWRGD_bounds        Rectangle
@@ -249,7 +249,7 @@ the ink data).
 **Library:** hwr.def
 
 ----------
-#### HWRLineData
+### HWRLineData
     HWRLineData     struct
         HWRLD_mode          HWRMode
         HWRLD_line          sword
@@ -258,7 +258,7 @@ the ink data).
 **Library:** hwr.def
 
 ----------
-#### HWRMode
+### HWRMode
     HWRMode etype word
         HM_NONE     enum HWRMode
         ; The user is writing in a multi-line object - no guidelines
@@ -272,7 +272,7 @@ the ink data).
 **Library:** hwr.def
 
 ----------
-#### HWRNoneData
+### HWRNoneData
     HWRNoneData     struct
         HWRND_mode      HWRMOde
     HWRNoneData     ends
@@ -280,7 +280,7 @@ the ink data).
 **Library:** hwr.def
 
 ----------
-#### HWRRoutine
+### HWRRoutine
     HWRRoutine      etype word
         HWRR_BEGIN_INTERACTION                  enum HWRRoutine
         HWRR_END_INTERACTION                    enum HWRRoutine
@@ -458,7 +458,7 @@ the ink data).
 **Library:** hwr.def
 
 ----------
-#### HyphenationPoints
+### HyphenationPoints
     HyphenationPoints           struct
         HP_wordLen          word
         HP_array            label byte
@@ -469,7 +469,7 @@ the ink data).
 **Library:** Objects/vTextC.def
 
 ----------
-#### HyphenFlags
+### HyphenFlags
     HyphenFlags     record
         HF_AUTO_HYPHEN  :1      ; set when auto-hyphen exists at EOL
     HyphenFlags     end
@@ -477,7 +477,7 @@ the ink data).
 **Library:** text.def
 
 ----------
-#### IACPConnectError
+### IACPConnectError
     IACPConnectError        etype word, GeodeLoadError
         IACPCE_CANNOT_FIND_SERVER   enum IACPConnectError
         IACPCE_NO_SERVER            enum IACPConnectError
@@ -492,7 +492,7 @@ Didn't ask IACP to start server, and no server is registered for the list.
 **Library:** iacp.def
 
 ----------
-#### IACPConnectFlags
+### IACPConnectFlags
     IACPConnectFlags        record
                                                 :10
         IACPCF_OBEY_LAUNCH_MODEL                :1
@@ -527,7 +527,7 @@ expected to support requests for lower-numbered modes.
 **Library:** iacp.def
 
 ----------
-#### IACPDocCloseAckParams
+### IACPDocCloseAckParams
     IACPDocCloseAckParams           struct
         IDCAP_docObj            optr
         IDCAP_connection        IACPConnection
@@ -538,7 +538,7 @@ expected to support requests for lower-numbered modes.
 **Library:** iacp.def
 
 ----------
-#### IACPDocOpenAckParams
+### IACPDocOpenAckParams
     IACPDocOpenAckParams        struct
         IDOAP_docObj                optr
         IDOAP_connection            IACPConnection
@@ -557,7 +557,7 @@ some other object).
 **Library:** iacp.def
 
 ----------
-#### IACPServerFlags
+### IACPServerFlags
     IACPServerFlags     record
         IACPSF_MULTIPLE_INSTANCES:1
         ; Set if application may have multiple instances of itself launched
@@ -567,7 +567,7 @@ some other object).
 **Library:** iacp.def
 
 ----------
-#### IACPServerMode
+### IACPServerMode
     IACPServerMode etype    byte
         IACPSM_NOT_USER_INTERACTIBLE        enum IACPServerMode
         IACPSM_IN_FLUX                      enum IACPServerMode
@@ -580,7 +580,7 @@ but the reverse is not true.
 **Library:** iacp.def
 
 ----------
-#### IACPSide
+### IACPSide
     IACPSide    etype word
         IACPS_CLIENT            enum IACPSide
         IACPS_SERVER            enum IACPSide
@@ -591,7 +591,7 @@ Specifies which side of an IACP connection is sending a message via
 **Library:** iacp.def
 
 ----------
-#### IEEE64
+### IEEE64
     IEEE64      struct
         IEEE64_wd0      word
         IEEE64_wd1      word
@@ -602,7 +602,7 @@ Specifies which side of an IACP connection is sending a message via
 **Library:** math.def
 
 ----------
-#### ImageBitSize
+### ImageBitSize
     ImageBitSize        etype byte
         IBS_1       enum ImageBitSize       ; 1 to 1 mapping
         IBS_2       enum ImageBitSize       ; 2 x 2 pixels
@@ -613,7 +613,7 @@ Specifies which side of an IACP connection is sending a message via
 **Library:** graphics.def
 
 ----------
-#### ImageFlags
+### ImageFlags
     ImageFlags      record
         IF_DRAW_IMAGE   :1,         ; reserved for internal use (set to zero)
         IF_HUGE         :1,         ; reserved for internal use (set to zero)
@@ -626,7 +626,7 @@ Specifies which side of an IACP connection is sending a message via
 **Library:** graphics.def
 
 ----------
-#### IMCFeatures
+### IMCFeatures
     IMCFeatures     record
                         :7
         IMCF_MAP        :1
@@ -635,7 +635,7 @@ Specifies which side of an IACP connection is sending a message via
 **Library:** impex.def
 
 ----------
-#### ImpexDataClasses
+### ImpexDataClasses
     ImpexDataClasses            record
         IDC_TEXT            :1
         IDC_GRAPHICS        :1
@@ -647,7 +647,7 @@ Specifies which side of an IACP connection is sending a message via
 **Library:** impex.def
 
 ----------
-#### ImpexFileSelectionData
+### ImpexFileSelectionData
     ImpexFileSelectionData          struct
         IFSD_selection          FileLongName
         IFSD_path               PathName
@@ -661,7 +661,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** impex.def
 
 ----------
-#### ImpexMapFileInfoHeader
+### ImpexMapFileInfoHeader
     ImpexMapFileInfoHeader          struc
         IMFTH_base              LMemBlockHeader
         IMFTH_fieldChunk        word
@@ -672,7 +672,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** impex.def
 
 ----------
-#### ImpexMapFlags
+### ImpexMapFlags
     ImpexMapFlags           record
         IMF_IMPORT      :1
         IMF_EXPORT      :1
@@ -682,7 +682,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** impex.def
 
 ----------
-#### ImpexTranslationParams
+### ImpexTranslationParams
     ImpexTranslationParams          struct
         ITP_impexOD             optr    ; OD of Import/ExportControl
         ITP_returnMsg           word    ; message to return to above
@@ -697,7 +697,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** ieCommon.def
 
 ----------
-#### ImportControlAttrs
+### ImportControlAttrs
     ImportControlAttrs      record
         ICA_IGNORE_INPUT            :1      ; ignore input while import occurs.
         ICA_NON_DOCUMENT_IMPORT     :1      ; non-document imports only
@@ -707,7 +707,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** impex.def
 
 ----------
-#### ImportControlFeatures
+### ImportControlFeatures
     ImportControlFeatures       record
         IMPORTCF_PREVIEW_TRIGGER    :1      ; not currently used
         IMPORTCF_IMPORT_TRIGGER     :1      ; import trigger
@@ -728,7 +728,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** impex.def
 
 ----------
-#### ImportControlToolboxFeatures
+### ImportControlToolboxFeatures
     ImportControlToolboxFeatures                record
         IMPORTCTF_DIALOG_BOX                :1
     ImportControlToolboxFeatures                end
@@ -736,7 +736,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** impex.def
 
 ----------
-#### InitFileCharConvert
+### InitFileCharConvert
     InitFileCharConvert         etype byte
         IFCC_INTACT     enum InitFileCharConvert    ; leave intact
         IFCC_UPCASE     enum InitFileCharConvert    ; upcase all chars
@@ -745,7 +745,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** initfile.def
 
 ----------
-#### InitFileReadFlags
+### InitFileReadFlags
     InitFileReadFlags       record
         IFRF_CHAR_CONVERT       InitFileCharConvert:2   ; character conversion
 
@@ -763,7 +763,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** initfile.def
 
 ----------
-#### InkBackgroundType
+### InkBackgroundType
     InkBackgroundType       etype word, 0, 2
         IBT_NO_BACKGROUND               enum InkBackgroundType
         IBT_NARROW_LINED_PAPER          enum InkBackgroundType
@@ -785,7 +785,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** pen.def
 
 ----------
-#### InkControlFeatures
+### InkControlFeatures
     InkControlFeatures      record
         ICF_PENCIL_TOOL             :1
         ICF_ERASER_TOOL             :1
@@ -795,7 +795,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** pen.def
 
 ----------
-#### InkControlToolboxFeatures
+### InkControlToolboxFeatures
     InkControlToolboxFeatures               record
         ICTF_PENCIL_TOOL                :1
         ICTF_ERASER_TOOL                :1
@@ -805,7 +805,7 @@ MSG_IMPORT_EXPORT_FILE_SELECTION_INFO.
 **Library:** pen.def
 
 ----------
-#### InkDBFrame
+### InkDBFrame
     InkDBFrame      struct
         IDBF_bounds             Rectangle
         IDBF_VMFile             hptr
@@ -827,7 +827,7 @@ create a new one).
 **Library:** pen.def
 
 ----------
-#### InkDestinationInfo
+### InkDestinationInfo
     InkDestinationInfo      struct
         IDI_destObj             optr
         IDI_gstate              hptr.GState
@@ -858,7 +858,7 @@ has entered multiple strokes.
 **Library:** Objects/uiInputC.def
 
 ----------
-#### InkDestinationInfoParams
+### InkDestinationInfoParams
     InkDestinationInfoParams            struct
         IDIP_dest               optr
         IDIP_brushSize          word
@@ -874,7 +874,7 @@ has entered multiple strokes.
 **Library:** Objects/gViewC.def
 
 ----------
-#### InkFlags
+### InkFlags
     InkFlags    record
         IF_HAS_MOUSE_GRAB           :1
         IF_SELECTING                :1
@@ -921,7 +921,7 @@ Set if this object should be undoable.
 **Library:** pen.def
 
 ----------
-#### InkGrab
+### InkGrab
     InkGrab     struct
         IG_OD       optr
         IG_gState   hptr
@@ -932,7 +932,7 @@ This structure is used by the ink code within the Flow object.
 **Library:** Objects/uiInputC.def
 
 ----------
-#### InkHeader
+### InkHeader
     InkHeader       struct
         IH_count            word
         IH_bounds           Rectangle
@@ -957,7 +957,7 @@ because it overlapped the screen. This field is set by the flow object.
 **Library:** Input.def
 
 ----------
-#### InkPoint
+### InkPoint
     InkPoint        struct
         IP_x    InkXCoord
         IP_y    word
@@ -966,7 +966,7 @@ because it overlapped the screen. This field is set by the flow object.
 **Library:** hwr.def
 
 ----------
-#### InkReturnValue
+### InkReturnValue
     InkReturnValue      etype word
         IRV_NO_REPLY                    enum InkReturnValue, 0
         IRV_NO_INK                      enum InkReturnValue
@@ -1008,7 +1008,7 @@ application object.
 **Library:** uiInputC.def
 
 ----------
-#### InkStrokeSize
+### InkStrokeSize
     InkStrokeSize           struct
         ISS_width       byte
         ISS_height      byte
@@ -1017,7 +1017,7 @@ application object.
 **Library:** pen.def
 
 ----------
-#### InkTool
+### InkTool
     InkTool etype word, 0, 2
         IT_PENCIL       enum InkTool        ;Default tool
         IT_ERASER       enum InkTool
@@ -1026,7 +1026,7 @@ application object.
 **Library:** pen.def
 
 ----------
-#### InkXCoord
+### InkXCoord
     InkXCoord       record
         IXC_TERMINATE_STROKE    :1
         IXC_X_COORD             :15
@@ -1035,7 +1035,7 @@ application object.
 **Library:** hwr.def
 
 ----------
-#### InsertChildFlags
+### InsertChildFlags
     InsertChildFlags        record
         ICF_MARK_DIRTY  :1,                 ;Marks chunk and modified object as 
                                             ; dirty
@@ -1046,7 +1046,7 @@ application object.
 **Library:** Objects/metaC.def
 
 ----------
-#### InsertChildOption
+### InsertChildOption
     InsertChildOption       etype byte
         ICO_FIRST               enum InsertChildOption
         ICO_LAST                enum InsertChildOption
@@ -1056,7 +1056,7 @@ application object.
 **Library:** Objects/metaC.def
 
 ----------
-#### InsertDeleteSpaceParams
+### InsertDeleteSpaceParams
     InsertDeleteSpaceParams         struct
         IDSP_position       PointDWFixed
         IDSP_space          PointDWFixed
@@ -1066,7 +1066,7 @@ application object.
 **Library:** Objects/visC.def
 
 ----------
-#### InsertDeleteSpaceTypes
+### InsertDeleteSpaceTypes
     InsertDeleteSpaceTypes          record
                                                                 :11 
         IDST_MOVE_OBJECTS_INSIDE_DELETED_SPACE_BY_AMOUNT_DELETED :1
@@ -1106,7 +1106,7 @@ space. In most uses of this message, this bit will be set.
 **Library:** Objects/visC.def
 
 ----------
-#### InstrumentPatch
+### InstrumentPatch
     InstrumentPatch     etype dword, 0, size InstrumentEnvelope
         ; MIDI patch    1 - 8 = Piano
         IP_ACOUSTIC_GRAND_PIANO                 enum InstrumentPatch
@@ -1310,7 +1310,7 @@ space. In most uses of this message, this bit will be set.
 **Library:** sound.def
 
 ----------
-#### InteractionCommand
+### InteractionCommand
     InteractionCommand      etype word
         IC_NULL                     enum InteractionCommand
         IC_DISMISS                  enum InteractionCommand
@@ -1400,7 +1400,7 @@ ATTR_GEN_TRIGGER_INTERACTION_COMMAND.
 **Library:** netware.def
 
 ----------
-#### JCFeatures
+### JCFeatures
     JCFeatures      record
         JCF_LEFT        :1
         JCF_RIGHT       :1
@@ -1411,7 +1411,7 @@ ATTR_GEN_TRIGGER_INTERACTION_COMMAND.
 **Library:** Objects/Text/tCtclC.def
 
 ----------
-#### JCToolboxFeatures
+### JCToolboxFeatures
     JCToolboxFeatures       record
         JCTF_LEFT       :1
         JCTF_RIGHT      :1
@@ -1422,7 +1422,7 @@ ATTR_GEN_TRIGGER_INTERACTION_COMMAND.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### JobStatus
+### JobStatus
     JobStatus       struct
         ; DO NOT CHANGE THE ORDER OF THESE FIRST FOUR ITEMS
         JS_fname            char 13 dup (?)
@@ -1451,7 +1451,7 @@ printing.)
 **Library:** spool.def
 
 ----------
-#### Justification
+### Justification
     Justification       etype byte
         J_LEFT              enum Justification
         J_RIGHT             enum Justification
@@ -1461,7 +1461,7 @@ printing.)
 **Library:** graphics.def
 
 ----------
-#### KbdGrab
+### KbdGrab
     KbdGrab     struct
         KG_OD           optr
         KG_unused       word
@@ -1470,7 +1470,7 @@ printing.)
 **Library:** Objects/uiInputC.def
 
 ----------
-#### KbdReturnFlags
+### KbdReturnFlags
     KbdReturnFlags      record
         KRF_PREVENT_PASS_THROUGH        :1
         KRF_UNUSED                      :15
@@ -1479,7 +1479,7 @@ printing.)
 **Library:** uiInputC.def
 
 ----------
-#### KeyboardOverride
+### KeyboardOverride
     KeyboardOverride        etype       word
         KO_NO_KEYBOARD              enum    KeyboardOverride
         KO_KEYBOARD_REQUIRED        enum    KeyboardOverride
@@ -1501,7 +1501,7 @@ needed.
 **Library:** genC.def
 
 ----------
-#### KeyboardShortcut
+### KeyboardShortcut
     KeyboardShortcut        record
         KS_PHYSICAL     :1          ;TRUE: match key, not character
         KS_ALT          :1          ;TRUE: <ALT> must be pressed
@@ -1513,7 +1513,7 @@ needed.
 **Library:** input.def
 
 ----------
-#### KeyboardType
+### KeyboardType
     KeyboardType            etype byte, 1, 1
         KT_NOT_EXTD     enum KeyboardType       ;84-key PC/AT
         KT_EXTD         enum KeyboardType       ;102-key PC/AT, PS/2
@@ -1522,7 +1522,7 @@ needed.
 **Library:** localize.def
 
 ----------
-#### KeyMapType
+### KeyMapType
     KeyMapType      etype word, 1, 1
         KEYMAP_US_EXTD              enum KeyMapType
         KEYMAP_US                   enum KeyMapType
@@ -1560,7 +1560,7 @@ needed.
 **Library:** localize.def
 
 ----------
-#### LanguageDialect
+### LanguageDialect
     LanguageDialect     record
                             :8
         LD_DEFAULT          :1
@@ -1576,7 +1576,7 @@ needed.
 **Library:** sllang.def
 
 ----------
-#### LargeMouseData
+### LargeMouseData
     LargeMouseData      struct
         ; LMD_location must be first entry
         LMD_location                PointDWFixed
@@ -1601,7 +1601,7 @@ holds going into the VisContentClass handler for the mouse event.
 **Library:** Objects/uiInput.def
 
 ----------
-#### LASCFeatures
+### LASCFeatures
     LASCFeatures        record
         LASCF_SINGLE                :1
         LASCF_ONE_AND_A_HALF        :1
@@ -1613,7 +1613,7 @@ holds going into the VisContentClass handler for the mouse event.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### LASCToolboxFeatures
+### LASCToolboxFeatures
     LASCToolboxFeatures         record
         LASCTF_SINGLE               :1
         LASCTF_ONE_AND_A_HALF       :1
@@ -1624,7 +1624,7 @@ holds going into the VisContentClass handler for the mouse event.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### LayerPriority
+### LayerPriority
     LayerPriority       etype byte
         LAYER_PRIO_MODAL        enum LayerPriority, 6   ; For system-modal dialog 
                                                         ; boxes, when layer is on 
@@ -1637,7 +1637,7 @@ holds going into the VisContentClass handler for the mouse event.
 **Library:** win.def
 
 ----------
-#### LibraryCallType
+### LibraryCallType
     LibraryCallType     etype word
         LCT_ATTACH                  enum LibraryCallType
         LCT_DETACH                  enum LibraryCallType
@@ -1649,7 +1649,7 @@ holds going into the VisContentClass handler for the mouse event.
 **Library:** library.def
 
 ----------
-#### LineAttr
+### LineAttr
     LineAttr        struct
         LA_colorFlag    ColorFlag CF_INDEX  ; RGB or INDEX
         LA_color        RGBValue <0,0,0>    ; RGB values or index
@@ -1666,7 +1666,7 @@ This structure is used with **GrSetLineAttr**.
 **Library:** graphics.def
 
 ----------
-#### LineEnd
+### LineEnd
     LineEnd etype byte
         LE_BUTTCAP          enum LineEnd        ; but cap
         LE_ROUNDCAP         enum LineEnd        ; round cap
@@ -1675,7 +1675,7 @@ This structure is used with **GrSetLineAttr**.
 **Library:** graphics.def
 
 ----------
-#### LineFlags
+### LineFlags
     LineFlags       record
         LF_STARTS_PARAGRAPH             :1
         LF_ENDS_PARAGRAPH               :1
@@ -1766,7 +1766,7 @@ Set if the line contains a non-kernel supported style.
 **Library:** text.def
 
 ----------
-#### LineInfo
+### LineInfo
     LineInfo        struct
         LI_flags            LineFlags
         LI_hgt              WBFixed
@@ -1800,7 +1800,7 @@ present.)
 **Library:** text.def
 
 ----------
-#### LineJoin
+### LineJoin
     LineJoin        etype byte
         LJ_MITERED              enum LineJoin       ; miter join
         LJ_ROUND                enum LineJoin       ; round join
@@ -1811,7 +1811,7 @@ present.)
 **Library:** graphics.def
 
 ----------
-#### LineStyle
+### LineStyle
     LineStyle       etype byte
         LS_SOLID        enum LineStyle      ; ___________   (solid)
         LS_DASHED       enum LineStyle      ; _ _ _ _ _ _   (dashed)
@@ -1823,7 +1823,7 @@ present.)
 **Library:** graphics.def
 
 ----------
-#### LinkPart
+### LinkPart
     LinkPart        struct
         LP_next         optr
     LinkPart        ends
@@ -1834,7 +1834,7 @@ indicate that the optr links a parent. (If 0, then object is not in a composite.
 **Library:** Objects/metaC.def
 
 ----------
-#### LMemBlockHeader
+### LMemBlockHeader
     LMemBlockHeader     struct
         LMBH_handle         hptr
         LMBH_offset         nptr.word
@@ -1876,7 +1876,7 @@ list of free chunks.
 **Library:** lmem.def
 
 ----------
-#### LMemType
+### LMemType
     LMemType        etype word
         LMEM_TYPE_GENERAL               enum LMemType
         LMEM_TYPE_WINDOW                enum LMemType
@@ -1889,7 +1889,7 @@ list of free chunks.
 **Library:** lmem.def
 
 ----------
-#### LocalCmpStringsDosToGeosFlags
+### LocalCmpStringsDosToGeosFlags
     LocalCmpStringsDosToGeosFlags               record
                                             :6
         LCSDTG_NO_CONVERT_STRING_2          :1
@@ -1899,7 +1899,7 @@ list of free chunks.
 **Library:** localize.def
 
 ----------
-#### LocalDistanceFlags
+### LocalDistanceFlags
     LocalDistanceFlags      record
         LDF_FULL_NAMES              :1
         LDF_PRINT_PLURAL_IF_NEEDED  :1
@@ -1911,7 +1911,7 @@ list of free chunks.
 **Library:** localize.def
 
 ----------
-#### LocalMemoryFlags
+### LocalMemoryFlags
     LocalMemoryFlags        record
         LMF_HAS_FLAGS       :1      ;True if block has a flags block
         LMF_IN_RESOURCE     :1      ;True if block is just loaded from resource
@@ -1942,7 +1942,7 @@ list of free chunks.
 **Library:** lmem.def
 
 ----------
-#### MakeRectVisibleFlags
+### MakeRectVisibleFlags
     MakeRectVisibleFlags            record
                                             :8
         MRVF_ALWAYS_SCROLL                  :1
@@ -1963,7 +1963,7 @@ rectangle.
 **Library:** Objects/gViewC.def
 
 ----------
-#### MakeRectVisibleMargin
+### MakeRectVisibleMargin
     MakeRectVisibleMargin           etype word
         MRVM_0_PERCENT      enum MakeRectVisibleMargin, 0
         MRVM_25_PERCENT     enum MakeRectVisibleMargin, 0ffffh/4
@@ -1998,7 +1998,7 @@ bottom edge of the screen.
 **Library:** Objects/gViewC.def
 
 ----------
-#### MakeRectVisibleParams
+### MakeRectVisibleParams
     MakeRectVisibleParams           struct
         MRVP_bounds         RectDWord
         MRVP_xMargin        MakeRectVisibleMargin
@@ -2015,14 +2015,14 @@ rectangle must be less than 65535 points high or wide.)
 **Library:** Objects/gViewC.def
 
 ----------
-#### ManufacturerID
+### ManufacturerID
     ManufacturerID      etype word
         MANUFACTURER_ID_GEOWORKS        enum ManufacturerID
 
 **Library:** geode.def
 
 ----------
-#### MapListBlockHeader
+### MapListBlockHeader
     MapListBlockHeader      struct
         MLBH_base               LMemBlockHeader
         MLBH_numDestFields      word
@@ -2032,7 +2032,7 @@ rectangle must be less than 65535 points high or wide.)
 **Library:** impex.def
 
 ----------
-#### MCFeatures
+### MCFeatures
     MCFeatures      record
         MCF_LEFT_MARGIN             :1
         MCF_PARA_MARGIN             :1
@@ -2042,14 +2042,14 @@ rectangle must be less than 65535 points high or wide.)
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### MCToolboxFeatures
+### MCToolboxFeatures
     MCToolboxFeatures       record
     MCToolboxFeatures       end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### MeasurementType
+### MeasurementType
     MeasurementType     etype byte
         MEASURE_US              enum MeasurementType
         MEASURE_METRIC          enum MeasurementType
@@ -2057,7 +2057,7 @@ rectangle must be less than 65535 points high or wide.)
 **Library:** localize.def
 
 ----------
-#### MediaType
+### MediaType
     MediaType       etype byte, 0
         MEDIA_NONEXISTENT       enum MediaType  ; used as error value
         MEDIA_160K              enum MediaType
@@ -2077,7 +2077,7 @@ rectangle must be less than 65535 points high or wide.)
 **Library:** drive.def
 
 ----------
-#### MemGetInfoType
+### MemGetInfoType
     MemGetInfoType      etype word, 0, 2
         MGIT_SIZE                       enum MemGetInfoType
         MGIT_FLAGS_AND_LOCK_COUNT       enum MemGetInfoType
@@ -2089,7 +2089,7 @@ rectangle must be less than 65535 points high or wide.)
 **Library:** heap.def
 
 ----------
-#### MenuSepFlags
+### MenuSepFlags
     MenuSepFlags        record
         MSF_SEP             :1
         MSF_USABLE          :1
@@ -2117,7 +2117,7 @@ its previous sibling or parent.
 **Library:** Objects/visC.def
 
 ----------
-#### MessageError
+### MessageError
     MessageError        etype word
         MESSAGE_NO_ERROR        enum MessageError
         MESSAGE_NO_HANDLES      enum MessageError   ; short on handles and
@@ -2127,7 +2127,7 @@ its previous sibling or parent.
 **Library:** object.def
 
 ----------
-#### MessageFlags
+### MessageFlags
     MessageFlags        record
         MF_CALL                     :1
         MF_FORCE_QUEUE              :1
@@ -2150,7 +2150,7 @@ its previous sibling or parent.
 **Library:** object.def
 
 ----------
-#### MetaAlterFTVMCExclFlags
+### MetaAlterFTVMCExclFlags
     MetaAlterFTVMCExclFlags     record
         MAEF_NOT_HERE               :1
         MAEF_SYS_EXCL               :1
@@ -2223,7 +2223,7 @@ menu-related object
 **Library:** uiInputC.def
 
 ----------
-#### MetaBase
+### MetaBase
     MetaBase        struct
         MB_class        fptr.ClassStruct        ; Instance's class
     MetaBase        ends
@@ -2233,7 +2233,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** Objects/metaC.def
 
 ----------
-#### MinIncrementType
+### MinIncrementType
     MinIncrementType        union
         MIT_US          MinUSMeasure
         MIT_METRIC      MinMetricMeasure
@@ -2244,7 +2244,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** ruler.def
 
 ----------
-#### MinMetricMeasure
+### MinMetricMeasure
     MinMetricMeasure        etype byte, 0
         MMM_MILLIMETER              enum    MinMetricMeasure
         MMM_HALF_CENTIMETER         enum    MinMetricMeasure
@@ -2253,7 +2253,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** 
 
 ----------
-#### MinPicaMeasure
+### MinPicaMeasure
     MinPicaMeasure      etype byte, 0
         MPM_PICA            enum MinPicaMeasure
         MPM_INCH            enum MinPicaMeasure
@@ -2261,7 +2261,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** ruler.def
 
 ----------
-#### MinPointMeasure
+### MinPointMeasure
     MinPointMeasure     etype byte, 0
         MPM_25_POINT            enum MinPointMeasure
         MPM_50_POINT            enum MinPointMeasure
@@ -2270,7 +2270,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** ruler.def
 
 ----------
-#### MinUSMeasure
+### MinUSMeasure
     MinUSMeasure        etype byte, 0
         MUSM_EIGHTH_INCH            enum MinUSMeasure
         MUSM_QUARTER_INCH           enum MinUSMeasure
@@ -2280,7 +2280,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** ruler.def
 
 ----------
-#### MixMode
+### MixMode
     MixMode etype byte
         MM_CLEAR        enum MixMode        ; dest <- 0
         MM_COPY         enum MixMode        ; dest <- src
@@ -2296,7 +2296,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** graphics.def
 
 ----------
-#### MonikerGroupEntry
+### MonikerGroupEntry
     MonikerGroupEntry       struct
         MGE_type        VisMonikerListEntryType
         MGE_group       word
@@ -2305,7 +2305,7 @@ This base structure is defined so Esp can build on it for all other classes.
 **Library:** token.def
 
 ----------
-#### MonikerMessageParams
+### MonikerMessageParams
     MonikerMessageParams            struct
         MMP_xInset          word
         MMP_yInset          word
@@ -2343,7 +2343,7 @@ used when drawing the moniker.
 **Library:** Objects/visC.def
 
 ----------
-#### MouseGrab
+### MouseGrab
     MouseGrab       struct
         MG_OD           optr
         MG_gWin         hptr
@@ -2355,7 +2355,7 @@ the window handle that mouse data should be translated into before sending.
 **Library:** Objects/uiInputC.def
 
 ----------
-#### MouseReturnFlags
+### MouseReturnFlags
     MouseReturnFlags        record
         MRF_PROCESSED                   :1
         MRF_REPLAY                      :1

--- a/TechDocs/Markdown/Asmref/asmstrnr.md
+++ b/TechDocs/Markdown/Asmref/asmstrnr.md
@@ -1,7 +1,7 @@
 ## 3.5 Structures N-R
 
 ----------
-#### NameArrayAddFlags
+### NameArrayAddFlags
     NameArrayAddFlags       record
         NAAF_SET_DATA_ON_REPLACE        :1
                                         :15
@@ -13,7 +13,7 @@ If replacing an existing name set, set data for the name to the data passed.
 **Library:** chunkarr.def
 
 ----------
-#### NameArrayElement
+### NameArrayElement
     NameArrayElement        struct
         NAE_meta        RefElementHeader    ;standard ElementArray header
         NAE_data        label byte          ;data
@@ -24,7 +24,7 @@ The name itself immediately follows the byte of data.
 **Library:** chunkarr.def
 
 ----------
-#### NameArrayHeader
+### NameArrayHeader
     NameArrayHeader     struct
         NAH_meta            ElementArrayHeader
         NAH_dataSize        word
@@ -42,7 +42,7 @@ array.
 **Library:** chunkarr.def
 
 ----------
-#### NameArrayMaxElement
+### NameArrayMaxElement
     NameArrayMaxElement         struct
         NAME_meta           RefElementHeader
         NAME_data           byte NAME_ARRAY_MAX_DATA_SIZE dup (?)
@@ -52,7 +52,7 @@ array.
 **Library:** chunkarr.def
 
 ----------
-#### NavigateCommonFlags
+### NavigateCommonFlags
     NavigateCommonFlags         record
         NCF_IS_COMPOSITE            :1
         NCF_IS_FOCUSABLE            :1
@@ -80,7 +80,7 @@ Set if this node is the root level of the tree.
 **Library:** Objects/visC.def
 
 ----------
-#### NavigateCommonParams
+### NavigateCommonParams
     NavigateCommonParams            struct
         NCP_object              optr
         NCP_navFlags            NavigateFlags
@@ -98,7 +98,7 @@ for navigation hints on the object.)
 **Library:** Objects/visC.def
 
 ----------
-#### NavigateFlags
+### NavigateFlags
     NavigateFlags       record
         ; reply flags
         NF_COMPLETED_CIRCUIT            :1
@@ -160,7 +160,7 @@ checking, and for the "navigate to previous" case.
 **Library:** Objects/visC.def
 
 ----------
-#### NCCFlagsUnion
+### NCCFlagsUnion
     NCCFlagsUnion       union
         NCCFU_char              VisTextCharAttrFlags
         NCCFU_paragraph         VisTextParaAttrFlags
@@ -170,7 +170,7 @@ checking, and for the "navigate to previous" case.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NoteType
+### NoteType
     NoteType    etype byte, 0, 2
         NT_INK      enum NoteType
         NT_TEXT     enum NoteType
@@ -178,7 +178,7 @@ checking, and for the "navigate to previous" case.
 **Library:** pen.def
 
 ----------
-#### NotificationType
+### NotificationType
     NotificationType        struct
         NT_manuf        ManufacturerID
         NT_type         word
@@ -190,7 +190,7 @@ MSG_META_NOTIFY and MSG_META_NOTIFY_WITH_DATA_BLOCK.
 **Library:** Objects/metaC.def
 
 ----------
-#### NotifyColorChange
+### NotifyColorChange
     NotifyColorChange       struct
         NCC_color           ColorQuad
         NCC_grayScreen      SystemDrawMask
@@ -216,7 +216,7 @@ MSG_META_NOTIFY and MSG_META_NOTIFY_WITH_DATA_BLOCK.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NotifyDisplayChange
+### NotifyDisplayChange
     NotifyDisplayChange         struct
         NDC_displayNum      word
         NDC_name            char MAX_DISPLAY_NAME_SIZE dup (?)
@@ -226,7 +226,7 @@ MSG_META_NOTIFY and MSG_META_NOTIFY_WITH_DATA_BLOCK.
 **Library:** Objects/gDCtrlC.def
 
 ----------
-#### NotifyDisplayListChange
+### NotifyDisplayListChange
     NotifyDisplayListChange         struct
         NDLC_counter            word
         NDLC_group              optr
@@ -235,7 +235,7 @@ MSG_META_NOTIFY and MSG_META_NOTIFY_WITH_DATA_BLOCK.
 **Library:** Objects/gDCtrlC.def
 
 ----------
-#### NotifyDocumentChange
+### NotifyDocumentChange
     NotifyDocumentChange            struct
         NDC_attrs               GenDocumentAttrs
         NDC_type                GenDocumentType
@@ -247,7 +247,7 @@ MSG_META_NOTIFY and MSG_META_NOTIFY_WITH_DATA_BLOCK.
 **Library:** Objects/gDocCtrl.def
 
 ----------
-#### NotifyEnabledFlags
+### NotifyEnabledFlags
     NotifyEnabledFlags      record
         NEF_STATE_CHANGING      :1  ;this is the object whose state is changing
                                 :7
@@ -256,7 +256,7 @@ MSG_META_NOTIFY and MSG_META_NOTIFY_WITH_DATA_BLOCK.
 **Library:** Objects/genC.def
 
 ----------
-#### NotifyFloatFormatChange
+### NotifyFloatFormatChange
     NotifyFloatFormatChange         struc
         NFFC_vmFileHan          word
         NFFC_vmBlkHan           word
@@ -267,7 +267,7 @@ MSG_META_NOTIFY and MSG_META_NOTIFY_WITH_DATA_BLOCK.
 **Library:** math.def
 
 ----------
-#### NotifyFocusWindowKbdStatus
+### NotifyFocusWindowKbdStatus
     NotifyFocusWindowKbdStatus      struct
         NFWKS_needsFloatingKbd          word
         NFWKS_kbdPosition               Point<>
@@ -292,7 +292,7 @@ Either zero if window is not sys-modal or 0xffff if it is
 **Library:** 
 
 ----------
-#### NotifyFontAttrChange
+### NotifyFontAttrChange
     NotifyFontAttrChange            struct
         NFAC_fontWeight                 byte
         NFAC_fontWeightDiffs            byte
@@ -305,7 +305,7 @@ Either zero if window is not sys-modal or 0xffff if it is
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NotifyFontChange
+### NotifyFontChange
     NotifyFontChange            struct
         NFC_fontID          FontID
         NFC_diffs           byte
@@ -314,7 +314,7 @@ Either zero if window is not sys-modal or 0xffff if it is
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NotifyGenControlStatusChange
+### NotifyGenControlStatusChange
     NotifyGenControlStatusChange                struct
         NGCS_controller                 optr
         NGCS_statusChange               GenControlStatusChange
@@ -330,7 +330,7 @@ object has undergone.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### NotifyInkHasTarget
+### NotifyInkHasTarget
     NotifyInkHasTarget          struct
         NIHT_optr           optr
     NotifyInkHasTarget          ends
@@ -341,7 +341,7 @@ notification.
 **Library:** pen.def
 
 ----------
-#### NotifyJustificationChange
+### NotifyJustificationChange
     NotifyJustificationChange           struct
         NJC_justification       Justification
         NJC_diffs               byte
@@ -352,7 +352,7 @@ notification.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NotifyPageInfoChange
+### NotifyPageInfoChange
     NotifyPageInfoChange        struct
         NPIC_width          word
         NPIC_height         word
@@ -365,7 +365,7 @@ notification.
 **Library:** pageInfo.def
 
 ----------
-#### NotifyPageStateChange
+### NotifyPageStateChange
     NotifyPageStateChange           struct
         NPSC_firstPage                  word        ;first page
         NPSC_lastPage                   word        ;last page
@@ -375,7 +375,7 @@ notification.
 **Library:** Objects/gPageCC.def
 
 ----------
-#### NotifyPointSizeChange
+### NotifyPointSizeChange
     NotifyPointSizeChange           struct
         NPSC_pointSize          WWFixed
         NPSC_diffs              byte
@@ -384,7 +384,7 @@ notification.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NotifySearchReplaceEnableChange
+### NotifySearchReplaceEnableChange
     NotifySearchReplaceEnableChange                 struct
         NSREC_flags         SearchReplaceEnableFlags
     NotifySearchReplaceEnableChange                 ends
@@ -392,7 +392,7 @@ notification.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NotifySelectStateChange
+### NotifySelectStateChange
     NotifySelectStateChange         struct
         NSSC_selectionType                  SelectionDataType
         NSSC_clipboardableSelection         BooleanByte
@@ -416,7 +416,7 @@ exists.
 **Library:** Objects/gEditCC.def
 
 ----------
-#### NotifyTextStyleChange
+### NotifyTextStyleChange
     NotifyTextStyleChange           struct
         NTSC_styles             TextStyle
         NTSC_indeterminates     TextStyle
@@ -425,7 +425,7 @@ exists.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### NotifyUndoStateChange
+### NotifyUndoStateChange
     NotifyUndoStateChange           struct
         NUSC_undoTitle          optr
         NUSC_undoType           UndoDescription
@@ -437,7 +437,7 @@ operation to undo.
 **Library:** Objects/gEditCC.def
 
 ----------
-#### NotifyViewStateChange
+### NotifyViewStateChange
     NotifyViewStateChange               struct
         NVSC_origin                 PointDWFixed
         NVSC_docBounds              RectDWord
@@ -457,7 +457,7 @@ operation to undo.
 **Library:** Objects/gViewCC.def
 
 ----------
-#### NumberFormatFlags
+### NumberFormatFlags
     NumberFormatFlags       record
                                 :7
         NFF_LEADING_ZERO        :1
@@ -466,7 +466,7 @@ operation to undo.
 **Library:** localize.def
 
 ----------
-#### NumberType
+### NumberType
     NumberType      etype byte, 0, 1
         NT_VALUE        enum NumberType         ; It's just a number
         NT_BOOLEAN      enum NumberType         ; It's a boolean
@@ -475,7 +475,7 @@ operation to undo.
 **Library:** parse.def
 
 ----------
-#### ObjChunkFlags
+### ObjChunkFlags
     ObjChunkFlags       record
                                 :3
         OCF_VARDATA_RELOC       :1
@@ -488,7 +488,7 @@ operation to undo.
 **Library:** object.def
 
 ----------
-#### ObjCompCallType
+### ObjCompCallType
     ObjCompCallType     etype word, 0, 2
         OCCT_SAVE_PARAMS_TEST_ABORT             enum ObjCompCallType
         OCCT_SAVE_PARAMS_DONT_TEST_ABORT        enum ObjCompCallType
@@ -500,7 +500,7 @@ operation to undo.
 **Library:** Objects/metaC.def
 
 ----------
-#### ObjectTransform
+### ObjectTransform
     ObjectTransform     struct
         OT_center           PointDWFixed
         OT_width            WWFixed
@@ -527,7 +527,7 @@ invalidation, etc.
 **Library:** grobj.def
 
 ----------
-#### ObjFlushInputQueueNextStop
+### ObjFlushInputQueueNextStop
     ObjFlushInputQueueNextStop          etype word, 0, 2
         OFIQNS_INPUT_MANAGER                enum ObjFlushInputQueueNextStop
         OFIQNS_SYSTEM_INPUT_OBJ             enum ObjFlushInputQueueNextStop
@@ -560,7 +560,7 @@ Queues are flushed, so FORCE_QUEUE dispatch passed Event.
 **Library:** Objects/metaC.def
 
 ----------
-#### ObjLMemBlockHeader
+### ObjLMemBlockHeader
     ObjLMemBlockHeader          struct
         OLMBH_header                LMemBlockHeader <>
         OLMBH_inUseCount            word
@@ -593,7 +593,7 @@ TO_OBJ_BLOCK_OUTPUT.
 **Library:** object.def
 
 ----------
-#### ObjRelocation
+### ObjRelocation
     ObjRelocation       struct
         OR_type     ObjRelocationType       ; Type of relocation
         OR_offset   word                    ; Offset to relocation
@@ -604,7 +604,7 @@ This is the structure of an object relocation table entry (for instance data).
 **Library:** object.def
 
 ----------
-#### ObjRelocationID
+### ObjRelocationID
     ObjRelocationID     record
         RID_SOURCE          ObjRelocationSource:4
         RID_INDEX           :12
@@ -613,7 +613,7 @@ This is the structure of an object relocation table entry (for instance data).
 **Library:** object.def
 
 ----------
-#### ObjRelocationSource
+### ObjRelocationSource
     ObjRelocationSource         etype byte
         ORS_NULL                        enum ObjRelocationSource
         ORS_OWNING_GEODE                enum ObjRelocationSource
@@ -660,7 +660,7 @@ Internal.
 **Library:** object.def
 
 ----------
-#### ObjRelocationType
+### ObjRelocationType
     ObjRelocationType           etype byte
         RELOC_END_OF_LIST   enum ObjRelocationType
         RELOC_HANDLE        enum ObjRelocationType  ;resource ID to handle
@@ -687,7 +687,7 @@ Resource ID/entry number.
 **Library:** object.def
 
 ----------
-#### OldErrorCheckingFlags
+### OldErrorCheckingFlags
     OldErrorCheckingFlags   record
         OECF_REGION             :1  ;Region checking
         OECF_HEAP_FREE_BLOCKS   :1  ;Ensure that all free blocks are 0xcccc
@@ -711,7 +711,7 @@ Resource ID/entry number.
 **Library:** ec.def
 
 ----------
-#### OperatorStackElement
+### OperatorStackElement
     OperatorStackElement    struct
         OSE_type        EvalStackOperatorType   ; Type of the operator
         OSE_data        EvalStackOperatorData   ; The associated data
@@ -720,7 +720,7 @@ Resource ID/entry number.
 **Library:** parse.def
 
 ----------
-#### OperatorType
+### OperatorType
     OperatorType        etype byte, 0, 1
         OP_RANGE_SEPARATOR              enum OperatorType
         OP_NEGATION                     enum OperatorType
@@ -778,7 +778,7 @@ Resource ID/entry number.
 **Library:** parse.def
 
 ----------
-#### OriginChangedParams
+### OriginChangedParams
     OriginChangedParams         struct
         OCP_origin      PointDWord      ;new origin
         OCP_window      lptr Window     ;window of view
@@ -787,7 +787,7 @@ Resource ID/entry number.
 **Library:** Objects/gViewC.def
 
 ----------
-#### PACFeatures
+### PACFeatures
     PACFeatures     record
         PACF_WORD_WRAP                  :1
         PACF_COLUMN_BREAK_BEFORE        :1
@@ -799,14 +799,14 @@ Resource ID/entry number.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### PACToolboxFeatures
+### PACToolboxFeatures
     PACToolboxFeatures      record
     PACToolboxFeatures      end
 
 **Library:** Object/Text/tCtrlC.def
 
 ----------
-#### PageEndCommand
+### PageEndCommand
     PageEndCommand      etype   byte
         PEC_FORM_FEED       enum    PageEndCommand  ; 0 = form feed
         PEC_NO_FORM_FEED    enum    PageEndCommand  ; 1 = no form feed
@@ -814,7 +814,7 @@ Resource ID/entry number.
 **Library:** graphics.def
 
 ----------
-#### PageLayout
+### PageLayout
     PageLayout      union
         PL_paper            PageLayoutPaper
         PL_envelope         PageLayoutEnvelope
@@ -824,7 +824,7 @@ Resource ID/entry number.
 **Library:** spool.def
 
 ----------
-#### PageLayoutEnvelope
+### PageLayoutEnvelope
     PageLayoutEnvelope          record
                             :12
         PLE_ORIENTATION     EnvelopeOrientation:1
@@ -834,7 +834,7 @@ Resource ID/entry number.
 **Library:** spool.def
 
 ----------
-#### PageLayoutLabel
+### PageLayoutLabel
     PageLayoutLabel         record
                         :1
         PLL_ROWS        :6              ; labels down
@@ -845,7 +845,7 @@ Resource ID/entry number.
 **Library:** spool.def
 
 ----------
-#### PageLayoutPaper
+### PageLayoutPaper
     PageLayoutPaper     record
                             :12
         PLP_ORIENTATION     PaperOrientation:1
@@ -855,7 +855,7 @@ Resource ID/entry number.
 **Library:** spool.def
 
 ----------
-#### PageSetupInfo
+### PageSetupInfo
     PageSetupInfo       struct
         PSI_meta            VMChainLink
         PSI_pageSize        XYSize          ; In pixels (points)
@@ -875,7 +875,7 @@ Resource ID/entry number.
 **Library:** Objects/vTextC.def
 
 ----------
-#### PageSizeControlAttrs
+### PageSizeControlAttrs
     PageSizeControlAttrs        record
         ; EXTERNAL
         PZCA_ACT_LIKE_GADGET        :1
@@ -909,7 +909,7 @@ attribute.
 **Library:** spool.def
 
 ----------
-#### PageSizeControlChanges
+### PageSizeControlChanges
     PageSizeControlChanges          struct
         PSCC_destination        optr        ; destination for message
         PSCC_message            word        ; message to be sent
@@ -924,7 +924,7 @@ attribute.
 **Library:** spool.def
 
 ----------
-#### PageSizeControlFeatures
+### PageSizeControlFeatures
     PageSizeControlFeatures         record
         PSIZECF_MARGINS         :1      ; not part of default features
         PSIZECF_CUSTOM_SIZE     :1
@@ -936,7 +936,7 @@ attribute.
 **Library:** spool.def
 
 ----------
-#### PageSizeControlMaxDimensions
+### PageSizeControlMaxDimensions
     PageSizeControlMaxDimensions    struct
         PZCMD_width             dword       ; maximum width
         PZCMD_height            dword       ; maximum height
@@ -945,7 +945,7 @@ attribute.
 **Library:** spool.def
 
 ----------
-#### PageSizeControlToolboxFeatures
+### PageSizeControlToolboxFeatures
     PageSizeControlToolboxFeatures          record
         PSIZECTF_DIALOG_BOX             :1
     PageSizeControlToolboxFeatures          end
@@ -953,7 +953,7 @@ attribute.
 **Library:** spool.def
 
 ----------
-#### PageSizeReport
+### PageSizeReport
     PageSizeReport          struct
         PSR_width       dword               ; width of the page
         PSR_height      dword               ; height of the page
@@ -964,7 +964,7 @@ attribute.
 **Library:** spool.def
 
 ----------
-#### PageType
+### PageType
     PageType        etype word, 0, 2
         PT_PAPER            enum PageType
         PT_ENVELOPE         enum PageType
@@ -973,7 +973,7 @@ attribute.
 **Library:** print.def
 
 ----------
-#### Palette
+### Palette
     Palette     struct
         P_entries       word 16     ; Number of 3-byte entries in palette.
     Palette     ends
@@ -984,7 +984,7 @@ associated with windows.
 **Library:** color.def
 
 ----------
-#### PaperOrientation
+### PaperOrientation
     PaperOrientation        etype byte, 0, 1
         PO_PORTRAIT             enum PaperOrientation
         PO_LANDSCAPE            enum PaperOrientation
@@ -992,7 +992,7 @@ associated with windows.
 **Library:** print.def
 
 ----------
-#### ParserFlags
+### ParserFlags
     ParserFlags     record
         ;
         ; These are initialized by the parser. They are initialized to zero.
@@ -1013,7 +1013,7 @@ associated with windows.
 **Library:** parse.def
 
 ----------
-#### ParserParameters
+### ParserParameters
     ParserParameters        struct
         ;
         ; Applications should initialize these fields before calling ParseString
@@ -1044,7 +1044,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserScannerEvaluatorError
+### ParserScannerEvaluatorError
     ParserScannerEvaluatorError             etype byte, 0, 1
         ;
         ; Scanner errors
@@ -1110,7 +1110,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserToken
+### ParserToken
     ParserToken         struct
         PT_type     ParserTokenType             ; Type of token data
         PT_data     ParserTokenData             ; The data itself
@@ -1119,7 +1119,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserTokenCellData
+### ParserTokenCellData
     ParserTokenCellData             struct
         PTCD_cellRef            CellReference <>
     ParserTokenCellData             ends
@@ -1127,7 +1127,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserTokenData
+### ParserTokenData
     ParserTokenData     union
         PTD_number          ParserTokenNumberData
         PTD_string          ParserTokenStringData
@@ -1140,7 +1140,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserTokenFunctionData
+### ParserTokenFunctionData
     ParserTokenFunctionData     struct
         PTFD_functionID             word    ; Identifier for the function
     ParserTokenFunctionData     ends
@@ -1148,7 +1148,7 @@ operations such as **ParseString**.
 **Library:** 
 
 ----------
-#### ParserTokenNameData
+### ParserTokenNameData
     ParserTokenNameData         struct
         PTND_name       word        ; The token describing the name
     ParserTokenNameData         ends
@@ -1156,7 +1156,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserTokenNumberData
+### ParserTokenNumberData
     ParseTokenNumberData            struct
         PTND_value          FloatNum <>     ; 8 byte constant
     ParseTokenNumberData            ends
@@ -1164,7 +1164,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserTokenOperatorData
+### ParserTokenOperatorData
     ParserTokenOperatorData             struct
         PTOD_operatorID         OperatorType    ; The operator ID.
     ParserTokenOperatorData             ends
@@ -1172,7 +1172,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserTokenStringData
+### ParserTokenStringData
     ParserTokenStringData           struct
         PTSD_length         word        ; Length of the string
     ParserTokenStringData           ends
@@ -1180,7 +1180,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### ParserTokenType
+### ParserTokenType
     ParserTokenType     etype byte, 0, 1
         PARSER_TOKEN_NUMBER                 enum ParserTokenType
         PARSER_TOKEN_STRING                 enum ParserTokenType
@@ -1202,7 +1202,7 @@ operations such as **ParseString**.
 **Library:** parse.def
 
 ----------
-#### PASCFeatures
+### PASCFeatures
     PASCFeatures        record
         PASCF_SPACE_ON_TOP          :1
         PASCF_SPACE_ON_BOTTOM       :1
@@ -1211,14 +1211,14 @@ operations such as **ParseString**.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### PASCToolboxFeatures
+### PASCToolboxFeatures
     PASCToolboxFeatures         record
     PASCToolboxFeatures         end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### PathCombineType
+### PathCombineType
     PathCombineType     etype word
         PCT_NULL            enum PathCombineType    ; destroy current
         PCT_REPLACE         enum PathCombineType    ; replace current
@@ -1228,7 +1228,7 @@ operations such as **ParseString**.
 **Library:** graphics.def
 
 ----------
-#### PathCompareType
+### PathCompareType
     PathCompareType     etype byte
         PCT_EQUAL           enum PathCompareType
         PCT_SUBDIR          enum PathCompareType
@@ -1252,7 +1252,7 @@ the paths was not found, etc.).
 **Library:** file.def
 
 ----------
-#### PatternType
+### PatternType
     PatternType     etype byte
         PT_SOLID                enum PatternType    
         PT_SYSTEM_HATCH         enum PatternType    
@@ -1286,7 +1286,7 @@ Appl-custom tiled bitmap.
 **Library:** graphics.def
 
 ----------
-#### PCComInitFlags
+### PCComInitFlags
     PCComInitFlags record
         PCCIF_NOTIFY_OUTPUT     :1  ; notify caller of output
         PCCIF_NOTIFY_EXIT       :1  ; notify caller of remote exit
@@ -1296,7 +1296,7 @@ Appl-custom tiled bitmap.
 **Library:** pccom.def
 
 ----------
-#### PCComReturnType
+### PCComReturnType
     PCComReturnType etype byte
         PCCRT_NO_ERROR                  enum PCComReturnType
         PCCRT_CANNOT_LOAD_SERIAL_DRIVER     enum PCComReturnType
@@ -1307,7 +1307,7 @@ Appl-custom tiled bitmap.
 **Library:** pccom.def
 
 ----------
-#### PCDocSizeParams
+### PCDocSizeParams
     PCDocSizeParams         struct
         PCDSP_width     dword (?)       ; width of the document
         PCDSP_height    dword (?)       ; height of the document
@@ -1316,7 +1316,7 @@ Appl-custom tiled bitmap.
 **Library:** spool.def
 
 ----------
-#### PCMarginParams
+### PCMarginParams
     PCMarginParams      struct
         PCMP_left           word (?)            ; left margin
         PCMP_top            word (?)            ; top margin
@@ -1327,7 +1327,7 @@ Appl-custom tiled bitmap.
 **Library:** print.def
 
 ----------
-#### PCProgressType
+### PCProgressType
     PCProgressType          etype word, 0, 2
         PCPT_PAGE       enum PCProgressType     ; change page number
         PCPT_PERCENT    enum PCProgressType     ; change percent done
@@ -1336,7 +1336,7 @@ Appl-custom tiled bitmap.
 **Library:** spool.def
 
 ----------
-#### PenInputDisplayType
+### PenInputDisplayType
     PenInputDisplayType         etype word
         PIDT_KEYBOARD                   enum PenInputDisplayType
         PIDT_CHAR_TABLE                 enum PenInputDisplayType
@@ -1349,7 +1349,7 @@ Appl-custom tiled bitmap.
 **Library:** Objects/gPenICC.def
 
 ----------
-#### PLInit
+### PLInit
     PLInit  struct
         PLI_align           byte
         PLI_message         word
@@ -1362,7 +1362,7 @@ Appl-custom tiled bitmap.
 **Library:** grobj.def
 
 ----------
-#### Point
+### Point
     Point   struct
         P_x sword
         P_y sword
@@ -1371,7 +1371,7 @@ Appl-custom tiled bitmap.
 **Library:** graphics.def
 
 ----------
-#### PointDWFixed
+### PointDWFixed
     PointDWFixed        struct
         PDF_x       DWFixed
         PDF_y       DWFixed
@@ -1383,7 +1383,7 @@ is in terms of a **DWFixed** value.
 **Library:** graphics.def
 
 ----------
-#### PointDWord
+### PointDWord
     PointDWord      struct
         PD_x    sdword
         PD_y    sdword
@@ -1395,7 +1395,7 @@ is in terms of a signed dword value.
 **Library:** graphics.def
 
 ----------
-#### PointerDef
+### PointerDef
     PointerDef      struct
         PD_width        PointerDefWidth
         PD_height       byte
@@ -1413,7 +1413,7 @@ of the pointer. These offsets are relative to the upper left corner of the point
 **Library:** graphics.def
 
 ----------
-#### PointerDefWidth
+### PointerDefWidth
     PointerDefWidth record
         PDW_ALWAYS_SHOW_PTR     :1
         ; flag, set in BUSY cursors & any other cursors that should be shown
@@ -1428,7 +1428,7 @@ of the pointer. These offsets are relative to the upper left corner of the point
 **Library:** graphics.def
 
 ----------
-#### PointerModes
+### PointerModes
     PointerModes        record
         PM_HANDLES_RESIZE                   :1
         PM_HANDLES_ROTATE                   :1
@@ -1438,7 +1438,7 @@ of the pointer. These offsets are relative to the upper left corner of the point
 **Library:** grobj.def
 
 ----------
-#### PointWBFixed
+### PointWBFixed
     PointWBFixed        struct
         PWBF_x      WBFixed
         PWBF_y      WBFixed
@@ -1450,7 +1450,7 @@ is in terms of a **WBFixed** value.
 **Library:** graphics.def
 
 ----------
-#### PointWWFixed
+### PointWWFixed
     PointWWFixed        struct
         PF_x        WWFixed
         PF_y        WWFixed
@@ -1462,7 +1462,7 @@ is in terms of a **WWFixed** value.
 **Library:** graphics.def
 
 ----------
-#### PrefAttributes
+### PrefAttributes
     PrefAttributes      record
         PA_REBOOT_IF_CHANGED            :1
         PA_LOAD_IF_USABLE               :1
@@ -1495,7 +1495,7 @@ Save options only if this object has changed.
 **Library:**  config.def
 
 ----------
-#### PrefDialogChangeType
+### PrefDialogChangeType
     PrefDialogChangeType            etype word, 0
         PDCT_OPEN           enum PrefDialogChangeType
         PDCT_CLOSE          enum PrefDialogChangeType
@@ -1506,7 +1506,7 @@ Save options only if this object has changed.
 **Library:** config.def
 
 ----------
-#### PrefEnableData
+### PrefEnableData
     PrefEnableData          struct
         PED_item        word
         PED_lptr        lptr
@@ -1522,7 +1522,7 @@ if no items are selected.
 **Library:** config.def
 
 ----------
-#### PrefEnableFlags
+### PrefEnableFlags
     PrefEnableFlags     record
         PEF_DISABLE_IF_SELECTED         :1
         PEF_DISABLE_IF_NONE             :1
@@ -1541,7 +1541,7 @@ selected-or if there are no items in the list.
 **Library:** config.def
 
 ----------
-#### PrefInitFileFlags
+### PrefInitFileFlags
     PrefInitFileFlags       record
         PIFF_USE_ITEM_STRINGS           :1
         PIFF_USE_ITEM_MONIKERS          :1
@@ -1565,7 +1565,7 @@ already exist for this key.
 **Library:** config.def
 
 ----------
-#### PrefInteractionAttrs
+### PrefInteractionAttrs
     PrefInteractionAttrs record
         PIA_LOAD_OPTIONS_ON_INITIATE    :1
         PIA_SAVE_OPTIONS_ON_APPLY       :1
@@ -1586,7 +1586,7 @@ for objects of **PrefDialogClass**.
 **Library:** config.def
 
 ----------
-#### PrefItemGroupStringVars
+### PrefItemGroupStringVars
     PrefItemGroupStringVars struct
         PIGSV_endPtr            nptr.char
         PIGSV_selections        word PREF_ITEM_GROUP_MAX_SELECTIONS dup (?)
@@ -1596,7 +1596,7 @@ for objects of **PrefDialogClass**.
 **Library:** config.def
 
 ----------
-#### PrefMgrFeatures
+### PrefMgrFeatures
     PrefMgrFeatures     record
         PMF_HARDWARE        :1
         PMF_SYSTEM          :1
@@ -1629,7 +1629,7 @@ example, to look at a scaled-down, "network-only" prefmgr.
 **Library:** config.def
 
 ----------
-#### PrefModuleEntryType
+### PrefModuleEntryType
     PrefModuleEntryType         etype word, 0, 1
         PMET_FETCH_UI               enum PrefModuleEntryType 
         ;
@@ -1658,7 +1658,7 @@ first routines exported from that library.
 **Library:** config.def
 
 ----------
-#### PrefModuleInfo
+### PrefModuleInfo
     PrefModuleInfo struct
         PMI_requiredFeatures        PrefMgrFeatures <>
         ; Features that MUST be set for this module to appear in PrefMgr
@@ -1686,7 +1686,7 @@ first routines exported from that library.
 **Library:** config.def
 
 ----------
-#### PrefTimeDateControlFeatures
+### PrefTimeDateControlFeatures
     PrefTimeDateControlFeatures     record
         PTDCF_DATE      :1
         PTDCF_TIME      :1
@@ -1695,14 +1695,14 @@ first routines exported from that library.
 **Library:** config.def
 
 ----------
-#### PrefTimeDateControlScreen
+### PrefTimeDateControlScreen
     PrefTimeDateControlScreen       etype   word, 0, 2
         PTDCS_TIME_DATE     enum    PrefTimeDateControlScreen
 
 **Library:** config.def
 
 ----------
-#### PrefTocExtraEntry
+### PrefTocExtraEntry
     PrefTocExtraEntry       struct
         PTEE_item       lptr.char
         PTEE_driver     lptr.char
@@ -1719,7 +1719,7 @@ For others, this is the filename.
 **Library:** config.def
 
 ----------
-#### PrefTriggerAction
+### PrefTriggerAction
     PrefTriggerAction       struct
         PTA_message     word
         PTA_dest        optr
@@ -1728,7 +1728,7 @@ For others, this is the filename.
 **Library:** config.def
 
 ----------
-#### PrefVMMapBlock
+### PrefVMMapBlock
     PrefVMMapBlock  struct 
         PVMMB_root      fptr
     PrefVMMapBlock  ends
@@ -1741,7 +1741,7 @@ portion is VM block handle
 **Library:** config.def
 
 ----------
-#### PrintControlAttrs
+### PrintControlAttrs
     PrintControlAttrs       record
                                 :1
         PCA_SEE_IF_DOC_WILL_FIT :1      ; check if document will fit on paper
@@ -1764,7 +1764,7 @@ portion is VM block handle
 **Library:** spool.def
 
 ----------
-#### PrintControlFeatures
+### PrintControlFeatures
     PrintControlFeatures            record
         PRINTCF_PRINT_TRIGGER           :1      ; wants a print trigger
         PRINTCF_FAX_TRIGGER             :1      ; wants a fax trigger
@@ -1773,7 +1773,7 @@ portion is VM block handle
 **Library:** spool.def
 
 ----------
-#### PrintControlStatus
+### PrintControlStatus
     PrintControlStatus      etype word
         PCS_PRINT_BOX_VISIBLE       enum PrintControlStatus ; Print DB is on screen
         PCS_PRINT_BOX_NOT_VISIBLE   enum PrintControlStatus ; Print DB not on screen
@@ -1781,7 +1781,7 @@ portion is VM block handle
 **Library:** spool.def
 
 ----------
-#### PrintControlToolboxFeatures
+### PrintControlToolboxFeatures
     PrintControlToolboxFeatures             record
         PRINTCTF_PRINT_TRIGGER      :1      ; wants a print tool trigger
         PRINTCTF_FAX_TRIGGER        :1      ; wants a fax tool trigger
@@ -1790,7 +1790,7 @@ portion is VM block handle
 **Library:** spool.def
 
 ----------
-#### PrinterDriverType
+### PrinterDriverType
     PrinterDriverType       etype byte, 0
         PDT_PRINTER         enum PrinterDriverType
         PDT_PLOTTER         enum PrinterDriverType
@@ -1802,7 +1802,7 @@ portion is VM block handle
 **Library:** print.def
 
 ----------
-#### PrinterMode
+### PrinterMode
     PrinterMode     etype byte, 0, 2
         PM_GRAPHICS_LOW_RES enum PrinterMode    ; lowest quality...fastest...
         PM_GRAPHICS_MED_RES enum PrinterMode    ; medium quality...slower...
@@ -1815,7 +1815,7 @@ portion is VM block handle
 **Library:** print.def
 
 ----------
-#### PrinterOutputModes
+### PrinterOutputModes
     PrinterOutputModes      record
         POM_unused              :3      ; leave these bits alone!!!
         POM_GRAPHICS_LOW        :1      ; Graphics mode low quality available
@@ -1828,7 +1828,7 @@ portion is VM block handle
 **Library:** spool.def
 
 ----------
-#### PrintQualityEnum
+### PrintQualityEnum
     PrintQualityenum    etype byte, 0, 1
         PQT_HIGH        enum PrintQualityenum       ; default to high
         PQT_MEDIUM      enum PrintQualityenum       ; default to medium
@@ -1837,7 +1837,7 @@ portion is VM block handle
 **Library:** spool.def
 
 ----------
-#### PrintStatusFlags
+### PrintStatusFlags
     PrintStatusFlags        record
         PSF_FAX_AVAILABLE       :1      ; set if a fax driver is available
                                 :3
@@ -1850,7 +1850,7 @@ portion is VM block handle
 **Library:** spool.def
 
 ----------
-#### PriorityList
+### PriorityList
     PriorityList        struct
         PL_message          word
         PL_point            PointDWFixed
@@ -1880,7 +1880,7 @@ list.
 **Library:** grobj.def
 
 ----------
-#### PriorityListElement
+### PriorityListElement
     PriorityListElement         struct
         PLE_od          optr
         PLE_priority    byte
@@ -1890,7 +1890,7 @@ list.
 **Library:** grobj.def
 
 ----------
-#### PriorityListInstructions
+### PriorityListInstructions
     PriorityListInstructions            record
         PLI_CHECK_SELECTION_HANDLE_BOUNDS               :1
         PLI_ONLY_PROCESS_SELECTED                       :1
@@ -1928,7 +1928,7 @@ objects must return EPN_SELECTION_LOCK_SET.
 **Library:** grobj.def
 
 ----------
-#### ProcessCallRoutineParams
+### ProcessCallRoutineParams
 ProcessCallRoutineParams        struct
 PCRP_address            fptr
 PCRP_dataAX             word
@@ -1942,7 +1942,7 @@ ProcessCallRoutineParams        ends
 **Library:** processC.def
 
 ----------
-#### ProtocolNumber
+### ProtocolNumber
     ProtocolNumber      struct
         PN_major            word
         PN_minor            word
@@ -1959,7 +1959,7 @@ different, the two items may or may not be compatible.
 **Library:** geode.def
 
 ----------
-#### PSCFeatures
+### PSCFeatures
     PSCFeatures     record
         PSCF_9              :1
         PSCF_10             :1
@@ -1978,7 +1978,7 @@ different, the two items may or may not be compatible.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### PSCToolboxFeatures
+### PSCToolboxFeatures
     PSCToolboxFeatures      record
         PSCTF_9         :1
         PSCTF_10        :1
@@ -1996,7 +1996,7 @@ different, the two items may or may not be compatible.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### PtrImageLevel
+### PtrImageLevel
     PtrImageLevel       etype word, 0
         PIL_SYSTEM          enum PtrImageLevel
         PIL_1               enum PtrImageLevel
@@ -2042,7 +2042,7 @@ Default pointer.
 **Library:** win.def
 
 ----------
-#### PtrImageValue
+### PtrImageValue
     PtrImageValue       etype word
         PIV_NONE                    enum PtrImageValue, 0
         PIV_VIDEO_DRIVER_DEFAULT    enum PtrImageValue
@@ -2066,7 +2066,7 @@ screens.
 **Library:** win.def
 
 ----------
-#### QuickSortParameters
+### QuickSortParameters
     QuickSortParameters             struct
         QSP_compareCallback     fptr    ; Compare two elements
         ;
@@ -2124,7 +2124,7 @@ and greater list parts. This is used internally by the quicksort algorithm.
 **Library:** chunkarr.def
 
 ----------
-#### QuitLevel
+### QuitLevel
     QuitLevel       etype word
         QL_BEFORE_UI            enum QuitLevel
         QL_UI                   enum QuitLevel
@@ -2155,7 +2155,7 @@ Why is it still around? You'll understand when you're older.
 **Library:** Objects/metaC.def
 
 ----------
-#### RandomGenInitFlags
+### RandomGenInitFlags
     RandomGenInitFlags      record
         RGIF_USE_SEED           :1
         RGIF_GENERATE_SEED      :1
@@ -2165,7 +2165,7 @@ Why is it still around? You'll understand when you're older.
 **Library:** math.def
 
 ----------
-#### RangeEnumFlags
+### RangeEnumFlags
     RangeEnumFlags      record
         REF_ALL_CELLS           :1  ; Set: callback for all cells.
         REF_NO_LOCK             :1  ; Set: callback will lock/unlock cells.
@@ -2189,7 +2189,7 @@ Why is it still around? You'll understand when you're older.
 **Library:** cell.def
 
 ----------
-#### RangeEnumParams
+### RangeEnumParams
     RangeEnumParams     struct
         REP_callback        fptr.far    ;routine to call
         REP_bounds          Rectangle   ;cells to enumerate
@@ -2232,7 +2232,7 @@ cells.
 **Library:** cell.def
 
 ----------
-#### RangeInsertParams
+### RangeInsertParams
     RangeInsertParams           struct
         RIP_bounds          Rectangle
         RIP_delta           Point
@@ -2253,7 +2253,7 @@ entry is set up automatically by the routine.
 **Library:** cell.def
 
 ----------
-#### RangeSortCellExistsFlags
+### RangeSortCellExistsFlags
     RangeSortCellExistsFlags            record
                                     :6      ; Unused bits
         RSCEF_SECOND_CELL_EXISTS    :1      ; Set: Second cell exists
@@ -2263,7 +2263,7 @@ entry is set up automatically by the routine.
 **Library:** cell.def
 
 ----------
-#### RangeSortError
+### RangeSortError
     RangeSortError      etype word, 0, 1
         RSE_NO_ERROR            enum RangeSortError
         RSE_UNABLE_TO_ALLOC     enum RangeSortError
@@ -2278,7 +2278,7 @@ needs to sort the data.
 **Library:** cell.def
 
 ----------
-#### RangeSortFlags
+### RangeSortFlags
     RangeSortFlags      record
         RSF_SORT_ROWS           :1  ; Set: Sort rows
         RSF_SORT_ASCENDING      :1  ; Set: Sort in ascending order
@@ -2293,7 +2293,7 @@ needs to sort the data.
 **Library:** cell.def
 
 ----------
-#### RangeSortParams
+### RangeSortParams
     RangeSortParams     struct
         RSP_range           Rectangle
         RSP_active          Point
@@ -2344,7 +2344,7 @@ upon.
 **Library:** cell.def
 
 ----------
-#### RecalcSizeArgs
+### RecalcSizeArgs
     RecalcSizeArgs      record
         RSA_CHOOSE_OWN_SIZE         :1
         RSA_SUGGESTED_SIZE          :15
@@ -2361,7 +2361,7 @@ Suggested size to use, if above bit is not set.
 **Library:** Objects/visC.def
 
 ----------
-#### Rectangle
+### Rectangle
     Rectangle           struct
         R_left      sword
         R_top       sword
@@ -2374,7 +2374,7 @@ This is the standard structure for a rectangle in GEOS.
 **Library:** graphics.def
 
 ----------
-#### RectDWFixed
+### RectDWFixed
     RectDWFixed     struct
         RDWF_left       DWFixed
         RDWF_top        DWFixed
@@ -2385,7 +2385,7 @@ This is the standard structure for a rectangle in GEOS.
 **Library:** bitmap.def
 
 ----------
-#### RectDWord
+### RectDWord
     RectDWord       struct
         RD_left         sdword
         RD_top          sdword
@@ -2398,7 +2398,7 @@ This is the standard structure for a rectangle in extended coordinates.
 **Library:** graphics.def
 
 ----------
-#### RectRegion
+### RectRegion
     RectRegion          struct
         RR_y1M1     word
         RR_eo1      word EOREGREC
@@ -2414,7 +2414,7 @@ This structure stores a rectangular region.
 **Library:** graphics.def
 
 ----------
-#### RectWWFixed
+### RectWWFixed
     RectWWFixed     struct
         RWWF_left       WWFixed
         RWWF_top        WWFixed
@@ -2425,7 +2425,7 @@ This structure stores a rectangular region.
 **Library:** grobj.def
 
 ----------
-#### RefElementHeader
+### RefElementHeader
     RefElementHeader        struct
         REH_refCount            WordAndAHalf
     RefElementHeader        ends
@@ -2435,7 +2435,7 @@ This structure defines a header for an element of a fixed size.
 **Library:** chunkarr.def
 
 ----------
-#### Region
+### Region
     Region  struct
         R_data      word
     Region  ends
@@ -2468,7 +2468,7 @@ those which are different
 **Library:** graphics.def
 
 ----------
-#### RegionFillRule
+### RegionFillRule
     RegionFillRule      etype byte
         RFR_ODD_EVEN    enum RegionFillRule     ; 0 = odd-even rule
         RFR_WINDING     enum RegionFillRule     ; 1 = winding rule
@@ -2476,7 +2476,7 @@ those which are different
 **Library:** graphics.def
 
 ----------
-#### ReleaseNumber
+### ReleaseNumber
     ReleaseNumber       struct
         RN_major            word
         RN_minor            word
@@ -2499,7 +2499,7 @@ need to be examined or changed.
 **Library:** geode.def
 
 ----------
-#### ReplaceAllFromOffsetFlags
+### ReplaceAllFromOffsetFlags
     ReplaceAllFromOffsetFlags           record
         RAFOF_CONTINUING_REPLACE    :1
         RAFOF_HAS_UNDO              :1
@@ -2518,7 +2518,7 @@ ReplaceAll are undoable.
 **Library:** Objects/vTextC.def
 
 ----------
-#### ReplaceAllFromOffsetStruct
+### ReplaceAllFromOffsetStruct
     ReplaceAllFromOffsetStruct          struct
         RAFOS_data              hptr.SearchReplaceStruct
         RAFOS_startOffset       dword
@@ -2542,7 +2542,7 @@ them.
 **Library:** Objects/vTextC.def
 
 ----------
-#### ReplaceAllInRangeStruct
+### ReplaceAllInRangeStruct
     ReplaceAllInRangeStruct         struct
         RAIRS_data          hptr.SearchReplaceStruct
         RAIRS_range         VisTextRange <>
@@ -2559,7 +2559,7 @@ SearchReplaceStruct.
 **Library:** Objects/vTextC.def
 
 ----------
-#### ReplaceItemMonikerFlags
+### ReplaceItemMonikerFlags
     ReplaceItemMonikerFlags         record
         RIMF_NOT_ENABLED        :1
                                 :15
@@ -2572,7 +2572,7 @@ disabled while visible.
 **Library:** Objects/gDListC.def
 
 ----------
-#### ReplaceItemMonikerFrame
+### ReplaceItemMonikerFrame
     ReplaceItemMonikerFrame         struct
         RIMF_source         dword
         RIMF_sourceType     VisMonikerSourceType
@@ -2615,7 +2615,7 @@ gstring.
 **Library:** Objects/gDListC.def
 
 ----------
-#### ReplaceVisMonikerFrame
+### ReplaceVisMonikerFrame
     ReplaceVisMonikerFrame          struct
         RVMF_source             dword
         RVMF_sourceType         VisMonikerSourceType
@@ -2660,7 +2660,7 @@ new moniker.
 **Library:** Objects/genC.def
 
 ----------
-#### ReplaceWithGraphicParams
+### ReplaceWithGraphicParams
     ReplaceWithGraphicParams            struct
         RWGP_range              VisTextRange    ;range to replace
         RWGP_pasteFrame         word            ;ptr to frame if quick paste.
@@ -2672,7 +2672,7 @@ new moniker.
 **Library:** Objects/vTextC.def
 
 ----------
-#### ReplaceWithHWRData
+### ReplaceWithHWRData
     ReplaceWithHWRData      struct
         RWHWRD_range            VisTextRange <>
         RWHWRD_context          HWRContext <>
@@ -2687,7 +2687,7 @@ data was added.
 **Library:** Objects/gPenICC.def
 
 ----------
-#### RequestedViewArea
+### RequestedViewArea
     RequestedViewArea       etype byte
         RVA_NO_AREA_CHOICE  enum RequestedViewArea  ;no choice made here
         RVA_X_SCROLLER_AREA enum RequestedViewArea  ;put with x scroller
@@ -2700,7 +2700,7 @@ data was added.
 **Library:** Objects/genC.def
 
 ----------
-#### RGBDelta
+### RGBDelta
     RGBDelta        struct
         RGBD_red        sbyte
         RGBD_green      sbyte
@@ -2710,7 +2710,7 @@ data was added.
 **Library:** color.def
 
 ----------
-#### RGBValue
+### RGBValue
     RGBValue        struct
         RGB_red         byte
         RGB_green       byte
@@ -2720,7 +2720,7 @@ data was added.
 **Library:** color.def
 
 ----------
-#### RGCFeatures
+### RGCFeatures
     RGCFeatures     record
         RGCF_GRID_SPACING       :1
         RGCF_SNAP_TO_GRID       :1
@@ -2730,7 +2730,7 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RowBlockList
+### RowBlockList
     RowBlockList        struct
         RBL_blocks          nptr N_ROW_BLOCKS dup (0)
     RowBlockList        ends
@@ -2738,7 +2738,7 @@ data was added.
 **Library:** cell.def
 
 ----------
-#### RSCCFeatures
+### RSCCFeatures
     RSCCFeatures        record
         RSCCF_SHOW_VERTICAL         :1
         RSCCF_SHOW_HORIZONTAL       :1
@@ -2748,14 +2748,14 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RSCCToolboxFeatures
+### RSCCToolboxFeatures
     RSCCToolboxFeatures         record
     RSCCToolboxFeatures         end
 
 **Library:** ruler.def
 
 ----------
-#### RTCFeatures
+### RTCFeatures
     RTCFeatures     record
         RTCF_DEFAULT        :1
         RTCF_SPREADSHEET    :1
@@ -2768,7 +2768,7 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RTCToolboxFeatures
+### RTCToolboxFeatures
     RTCToolboxFeatures      record
         RTCTF_DEFAULT           :1
         RTCTF_SPREADSHEET       :1
@@ -2781,7 +2781,7 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RulerGridNotificationBlock
+### RulerGridNotificationBlock
     RulerGridNotificationBlock              struct
         RGNB_gridSpacing                WWFixed
         RGNB_gridOptions                GridOptions
@@ -2790,7 +2790,7 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RulerGuideControlFeatures
+### RulerGuideControlFeatures
     RulerGuideControlFeatures           record
         RGCF_HV                 :1
         RGCF_LIST               :1
@@ -2801,7 +2801,7 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RulerShowControlAttributes
+### RulerShowControlAttributes
     RulerShowControlAttributes              record
         RSCA_SHOW_VERTICAL              :1
         RSCA_SHOW_HORIZONTAL            :1
@@ -2811,7 +2811,7 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RulerTypeNotificationBlock
+### RulerTypeNotificationBlock
     RulerTypeNotificationBlock          struct
         RTNB_type       VisRulerType
     RulerTypeNotificationBlock          ends
@@ -2819,7 +2819,7 @@ data was added.
 **Library:** ruler.def
 
 ----------
-#### RulerViewAttributes
+### RulerViewAttributes
     RulerViewAttributes         record
         RVA_HORIZONTAL      :1
                             :7

--- a/TechDocs/Markdown/Asmref/asmstrss.md
+++ b/TechDocs/Markdown/Asmref/asmstrss.md
@@ -1,7 +1,7 @@
 ## 3.6 Structures S-S
 
 ----------
-#### SampleFormat
+### SampleFormat
     SampleFormat        record
         SMID_format         DAC_SampleFormat:15
         SMID_refernce       DAC_ReferenceByte:1
@@ -10,7 +10,7 @@
 **Library:** sound.def
 
 ----------
-#### SampleFormatDescription
+### SampleFormatDescription
     SampleFormatDescription         struct
         SFD_manufact            ManufacturerID
         SFD_format              SampleFormat
@@ -21,7 +21,7 @@
 **Library:** sound.def
 
 ----------
-#### SamplesStruc
+### SamplesStruc
     SamplesStruc        struc
         SS_sample1Str       char FLOAT_TO_ASCII_HUGE_BUF_LEN dup (?)
         SS_sample2Str       char FLOAT_TO_ASCII_HUGE_BUF_LEN dup (?)
@@ -32,7 +32,7 @@
 **Library:** math.def
 
 ----------
-#### SansFace
+### SansFace
     SansFace        etype byte
         SF_A_OPEN           enum SansFace, 0
         SF_A_CLOSED         enum SansFace, 0x80
@@ -45,7 +45,7 @@ the bottom, and an extra stem on top).
 **Library:** fontID.def
 
 ----------
-#### ScaleChangedParams
+### ScaleChangedParams
     ScaleChangedParams          struct
         SCP_scaleFactor     PointWWFixed    ;new scale factor
         SCP_window          lptr Window     ;window of view
@@ -54,7 +54,7 @@ the bottom, and an extra stem on top).
 **Library:** Objects/gViewC.def
 
 ----------
-#### ScaleViewParams
+### ScaleViewParams
     ScaleViewParams     struct
         SVP_scaleFactor     PointWWFixed        ;new, absolute scale factor
         SVP_unused          byte
@@ -65,7 +65,7 @@ the bottom, and an extra stem on top).
 **Library:** Objects/gViewC.def
 
 ----------
-#### ScaleViewType
+### ScaleViewType
     ScaleViewType       etype byte
         SVT_AROUND_UPPER_LEFT           enum ScaleViewType
         SVT_AROUND_CENTER               enum ScaleViewType
@@ -83,7 +83,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** Objects/gViewC.def
 
 ----------
-#### ScannerToken
+### ScannerToken
     ScannerToken        struct
         ST_type     ScannerTokenType    ; The type of token
         ST_data     ScannerTokenData    ; The data associated with the token
@@ -92,7 +92,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScannerTokenCellData
+### ScannerTokenCellData
     ScannerTokenCellData            struct
         STCD_cellRef            CellReference <>
     ScannerTokenCellData            ends
@@ -100,7 +100,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScannerTokenData
+### ScannerTokenData
     ScannerTokenData    union
         STD_number          ScannerTokenNumberData
         STD_string          ScannerTokenStringData
@@ -112,7 +112,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScannerTokenIdentifierData
+### ScannerTokenIdentifierData
     ScannerTokenIdentifierData              struct
         STID_start      word    ; The offset to the start of the identifier
     ScannerTokenIdentifierData              ends
@@ -120,7 +120,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScannerTokenNumberData
+### ScannerTokenNumberData
     ScannerTokenNumberData          struct
         STND_value          FloatNum        ; 8 byte constant
     ScannerTokenNumberData          ends
@@ -128,7 +128,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScannerTokenOperatorData
+### ScannerTokenOperatorData
     ScannerTokenOperatorData                struct
         STOD_operatorID     OperatorType    ; Identifier for this operator
     ScannerTokenOperatorData                ends
@@ -136,7 +136,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScannerTokenStringData
+### ScannerTokenStringData
     ScannerTokenStringData      struct
         STSD_start      word        ; Offset to start of string
         STSD_length     word        ; Length of the string
@@ -145,7 +145,7 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScannerTokenType
+### ScannerTokenType
     ScannerTokenType        etype byte, 0, 1
         SCANNER_TOKEN_NUMBER            enum ScannerTokenType
         SCANNER_TOKEN_STRING            enum ScannerTokenType
@@ -165,14 +165,14 @@ Point specified in *SVP_point* is kept fixed as we scale.
 **Library:** parse.def
 
 ----------
-#### ScriptFace
+### ScriptFace
     ScriptFace      etype byte
         SF_CALLIGRAPHIC enum ScriptFace, 0      ; variable thickness stroke
         SF_CURSIVE      enum ScriptFace, 0x80   ; single thickness stroke
 
 **Library:** fontID.def
 ----------
-#### ScrollAction
+### ScrollAction
     ScrollAction        etype byte
         SA_NOTHING                  enum ScrollAction
         SA_TO_BEGINNING             enum ScrollAction
@@ -241,7 +241,7 @@ Any scrolling that's required as a result of the view size change
 **Library:** Objects/gViewC.def
 
 ----------
-#### ScrollFlags
+### ScrollFlags
     ScrollFlags     record
         SF_VERTICAL                 :1
         SF_ABSOLUTE                 :1
@@ -287,7 +287,7 @@ routines.
 **Library:** Objects/gViewC.def
 
 ----------
-#### SearchFromOffsetFlags
+### SearchFromOffsetFlags
 
 SearchFromOffsetFlags           record
 
@@ -301,7 +301,7 @@ Set (internally) if this search has wrapped around.
 **Library:** Objects/vTextC.def
 
 ----------
-#### SearchFromOffsetReturnStruct
+### SearchFromOffsetReturnStruct
     SearchFromOffsetReturnStruct                struct
         SFORS_object            optr (?)
         SFORS_offset            dword (?)
@@ -319,7 +319,7 @@ Set (internally) if this search has wrapped around.
 **Library:** Objects/vTextC.def
 
 ----------
-#### SearchFromOffsetStruct
+### SearchFromOffsetStruct
     SearchFromOffsetStruct          struct
         SFOS_data           hptr.SearchReplaceStruct
         SFOS_startObject    optr
@@ -351,7 +351,7 @@ start search. (This value can range from 0 to <text size>).
 **Library:** Objects/vTextC.def
 
 ----------
-#### SearchOptions
+### SearchOptions
     SearchOptions       record
                                                 :2
         SO_NO_WILDCARDS                         :1
@@ -389,7 +389,7 @@ replacing it).
 **Library:** Objects/vTextC.def
 
 ----------
-#### SearchReplaceEnableFlags
+### SearchReplaceEnableFlags
     SearchReplaceEnableFlags            record
         SREF_SEARCH     :1  ; Set if the object can handle searches
         SREF_REPLACE    :1  ; Set if the object can handle replaces
@@ -398,7 +398,7 @@ replacing it).
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### SearchReplaceFocusInfo
+### SearchReplaceFocusInfo
     SearchReplaceFocusInfo          etype byte
         SRFI_SEARCH_TEXT                enum SearchReplaceFocusInfo
     SRFI_REPLACE_TEXT               enum SearchReplaceFocusInfo
@@ -406,7 +406,7 @@ replacing it).
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### SearchReplaceStruct
+### SearchReplaceStruct
     SearchReplaceStruct     struct
         SRS_searchSize          word
         SRS_replaceSize         word
@@ -435,7 +435,7 @@ was not found.
 **Library:** Objects/vTextC.def
 
 ----------
-#### SelectionDataType
+### SelectionDataType
     SelectionDataType       etype word
         SDT_TEXT                enum SelectionDataType
         SDT_GRAPHICS            enum SelectionDataType
@@ -446,7 +446,7 @@ was not found.
 **Library:** Objects/gEditCC.def
 
 ----------
-#### SelectionType
+### SelectionType
     SelectionType       etype byte
         ST_DOING_CHAR_SELECTION             enum SelectionType
         ST_DOING_WORD_SELECTION             enum SelectionType
@@ -456,7 +456,7 @@ was not found.
 **Library:** Objects/vTextC.def
 
 ----------
-#### SemaphoreError
+### SemaphoreError
     SemaphoreError      etype word
         SE_NO_ERROR                 enum SemaphoreError
         SE_TIMEOUT                  enum SemaphoreError
@@ -465,7 +465,7 @@ was not found.
 **Library:** sem.def
 
 ----------
-#### SerifFace
+### SerifFace
     SerifFace       etype byte, 0
         SF_OLD          enum SerifFace, 0
         SF_TRANS        enum SerifFace, 0x40
@@ -494,7 +494,7 @@ are usually unbracketed
 **Library:** fontID.def
 
 ----------
-#### SetDateTimeParams
+### SetDateTimeParams
     SetDateTimeParams       record
         SDTP_SET_DATE           :1  ;TRUE: set date (must be bit 7)
         SDTP_SET_TIME           :1  ;TRUE: set time (must be bit 6)
@@ -504,7 +504,7 @@ are usually unbracketed
 **Library:** timedate.def
 
 ----------
-#### SetPalElement
+### SetPalElement
     SetPalElement        struct
         SPE_entry       byte            ; palette entry number
         SPE_color       RGBValue <>     ; color to set that entry
@@ -515,7 +515,7 @@ This structure is passed to GrSetPalette.
 **Library:** color.def
 
 ----------
-#### SetSizeArgs
+### SetSizeArgs
     SetSizeArgs     struct
         SSA_width       SpecWidth <>    ;Width of the composite
         SSA_height      SpecHeight <>   ;Height of each child
@@ -528,7 +528,7 @@ This structure is passed to GrSetPalette.
 **Library:** Objects/genC.def
 
 ----------
-#### ShadowAnchor
+### ShadowAnchor
     ShadowAnchor        etype byte
         SA_TOP_LEFT             enum ShadowAnchor
         SA_TOP_RIGHT            enum ShadowAnchor
@@ -538,7 +538,7 @@ This structure is passed to GrSetPalette.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### ShiftState
+### ShiftState
     ShiftState      record
         SS_LALT             :1  ;Set if left ALT modifier
         SS_RALT             :1  ;Set if right ALT modifier
@@ -553,7 +553,7 @@ This structure is passed to GrSetPalette.
 **Library:** input.def
 
 ----------
-#### SortableArrayElement
+### SortableArrayElement
     SortableArrayElement            struct
         SAE_OD      optr
         SAE_key     DWFixed
@@ -562,7 +562,7 @@ This structure is passed to GrSetPalette.
 **Library:** grobj.def
 
 ----------
-#### SortableArrayHeader
+### SortableArrayHeader
     SortableArrayHeader         struct
         SAH_CAH                     ChunkArrayHeader
         SAH_originalArray           optr
@@ -571,7 +571,7 @@ This structure is passed to GrSetPalette.
 **Library:** grobj.def
 
 ----------
-#### SortedNameArrayFindFlags
+### SortedNameArrayFindFlags
     SortedNameArrayFindFlags            record
         SNAFF_IGNORE_CASE           :1
     SortedNameArrayFindFlags            end
@@ -579,7 +579,7 @@ This structure is passed to GrSetPalette.
 **Library:** config.def
 
 ----------
-#### SoundBasicStatus
+### SoundBasicStatus
     SoundBasicStatus        struct
         SBS_blockHandle     word 0              ; handle of block
         SBS_ID              word SOUND_ID       ; Says this struct is a sound
@@ -595,7 +595,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundControl
+### SoundControl
     SoundControl        struct
         SC_status           SoundBasicStatus
         SC_format           SoundFormatStatus
@@ -606,7 +606,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:**        sound.def
 
 ----------
-#### SoundDACStatus
+### SoundDACStatus
     SoundDACStatus      struct
         SDACS_rate          word 0              ; sample rate of sound
         SDACS_format        DACSampleFormat 0   ; sample format of sound
@@ -616,7 +616,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundErrors
+### SoundErrors
     SoundErrors                 etype   word, 0, 2
         SOUND_ERROR_NO_ERROR                        enum    SoundErrors
         SOUND_ERROR_EXCLUSIVE_ACCESS_GRANTED        enum    SoundErrors
@@ -631,7 +631,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundFMStatus
+### SoundFMStatus
     SoundFMStatus       struct
         SFMS_timerHandle    hptr 0      ; current timer handle
         SFMS_timerID        word 0      ; current timer ID
@@ -643,7 +643,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundFormatStatus
+### SoundFormatStatus
     SoundFormatStatus       union
         SFS_fm      SoundFMStatus
         SFS_dac     SoundDACStatus
@@ -652,7 +652,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundFunction
+### SoundFunction
     SoundFunction       etype word, DriverFunction, 2
         DR_SOUND_ENTER_LIBRARY_ROUTINE  enum SoundFunction
         DR_SOUND_EXIT_LIBRARY_ROUTINE   enum SoundFunction
@@ -679,7 +679,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundPositionStatus
+### SoundPositionStatus
     SoundPositionStatus         union
         SSS_simple      SoundSimpleStatus
         SSS_stream      SoundStreamStatus
@@ -688,7 +688,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundPriority
+### SoundPriority
     SoundPriority       etype word, 10, 10
         SP_SYSTEM_LEVEL     enum SoundPriority
         SP_ALARM            enum SoundPriority
@@ -702,7 +702,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundSimpleStatus
+### SoundSimpleStatus
     SoundSimpleStatus           struct
         SSS_songBuffer      fptr 0          ; fptr to song buffer
         SSS_songPointer     nptr 0          ; current place in song
@@ -711,7 +711,7 @@ all sounds. This structure is an entry within the basic Sound structure.
 **Library:** sound.def
 
 ----------
-#### SoundStreamDeltaTimeType
+### SoundStreamDeltaTimeType
     SoundStreamDeltaTimeType        etype word, SoundStreamEvent, 2
         SSDTT_MSEC          enum SoundStreamDeltaTimeType
         SSDTT_TICKS         enum SoundStreamDeltaTimeType
@@ -725,7 +725,7 @@ seconds, in ticks (giving a maximum delay of ~18 minutes, or in 1/64th notes
 **Library:** sound.def
 
 ----------
-#### SoundStreamEvent
+### SoundStreamEvent
     SoundStreamEvent        etype word, 0, 2
         SSE_VOICE_ON            enum SoundStreamEvent
         SSE_VOICE_OFF           enum SoundStreamEvent
@@ -737,7 +737,7 @@ A sound stream is just made up of a bunch of events.
 **Library:** sound.def
 
 ----------
-#### SoundStreamSize
+### SoundStreamSize
     SoundStreamSize     etype   word
         SSS_ONE_SHOT        enum    SoundStreamSize, 128; bytes
         SSS_SMALL           enum    SoundStreamSize, 256; bytes
@@ -747,7 +747,7 @@ A sound stream is just made up of a bunch of events.
 **Library:** sound.def
 
 ----------
-#### SoundStreamState
+### SoundStreamState
     SoundStreamState    record
         SSS_active          :1  ; does a reader exist?
         SSS_destroying      :1  ; is it being destroyed?
@@ -758,7 +758,7 @@ A sound stream is just made up of a bunch of events.
 **Library:** sound.def
 
 ----------
-#### SoundStreamStatus
+### SoundStreamStatus
     SoundStreamStatus       struct
         SSS_streamToken         word 0              ; stream handle
         SSS_streamSegment       word 0              ; stream segment
@@ -774,7 +774,7 @@ A sound stream is just made up of a bunch of events.
 **Library:** sound.def
 
 ----------
-#### SoundType
+### SoundType
     SoundType       etype word, 0, 2
         ST_SIMPLE_FM            enum SoundType
         ST_STREAM_FM            enum SoundType
@@ -791,7 +791,7 @@ analog.
 **Library:** sound.def
 
 ----------
-#### SoundVoiceStatus
+### SoundVoiceStatus
     SoundVoiceStatus        struct
         SVS_instrument          fptr.InstrumentEnvelope 0
         SVS_physicalVoice       word 0
@@ -811,7 +811,7 @@ The **SoundVoiceStatus** structure stores these two pieces of information.
 **Library:** sound.def
 
 ----------
-#### SpecAttrs
+### SpecAttrs
     SpecAttrs       record
         SA_ATTACHED                     :1
         SA_REALIZABLE                   :1
@@ -891,7 +891,7 @@ send a recursive MSG_SPEC_BUILD_BRANCH down the tree.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecBuildFlags
+### SpecBuildFlags
     SpecBuildFlags      record
         SBF_IN_UPDATE_WIN_GROUP                         :1
         SBF_WIN_GROUP                                   :1
@@ -983,7 +983,7 @@ VisUpdateMode to use.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecChildCount
+### SpecChildCount
     SpecChildCount      record
         SCC_DATA        :16
     SpecChildCount      end
@@ -991,7 +991,7 @@ VisUpdateMode to use.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecHeight
+### SpecHeight
     SpecHeight      record
         SH_TYPE         SpecSizeType:6
         SH_DATA         :10
@@ -1000,7 +1000,7 @@ VisUpdateMode to use.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecialChar
+### SpecialChar
     SpecialChar     etype word, 0, 2
         SC_WILDCARD             enum    SpecialChar
         SC_WILDCHAR             enum    SpecialChar
@@ -1012,7 +1012,7 @@ VisUpdateMode to use.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### SpecialFunction
+### SpecialFunction
     SpecialFunction     etype word, 0, 2
         SF_FILENAME         enum SpecialFunction
         SF_PAGE             enum SpecialFunction
@@ -1021,7 +1021,7 @@ VisUpdateMode to use.
 **Library:** parse.def
 
 ----------
-#### SpecQueryVisParentType
+### SpecQueryVisParentType
     SpecQueryVisParentType              etype word
         SQT_VIS_PARENT_FOR_FIELD        enum SpecQueryVisParentType
         SQT_VIS_PARENT_FOR_APPLICATION  enum SpecQueryVisParentType
@@ -1034,7 +1034,7 @@ VisUpdateMode to use.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecSizeArgs
+### SpecSizeArgs
     SpecSizeArgs        struct
         SSA_minWidth            sword       ; HINT_MINIMUM_SIZE
         SSA_minHeight           sword
@@ -1059,7 +1059,7 @@ suggested size arguments in various ways.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecSizeSpec
+### SpecSizeSpec
     SpecSizeSpec            record
         SSS_TYPE        SpecSizeType:6
         SSS_DATA        :10
@@ -1068,7 +1068,7 @@ suggested size arguments in various ways.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecSizeType
+### SpecSizeType
     SpecSizeType        etype byte
         SST_PIXELS                      enum SpecSizeType
         SST_COUNT                       enum SpecSizeType
@@ -1145,13 +1145,13 @@ lines of text are normally only handled by the text object.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecUINavigationID
+### SpecUINavigationID
     SpecUINavigationID      etype word, NAVIGATION_ID_UI_START
 
 **Library:** Objects/genC.def
 
 ----------
-#### SpecWidth
+### SpecWidth
     SpecWidth           record
         SW_TYPE     SpecSizeType:6
         SW_DATA     :10
@@ -1160,7 +1160,7 @@ lines of text are normally only handled by the text object.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecWinSizePair
+### SpecWinSizePair
     SpecWinSizePair     struct
         SWSP_x  SpecWinSizeSpec
         SWSP_y  SpecWinSizeSpec
@@ -1173,7 +1173,7 @@ object.
 **Library:** Objects/visC.def
 
 ----------
-#### SpecWinSizeSpec
+### SpecWinSizeSpec
     SpecWinSizeSpec     record
         SWSS_RATIO      :1      ;TRUE if value is ratio. If FALSE,
                                 ;bits 14-0 contain signed pixel value.
@@ -1186,7 +1186,7 @@ object.
 **Library:** Objects/visC.def
 
 ----------
-#### SpellCheckFromOffsetFlags
+### SpellCheckFromOffsetFlags
     SpellCheckFromOffsetFlags               record
         SCFOF_CHECK_NUM_CHARS           :1
     SpellCheckFromOffsetFlags               end
@@ -1198,7 +1198,7 @@ number of characters.
 **Library:** Objects/vTextC.def
 
 ----------
-#### SpellCheckFromOffsetStruct
+### SpellCheckFromOffsetStruct
     SpellCheckFromOffsetStruct              struct
         SCFOS_ICBuff                hptr
         SCFOS_flags                 SpellCheckFromOffsetFlags
@@ -1225,7 +1225,7 @@ SPELL_CHECK_COMPLETED) should be sent to.
 **Library:** Objects/vTextC.def
 
 ----------
-#### SpoolFileName
+### SpoolFileName
     SpoolFileName       struct
         SFN_base    char "spool"
         SFN_num     char "000"
@@ -1237,7 +1237,7 @@ This structure stores the default names to attach to spool files.
 **Library:** spool.def
 
 ----------
-#### SpoolInfoType
+### SpoolInfoType
     SpoolInfoType       etype word, 0, 2
         SIT_JOB_INFO                enum SpoolInfoType
         SIT_QUEUE_INFO              enum SpoolInfoType
@@ -1245,7 +1245,7 @@ This structure stores the default names to attach to spool files.
 **Library:** spool.def
 
 ----------
-#### SpoolOpStatus
+### SpoolOpStatus
     SpoolOpStatus       etype word, 0, 1
         SPOOL_OPERATION_SUCCESSFUL          enum SpoolOpStatus
         SPOOL_JOB_NOT_FOUND                 enum SpoolOpStatus
@@ -1258,7 +1258,7 @@ This structure stores the default names to attach to spool files.
 **Library:** spool.def
 
 ----------
-#### SpoolTimeStruct
+### SpoolTimeStruct
     SpoolTimeStruct     struct
         STS_second      byte        ; second of the minute (0-59)
         STS_minute      byte        ; minute of the hour (0-59)
@@ -1270,7 +1270,7 @@ This structure holds the time stamp for a print spool job.
 **Library:** spool.def
 
 ----------
-#### SRCFeatures
+### SRCFeatures
     SRCFeatures     record
         SRCF_CLOSE                      :1
         SRCF_FIND_NEXT                  :1
@@ -1287,7 +1287,7 @@ This structure holds the time stamp for a print spool job.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### SRCToolboxFeatures
+### SRCToolboxFeatures
     SRCToolboxFeatures      record
         SRCTF_SEARCH_REPLACE        :1
     SRCToolboxFeatures      end
@@ -1295,7 +1295,7 @@ This structure holds the time stamp for a print spool job.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### StandardArrowheadType
+### StandardArrowheadType
     StandardArrowheadType           record
         SAT_LENGTH                          :6
         SAT_FILLED                          :1
@@ -1306,7 +1306,7 @@ This structure holds the time stamp for a print spool job.
 **Library:** grobj.def
 
 ----------
-#### StandardDialogOptrParams
+### StandardDialogOptrParams
     StandardDialogOptrParams                struct
         SDOP_customFlags            CustomDialogBoxFlags
         SDOP_customString           optr
@@ -1323,7 +1323,7 @@ routine. These entries must be in the same order as
 **Library:** uDialog.def
 
 ----------
-#### StandardDialogParams
+### StandardDialogParams
     StandardDialogParams            struct
         SDP_customFlags         CustomDialogBoxFlags
         SDP_customString        fptr
@@ -1339,7 +1339,7 @@ MSG_GEN_APPLICATION_DO_STANDARD_DIALOG.
 **Library:** uDialog.def
 
 ----------
-#### StandardDialogResponseTriggerEntry
+### StandardDialogResponseTriggerEntry
     StandardDialogResponseTriggerEntry  struct
         SDRTE_moniker               optr
         SDRTE_responseValue         word
@@ -1359,7 +1359,7 @@ value.
 **Library:** uDialog.def
 
 ----------
-#### StandardDialogResponseTriggerTable
+### StandardDialogResponseTriggerTable
     StandardDialogResponseTriggerTable  struct
         SDRTT_numTriggers       word
         SDRTT_triggers          label StandardDialogResponseTriggerEntry
@@ -1372,7 +1372,7 @@ of type GIT_MULTIPLE_RESPONSE initiated through
 **Library:** uDialog.def
 
 ----------
-#### StandardLanguage
+### StandardLanguage
     StandardLanguage        etype byte, 0, 1
         SL_UNIVERSAL            enum StandardLanguage,0 ; Universal Language code
 
@@ -1419,7 +1419,7 @@ of type GIT_MULTIPLE_RESPONSE initiated through
 **Library:** sllang.def
 
 ----------
-#### StandardPath
+### StandardPath
     StandardPath        etype word, 1, 2
         SP_NOT_STANDARD_PATH        enum StandardPath,0
         SP_TOP                      enum StandardPath,1
@@ -1546,7 +1546,7 @@ his is where backup files go. Default is PRIVDATA/BACKUP.
 **Library:** file.def
 
 ----------
-#### StandardPathByte
+### StandardPathByte
     StandardPathByte        record
         SPB_SP      StandardPath:8
     StandardPathByte        end
@@ -1554,7 +1554,7 @@ his is where backup files go. Default is PRIVDATA/BACKUP.
 **Library:** file.def
 
 ----------
-#### StandardSoundType
+### StandardSoundType
     StandardSoundType       etype word
         SST_ERROR               enum StandardSoundType
         SST_WARNING             enum StandardSoundType
@@ -1607,7 +1607,7 @@ PRIORITY = SYSTEM_IMMEDIATE.
 **Library:** ui.def
 
 ----------
-#### StartUndoChainStruct
+### StartUndoChainStruct
     StartUndoChainStruct            struct
         SUCS_owner          optr
         SUCS_title          optr
@@ -1622,7 +1622,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** Objects/gProcC.def
 
 ----------
-#### SubscriptPosition
+### SubscriptPosition
     SubscriptPosition       etype byte
         SBP_CHEMICAL                enum SubscriptPosition, 30
         SBP_DENOMINATOR             enum SubscriptPosition, 0
@@ -1631,7 +1631,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** font.def
 
 ----------
-#### SubscriptSize
+### SubscriptSize
     SubscriptSize       etype byte
         SBS_CHEMICAL                enum SubscriptSize, 65
         SBS_DENOMINATOR             enum SubscriptSize, 60
@@ -1640,7 +1640,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** font.def
 
 ----------
-#### SuperscriptPosition
+### SuperscriptPosition
     SuperscriptPosition         etype byte
         SPP_DISPLAY         enum SuperscriptPosition, 50
         SPP_FOOTNOTE        enum SuperscriptPosition, 40
@@ -1651,7 +1651,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** font.def
 
 ----------
-#### SuperscriptSize
+### SuperscriptSize
     SuperscriptSize     etype byte
         SPS_DISPLAY         enum SuperscriptSize, 55
         SPS_FOOTNOTE        enum SuperscriptSize, 65
@@ -1662,7 +1662,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** font.def
 
 ----------
-#### SysConfigFlags
+### SysConfigFlags
     SysConfigFlags      record
         SCF_UNDER_SWAT  :1, ; Non-zero if kernel started by Swat stub
         SCF_2ND_IC      :1, ; Non-zero if second 8259 present
@@ -1677,7 +1677,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** system.def
 
 ----------
-#### SysDrawMask
+### SysDrawMask
     SysDrawMask     record
         SDM_INVERSE     :1                  ; bit 7: 0 for mask as is
                                             ; 1 for inverse of mask
@@ -1688,7 +1688,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** graphics.def
 
 ----------
-#### SysGetInfoType
+### SysGetInfoType
     SysGetInfoType      etype word, 0, 2
         SGIT_TOTAL_HANDLES          enum SysGetInfoType
         SGIT_HEAP_SIZE              enum SysGetInfoType
@@ -1706,7 +1706,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** sysstats.def
 
 ----------
-#### SysInitialTextMode
+### SysInitialTextMode
     SysInitialTextMode      etype   byte, 0
         SITM_UNKNOWN                enum SysInitialTextMode, 0
         SITM_TEXT_80_25_16_COLOR    enum SysInitialTextMode, 3
@@ -1715,7 +1715,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** system.def
 
 ----------
-#### SysMachineType
+### SysMachineType
     SysMachineType      etype byte, 0
         SMT_UNKNOWN         enum SysMachineType
         SMT_PC              enum SysMachineType
@@ -1733,7 +1733,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** system.def
 
 ----------
-#### SysNotifyFlags
+### SysNotifyFlags
     SysNotifyFlags          record
         SNF_RETRY       :1, ; Retry the operation.
         SNF_EXIT        :1, ; Shutdown the system.
@@ -1753,7 +1753,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** system.def
 
 ----------
-#### SysProcessorType
+### SysProcessorType
     SysProcessorType        etype byte, 0
         SPT_8088            enum SysProcessorType
         SPT_8086            enum SysProcessorType, SPT_8088
@@ -1765,7 +1765,7 @@ MSG_GEN_PROCESS_UNDO_START_CHAIN.
 **Library:** system.def
 
 ----------
-#### SysShutdownType
+### SysShutdownType
     SysShutdownType     etype word
         SST_CLEAN           enum SysShutdownType
         SST_CLEAN_FORCED    enum SysShutdownType
@@ -1872,7 +1872,7 @@ cx - 0 to deny the shutdown.
 **Library:** system.def
 
 ----------
-#### SysSimpleGraphicsMode
+### SysSimpleGraphicsMode
     SysSimpleGraphicsMode   etype   byte, 0
         SSGM_NONE               enum    SysSimpleGraphicsMode, 0
         SSGM_VGA                enum    SysSimpleGraphicsMode, 1
@@ -1886,7 +1886,7 @@ cx - 0 to deny the shutdown.
 **Library:** system.def
 
 ----------
-#### SysStats
+### SysStats
     SysStats        struct
         SS_idleCount            dword
         SS_swapOuts             SysSwapInfo
@@ -1917,7 +1917,7 @@ second.
 **Library:** sysstats.def
 
 ----------
-#### SysSwapInfo
+### SysSwapInfo
     SysSwapInfo     struct
         SSI_paragraphs      word
         SSI_blocks          word
@@ -1933,7 +1933,7 @@ information is used in the **SysStats** structure.
 **Library:** sysstats.def
 
 ----------
-#### SystemAttrs
+### SystemAttrs
     SystemAttrs     record
         SA_NOT                  :1  ;Any following set bits must be OFF for hints
                                     ;to be included, rather than on.
@@ -1957,13 +1957,13 @@ information is used in the **SysStats** structure.
 **Library:** genC.def
 
 ----------
-#### SystemBitmap
+### SystemBitmap
     SystemBitmap        etype byte
 
 **Library:** graphics.def
 
 ----------
-#### SystemDrawMask
+### SystemDrawMask
     SystemDrawMask       etype byte
         SDM_TILE        enum SystemDrawMask     ; tile pattern
         SDM_SHADED_BAR  enum SystemDrawMask     ; shaded bar
@@ -1991,7 +1991,7 @@ information is used in the **SysStats** structure.
 **Library:** graphics.def
 
 ----------
-#### SystemHatch
+### SystemHatch
     SystemHatch     etype byte
     SH_VERTICAL         enum SystemHatch    ; vertical lines
     SH_HORIZONTAL       enum SystemHatch    ; horizontal lines
@@ -2003,7 +2003,7 @@ information is used in the **SysStats** structure.
 **Library:** graphics.def
 
 ----------
-#### SystemVMID
+### SystemVMID
     SystemVMID      etype word, 0xff00
         SVMID_RANGE_DBASE   equ 0xff00          ;Reserved for DB code
 

--- a/TechDocs/Markdown/Asmref/asmstrtu.md
+++ b/TechDocs/Markdown/Asmref/asmstrtu.md
@@ -1,7 +1,7 @@
 ## 3.7 Structures T-U
 
 ----------
-#### Tab
+### Tab
     Tab     struct
         T_position      word            ; Position of tab (pixels * 8)
         T_attr          TabAttributes   ; Tab attributes.
@@ -16,7 +16,7 @@
 **Library:** text.def
 
 ----------
-#### TabAttributes
+### TabAttributes
     TabAttributes           record
                         :3
         TA_LEADER       TabLeader:3
@@ -26,7 +26,7 @@
 **Library:** text.def
 
 ----------
-#### TabLeader
+### TabLeader
     TabLeader           etype byte
         TL_NONE     enum TabLeader
         TL_DOT      enum TabLeader
@@ -36,7 +36,7 @@
 **Library:** text.def
 
 ----------
-#### TabReference
+### TabReference
     TabReference        record
         TR_TYPE             TabReferenceType:1  ; Type of reference.
         TR_REF_NUMBER       :7                  ; Reference number
@@ -45,7 +45,7 @@
 **Library:** text.def
 
 ----------
-#### TabReferenceType
+### TabReferenceType
     TabReferenceType        etype byte
         TRT_RULER   enum TabReferenceType   ; Reference is into the ruler.
         TRT_OTHER   enum TabReferenceType
@@ -53,7 +53,7 @@
 **Library:** text.def
 
 ----------
-#### TabType
+### TabType
     TabType etype byte
         TT_LEFT             enum TabType
         TT_CENTER           enum TabType
@@ -63,7 +63,7 @@
 **Library:** text.def
 
 ----------
-#### TargetLevel
+### TargetLevel
     TargetLevel     etype word
         TL_TARGET                   enum TargetLevel, 0
         TL_CONTENT                  enum TargetLevel
@@ -115,7 +115,7 @@ View within display.
 **Library:** Objects/genC.def
 
 ----------
-#### TargetReference
+### TargetReference
     TargetReference         struct
         TR_object       optr    ; OD of node/leaf in target hierarchy
         TR_class        fptr    ; class of above object
@@ -124,7 +124,7 @@ View within display.
 **Library:** Objects/gViewC.def
 
 ----------
-#### TCCFeatures
+### TCCFeatures
     TCCFeatures     record
         TCCF_CHARACTER      :1
         TCCF_WORD           :1
@@ -136,14 +136,14 @@ View within display.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TCCToolboxFeatures
+### TCCToolboxFeatures
     TCCToolboxFeatures      record
     TCCToolboxFeatures      end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TCFeatures
+### TCFeatures
     TCFeatures      record
         TCF_LIST            :1
         TCF_POSITION        :1
@@ -158,14 +158,14 @@ View within display.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TCToolboxFeatures
+### TCToolboxFeatures
     TCToolboxFeatures       record
     TCToolboxFeatures       end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TempGenControlInstance
+### TempGenControlInstance
     TempGenControlInstance          struct
         TGCI_interactibleFlags          GenControlInteractibleFlags
         TGCI_childBlock                 hptr
@@ -201,7 +201,7 @@ and avoid a redundant update.
 **Library:** Objects/gCtrlC.def
 
 ----------
-#### TempGenToolControlInstance
+### TempGenToolControlInstance
     TempGenToolControlInstance              struct
         TGTCI_curController         optr
         TGTCI_features              word
@@ -232,7 +232,7 @@ bring it to the attention of the user.
 **Library:** Objects/gToolCC.def
 
 ----------
-#### TempImportExportData
+### TempImportExportData
     TempImportExportData            struct
         TIED_formatUI           optr    ; OD of duplicated format UI
         TIED_formatLibrary      hptr    ; handle of library for above
@@ -241,7 +241,7 @@ bring it to the attention of the user.
 **Library:** impex.def
 
 ----------
-#### TempMetaGCNData
+### TempMetaGCNData
     TempMetaGCNData     struct
         TMGCND_listOfLists      lptr.GCNListOfListsHeader
         TMGCND_flags            TempMetaGCNFlags
@@ -252,7 +252,7 @@ bring it to the attention of the user.
 **Library:** Objects/metaC.def
 
 ----------
-#### TempMetaGCNFlags
+### TempMetaGCNFlags
     TempMetaGCNFlags        record
         TMGCNF_RELOCATED        :1      ; set if relocated
                                 :7
@@ -261,7 +261,7 @@ bring it to the attention of the user.
 **Library:** Objects/metaC.def
 
 ----------
-#### TempPrintCtrlInstance
+### TempPrintCtrlInstance
     TempPrintCtrlInstance           struct
         TPCI_currentSummons         optr    ; currently active summons
         TPCI_progressBox            optr    ; OD of progress dialog box
@@ -279,7 +279,7 @@ bring it to the attention of the user.
 **Library:** spool.def
 
 ----------
-#### TestRectReturnType
+### TestRectReturnType
     TestRectReturnType          etype byte
         TRRT_OUT            enum TestRectReturnType
         TRRT_PARTIAL        enum TestRectReturnType
@@ -288,7 +288,7 @@ bring it to the attention of the user.
 **Library:** graphics.def
 
 ----------
-#### TextArrayType
+### TextArrayType
     TextArrayType       etype byte
         TAT_CHAR_ATTRS          enum TextArrayType
         TAT_PARA_ATTRS          enum TextArrayType
@@ -298,7 +298,7 @@ bring it to the attention of the user.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextAttr
+### TextAttr
     TextAttr        struct
         TA_color        ColorQuad           ; RGB values or index
         TA_mask         SystemDrawMask      ; draw mask
@@ -321,7 +321,7 @@ This structure is used with **GrSetTextAttr** and **GrDrawTextField**.
 **Library:** graphics.def
 
 ----------
-#### TextClipboardOption
+### TextClipboardOption
     TextClipboardOption         etype word
         TCO_COPY                        enum TextClipboardOption
         TCO_RETURN_TRANSFER_FORMAT      enum TextClipboardOption
@@ -331,7 +331,7 @@ This structure is used with **GrSetTextAttr** and **GrDrawTextField**.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextColors
+### TextColors
     TextColors      struc
         TC_unselectedColor      byte
         TC_selectedColor        byte
@@ -340,7 +340,7 @@ This structure is used with **GrSetTextAttr** and **GrDrawTextField**.
 **Library:** genC.def
 
 ----------
-#### TextElementArrayHeader
+### TextElementArrayHeader
     TextElementArrayHeader      struct
         TEAH_meta           ElementArrayHeader
         TEAH_arrayType      TextArrayType
@@ -350,7 +350,7 @@ This structure is used with **GrSetTextAttr** and **GrDrawTextField**.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextFocusFlags
+### TextFocusFlags
     TextFocusFlags  record      ;Record passed in BP
         TFF_EDITABLE_TEXT_OBJECT_HAS_FOCUS      :1
                                 ; Set if an editable text object has the focus
@@ -362,7 +362,7 @@ This structure is used with **GrSetTextAttr** and **GrDrawTextField**.
 **Library:** vTextC.def
 
 ----------
-#### TextGuardianFlags
+### TextGuardianFlags
     TextGuardianFlags       record
         TGF_ENFORCE_DESIRED_MIN_HEIGHT                          :1
         TGF_ENFORCE_DESIRED_MAX_HEIGHT                          :1
@@ -399,7 +399,7 @@ clicks and releases in the same spot to create.
 **Library:** grobj.def
 
 ----------
-#### TextLargeRunArrayHeader
+### TextLargeRunArrayHeader
     TextLargeRunArrayHeader         struct
         TLRAH_meta              HugeArrayDirectory
         TLRAH_elementVMBlock    word        ; Element block (or null)
@@ -410,7 +410,7 @@ This structure stores a generic array of runs in the large text format.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextMetricStyles
+### TextMetricStyles
     TextMetricStyles        struct
         TMS_styleCallBack       fptr.far        ;style callback routine
         ;
@@ -448,7 +448,7 @@ This structure stores a generic array of runs in the large text format.
 **Library:** text.def
 
 ----------
-#### TextMode
+### TextMode
     TextMode        record
         TM_DRAW_CONTROL_CHARS       :1  ; Does the following mapping when drawing
                                         ; text:
@@ -469,7 +469,7 @@ This structure stores a generic array of runs in the large text format.
 **Library:** graphics.def
 
 ----------
-#### TextReference
+### TextReference
     TextReference       struct
         TR_type     TextReferenceType
         TR_ref      TextReferenceUnion
@@ -478,7 +478,7 @@ This structure stores a generic array of runs in the large text format.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferenceBlock
+### TextReferenceBlock
     TextReferenceBlock          struct
         TRB_handle          hptr.char
     TextReferenceBlock          ends
@@ -495,7 +495,7 @@ passed block or the allocated block will be resized to accommodate the text.
 **Library:** Object/vTextC.def
 
 ----------
-#### TextReferenceBlockChunk
+### TextReferenceBlockChunk
     TextReferenceBlockChunk         struct
         TRBC_ref        optr.char
     TextReferenceBlockChunk         ends
@@ -516,7 +516,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferenceDBItem
+### TextReferenceDBItem
     TextReferenceDBItem         struct
         TRDBI_file      hptr
         TRDBI_item      word
@@ -546,7 +546,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferenceHugeArray
+### TextReferenceHugeArray
     TextReferenceHugeArray          struct
         TRHA_file           hptr
         TRHA_array          word
@@ -568,7 +568,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferencePointer
+### TextReferencePointer
     TextReferencePointer            struct
         TRP_pointer         fptr.char
     TextReferencePointer            ends
@@ -589,7 +589,7 @@ caller allocates the block it can also handle errors in the allocation.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferenceSegmentChunk
+### TextReferenceSegmentChunk
     TextReferenceSegmentChunk               struct
         TRSC_chunk              word
         TRSC_segment            word
@@ -611,7 +611,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferenceType
+### TextReferenceType
     TextReferenceType       etype word, 0, 2
         TRT_POINTER             enum    TextReferenceType
         TRT_SEGMENT_CHUNK       enum    TextReferenceType
@@ -624,7 +624,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferenceUnion
+### TextReferenceUnion
     TextReferenceUnion          union
         TRU_pointer         TextReferencePointer
         TRU_segChunk        TextReferenceSegmentChunk
@@ -638,7 +638,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextReferenceVMBlock
+### TextReferenceVMBlock
     TextReferenceVMBlock            struct
         TRVMB_file          hptr
         TRVMB_block         word
@@ -659,7 +659,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextRulerAction
+### TextRulerAction
     TextRulerAction     etype byte
         TRA_NULL                enum TextRulerAction
         TRA_MOVE_TAB            enum TextRulerAction
@@ -669,7 +669,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TextRulerControlAttributes
+### TextRulerControlAttributes
     TextRulerControlAttributes      record
         TRCA_ROUND              :1
         TRCA_IGNORE_ORIGIN      :1
@@ -679,7 +679,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TextRulerFlags
+### TextRulerFlags
     TextRulerFlags      record
                                         :3
         TRF_ALWAYS_MOVE_BOTH_MARGINS    :1
@@ -692,7 +692,7 @@ block will be resized to accommodate the text.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TextRunArrayElement
+### TextRunArrayElement
     TextRunArrayElement         struct
         TRAE_position   WordAndAHalf <>     ; Position for start of run
         TRAE_token      word                ; Token for run
@@ -703,7 +703,7 @@ This structure stores an element in an array of text runs.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextRunArrayHeader
+### TextRunArrayHeader
     TextRunArrayHeader      struct
         TRAH_meta               ChunkArrayHeader
         TRAH_elementVMBlock     word        ; Element block
@@ -716,7 +716,7 @@ objects).
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextSearchInHugeArrayFrame
+### TextSearchInHugeArrayFrame
     TextSearchInHugeArrayFrame              struct
         TSIHAF_str1Size             dword (?)
         TSIHAF_curOffset            dword (?)
@@ -744,7 +744,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextStyle
+### TextStyle
     TextStyle       record
                             :1  ; Do not use this bit.
         TS_OUTLINE          :1
@@ -759,7 +759,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** graphics.def
 
 ----------
-#### TextStyleElementHeader
+### TextStyleElementHeader
     TextStyleElementHeader          struct
         TSEH_meta               NameArrayElement
         TSEH_baseStyle          word
@@ -774,7 +774,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextStyleFlags
+### TextStyleFlags
     TextStyleFlags      record
         TSF_APPLY_TO_SELECTION_ONLY     :1
         TSF_POINT_SIZE_RELATIVE         :1
@@ -786,7 +786,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextStylePrivateData
+### TextStylePrivateData
     TextStylePrivateData            struct
         TSPD_flags          TextStyleFlags
         TSPD_unused         byte 2 dup (0)
@@ -795,7 +795,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TextTransferBlockHeader
+### TextTransferBlockHeader
     TextTransferBlockHeader             struct
         TTBH_meta                       VMChainTree
         TTBH_reservedOther              word 20 dup (0)
@@ -825,7 +825,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** Objects/vTextC.def
 
 ----------
-#### TFStyleRun
+### TFStyleRun
     TFStyleRun      struct
         TFSR_count          word    ?       ; character count
         TFSR_attr           TextAttr <>     ; text attributes
@@ -834,7 +834,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** gstring.def
 
 ----------
-#### THCFeatures
+### THCFeatures
     THCFeatures     record
         THCF_FOLLOW_HYPERLINK           :1
         THCF_SET_HYPERLINK              :1
@@ -846,14 +846,14 @@ and block handles for the huge array we will be extracting text from.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### THCToolboxFeatures
+### THCToolboxFeatures
     THCToolboxFeatures      record
     THCToolboxFeatures      end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### ThreadException
+### ThreadException
     ThreadException     etype word, 0, 4
         TE_DIVIDE_BY_ZERO       enum ThreadException
         TE_OVERFLOW             enum ThreadException
@@ -865,7 +865,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** thread.def
 
 ----------
-#### ThreadGetInfoType
+### ThreadGetInfoType
     ThreadGetInfoType       etype word, 0, 2
         TGIT_PRIORITY_AND_USAGE         enum ThreadGetInfoType
         TGIT_THREAD_HANDLE              enum ThreadGetInfoType
@@ -874,7 +874,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** thread.def
 
 ----------
-#### ThreadModifyFlags
+### ThreadModifyFlags
     ThreadModifyFlags       record
         TMF_BASE_PRIO           :1
         TMF_ZERO_USAGE          :1
@@ -884,7 +884,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** thread.def
 
 ----------
-#### ThreadPriority
+### ThreadPriority
     ThreadPriority      etype byte
         PRIORITY_TIME_CRITICAL      enum ThreadPriority, 0
         PRIORITY_HIGH               enum ThreadPriority, 64     ;IM
@@ -897,7 +897,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** thread.def
 
 ----------
-#### ThreePointArcParams
+### ThreePointArcParams
     ThreePointArcParams             struct
         TPAP_close          ArcCloseType    ; how the arc should be closed
         TPAP_point1         PointWWFixed    ; Point #1 (start of arc)
@@ -909,7 +909,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** graphics.def
 
 ----------
-#### ThreePointArcToParams
+### ThreePointArcToParams
     ThreePointArcToParams           struct
         TPATP_close         ArcCloseType    ; how the arc should be closed
         TPATP_point2        PointWWFixed    ; Point #2 (a non-terminal point on the 
@@ -920,7 +920,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** graphics.def
 
 ----------
-#### ThreePointRelArcToParams
+### ThreePointRelArcToParams
     ThreePointRelArcToParams            struct
         TPRATP_close        ArcCloseType    ; how the arc should be closed
         TPRATP_delta2       PointWWFixed    ; delta to Point #2 
@@ -930,7 +930,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** graphics.def
 
 ----------
-#### TimerType
+### TimerType
     TimerType       etype word, 0, 2
         TIMER_ROUTINE_ONE_SHOT              enum TimerType
         TIMER_ROUTINE_CONTINUAL             enum TimerType
@@ -942,7 +942,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** timer.def
 
 ----------
-#### TMSFlags
+### TMSFlags
     TMSFlags        record
         TMSF_IS_BREAK_CHARACTER     :1  ;TRUE: Last char was a break character.
         TMSF_IS_OPTIONAL_HYPHEN     :1  ;TRUE: Break is an optional hyphen.
@@ -961,7 +961,7 @@ and block handles for the huge array we will be extracting text from.
 **Library:** text.def
 
 ----------
-#### TocCategoryStruct
+### TocCategoryStruct
     TocCategoryStruct           struct
         TCS_tokenChars      TokenChars <>
         TCS_files           dbptr <>        ; file name array
@@ -976,7 +976,7 @@ TCF_EXTENDED_DEVICE_DRIVERS is set).
 **Library:** config.def
 
 ----------
-#### TocDeviceStruct
+### TocDeviceStruct
     TocDeviceStruct         struct
         TDS_driver      word        ; element in driver array
         TDS_info        word        ; extra word of info (depends on device type).
@@ -986,7 +986,7 @@ TCF_EXTENDED_DEVICE_DRIVERS is set).
 **Library:** config.def
 
 ----------
-#### TocDiskStruct
+### TocDiskStruct
     TocDiskStruct       struct
         TDSS_volumeName         VolumeName
         TDSS_mediaType          MediaType
@@ -996,7 +996,7 @@ TCF_EXTENDED_DEVICE_DRIVERS is set).
 **Library:** config.def
 
 ----------
-#### TOC_ext
+### TOC_ext
     TOC_ext struct
         ;
         ; Entries that are passed
@@ -1129,7 +1129,7 @@ justification. This value doesn't include the spaces at the end of the line.
 **Library:** text.def
 
 ----------
-#### TocFileStruct
+### TocFileStruct
     TocFileStruct       struct
         TFS_sourceDisk      word            ; Disk token
         TFS_release         ReleaseNumber <>
@@ -1139,7 +1139,7 @@ justification. This value doesn't include the spaces at the end of the line.
 **Library:** config.def
 
 ----------
-#### TOCFlags
+### TOCFlags
     TOCFlags        record
         TOCF_NO_WORD_WRAP           :1  ; PASS: Set - word-wrap should be done
         TOCF_AUTO_HYPHENATE         :1  ; PASS: Set - attempt auto hyphenation
@@ -1157,7 +1157,7 @@ justification. This value doesn't include the spaces at the end of the line.
 **Library:** text.def
 
 ----------
-#### TOC_int
+### TOC_int
     TOC_int struct
         TOCI_style                  TextMetricStyles
         TOCI_currentHgt             WBFixed     ; Height of the field
@@ -1184,7 +1184,7 @@ are initialized and used inside **GrTextObjCalc**.
 **Library:** text.def
 
 ----------
-#### TocMap
+### TocMap
     TocMap  struct
         TM_disks            dbptr
         TM_categories       dbptr
@@ -1195,7 +1195,7 @@ This structure is the map item of the TOC file.
 **Library:** config.def
 
 ----------
-#### TOCOtherFlags
+### TOCOtherFlags
     TOCOtherFlags       record
         TOCOF_IS_FIRST_FIELD    :1  ; PASS: Set - This is the first field on the 
                                     ; line
@@ -1209,7 +1209,7 @@ This structure is the map item of the TOC file.
 **Library:** text.def
 
 ----------
-#### TocUpdateCategoryFlags
+### TocUpdateCategoryFlags
     TocUpdateCategoryFlags record
         TUCF_EXTENDED_DEVICE_DRIVERS        :1
         ; Files being enumerated are assumed to be extended device drivers.
@@ -1236,7 +1236,7 @@ This structure is the map item of the TOC file.
 **Library:** config.def
 
 ----------
-#### TocUpdateCategoryParams
+### TocUpdateCategoryParams
     TocUpdateCategoryParams struct
         TUCP_flags                      TocUpdateCategoryFlags
         TUCP_tokenChars                 TokenChars
@@ -1259,7 +1259,7 @@ This structure is the map item of the TOC file.
 **Library:** 
 
 ----------
-#### TOC_vars
+### TOC_vars
     TOC_vars        struct
         TOCV_int        TOC_int
         TOCV_ext        TOC_ext
@@ -1272,7 +1272,7 @@ parameters (*TOC_ext*) and internal variables (*TOC_int*).
 **Library:** text.def
 
 ----------
-#### ToggleState
+### ToggleState
     ToggleState     record
         TS_CAPSLOCK         :1
         TS_NUMLOCK          :1
@@ -1282,7 +1282,7 @@ parameters (*TOC_ext*) and internal variables (*TOC_int*).
 **Library:** 
 
 ----------
-#### TokenDBItem
+### TokenDBItem
     TokenDBItem     struct
         TDBI_group      word
         TDBI_item       word
@@ -1293,7 +1293,7 @@ This structure defines the identifier for a token database item.
 **Library:** token.def
 
 ----------
-#### TokenEntry
+### TokenEntry
     TokenEntry      struct
         TE_type             TokenIndexType
         TE_token            GeodeToken <>
@@ -1323,7 +1323,7 @@ relocation status.
 **Library:** token.def
 
 ----------
-#### TokenError
+### TokenError
     TokenError              etype   word, 1
         BAD_PROTOCOL_IN_SHARED_TOKEN_DATABASE_FILE      enum    TokenError
         ERROR_OPENING_SHARED_TOKEN_DATABASE_FILE        enum    TokenError
@@ -1332,7 +1332,7 @@ relocation status.
 **Library:** token.def
 
 ----------
-#### TokenFlags
+### TokenFlags
     TokenFlags      record
         TF_NEED_RELOCATION      :1
         TF_UNUSED               :15
@@ -1341,7 +1341,7 @@ relocation status.
 **Library:** token.def
 
 ----------
-#### TokenMonikerInfo
+### TokenMonikerInfo
     TokenMonikerInfo        struct
         TMI_moniker     TokenDBItem <>
         TMI_fileFlag    word            ; 0 if token is in shared
@@ -1356,7 +1356,7 @@ call **TokenLockTokenMoniker**.
 **Library:** token.def
 
 ----------
-#### TokenRangeFlags
+### TokenRangeFlags
     TokenRangeFlags record
         TRF_ONLY_GSTRING            :1
         TRF_ONLY_PASSED_MANUFID     :1
@@ -1366,7 +1366,7 @@ call **TokenLockTokenMoniker**.
 **Library:** token.def
 
 ----------
-#### ToolboxInfo
+### ToolboxInfo
     ToolboxInfo     struct
         TI_object       optr
         TI_name         optr
@@ -1381,7 +1381,7 @@ placed (This optr is *unrelocated*! Use the UN_OPTR macro in assembly).
 **Library:** Objects/gToolCC.def
 
 ----------
-#### ToolGroupHighlightType
+### ToolGroupHighlightType
     ToolGroupHighlightType              etype byte
         TGHT_INACTIVE_HIGHLIGHT     enum ToolGroupHighlightType
         TGHT_ACTIVE_HIGHLIGHT       enum ToolGroupHighlightType
@@ -1390,7 +1390,7 @@ placed (This optr is *unrelocated*! Use the UN_OPTR macro in assembly).
 **Library:** Objects/gToolGC.def
 
 ----------
-#### ToolGroupInfo
+### ToolGroupInfo
     ToolGroupInfo       struct
         TGI_object          optr
     ToolGroupInfo       ends
@@ -1401,7 +1401,7 @@ placed (This optr is *unrelocated*! Use the UN_OPTR macro in assembly).
 **Library:** Objects/gToolCC.def
 
 ----------
-#### TrackScrollingParams
+### TrackScrollingParams
     TrackScrollingParams            struct
         TSP_action              ScrollAction
         TSP_flags               ScrollFlags     ;scroll flags
@@ -1432,7 +1432,7 @@ message; in fact, return methods will be ignored for drags.
 **Library:** Objects/gViewC.def
 
 ----------
-#### TransferFileHeader
+### TransferFileHeader
     TransferFileHeader          struct
         TFH_normalItem      word    ; VM block handle of normal transfer item
     TransferFileHeader          ends
@@ -1444,7 +1444,7 @@ handles must be valid handles for this VM transfer file.
 **Library:** Objects/clipbrd.def
 
 ----------
-#### TransFlags
+### TransFlags
     TransFlags      record
         TF_INV_VALID        :1
         TF_ROTATED          :1
@@ -1455,7 +1455,7 @@ handles must be valid handles for this VM transfer file.
 **Library:** tmatrix.def
 
 ----------
-#### TransMatrix
+### TransMatrix
     TransMatrix         struct
         TM_e11      WWFixed <0,1>
         TM_e12      WWFixed <0,0>
@@ -1486,7 +1486,7 @@ This **TransMatrix** is initially set to the identity matrix.
 **Library:** graphics.def
 
 ----------
-#### TravelingObjectReference
+### TravelingObjectReference
     TravelingObjectReference            struct
         TIR_travelingObject         optr
         TIR_parent                  lptr
@@ -1507,7 +1507,7 @@ traveling object below the parent.
 **Library:** Objects/gDispC.def
 
 ----------
-#### TravelOption
+### TravelOption
     TravelOption        etype word, 0
         TO_NULL                 enum TravelOption
         TO_SELF                 enum TravelOption
@@ -1531,7 +1531,7 @@ Sends event to the process owning the UI block.
 **Library:** Objects/metaC.def
 
 ----------
-#### TRCCFeatures
+### TRCCFeatures
     TRCCFeatures        record
         TRCCF_ROUND             :1
         TRCCF_IGNORE_ORIGIN     :1
@@ -1540,14 +1540,14 @@ Sends event to the process owning the UI block.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TRCCToolboxFeatures
+### TRCCToolboxFeatures
     TRCCToolboxFeatures         record
     TRCCToolboxFeatures         end
 
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TSCFeatures
+### TSCFeatures
     TSCFeatures     record
         TSCF_PLAIN              :1
         TSCF_BOLD               :1
@@ -1566,7 +1566,7 @@ Sends event to the process owning the UI block.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TSCToolboxFeatures
+### TSCToolboxFeatures
     TSCToolboxFeatures      record
         TSCTF_PLAIN             :1
         TSCTF_BOLD              :1
@@ -1585,7 +1585,7 @@ Sends event to the process owning the UI block.
 **Library:** Objects/Text/tCtrlC.def
 
 ----------
-#### TVTNCPIData
+### TVTNCPIData
     TVTNCPIData         struct
         TVTNCPID_handle     word
         TVTNCPID_id         word
@@ -1594,7 +1594,7 @@ Sends event to the process owning the UI block.
 **Library:** vTextC.def
 
 ----------
-#### UChar
+### UChar
     UChar   etype byte
         UC_NULL             enum UChar, 0x0     ;NULL
         UC_QUICK_COPY       enum UChar, 0x1     ;unnecessary -- should remove!
@@ -1603,7 +1603,7 @@ Sends event to the process owning the UI block.
 **Library:** uiInputC.def
 
 ----------
-#### UIButtonFlags
+### UIButtonFlags
     UIButtonFlags       record
         UIBF_NO_KEYBOARD                :1
         UIBF_CLICK_TO_TYPE              :1
@@ -1660,7 +1660,7 @@ Set if the text cursor should blink.
 **Library:** Objects/uiInputC.def
 
 ----------
-#### UIExpressOptions
+### UIExpressOptions
     UIExpressOptions        record
                                     :4
         UIEO_RETURN_TO_DEFAULT_LAUNCHER :1  ; Set to have a "Return to <default
@@ -1685,7 +1685,7 @@ Set if the text cursor should blink.
 **Library:** ui.def
 
 ----------
-#### UIExpressPositions
+### UIExpressPositions
     UIExpressPositions      etype word
         UIEP_NONE               enum UIExpressPositions
         UIEP_TOP_PRIMARY        enum UIExpressPositions
@@ -1729,7 +1729,7 @@ Set if the text cursor should blink.
 **Library:** Objects/uiInput.def
 
 ----------
-#### UIHelpOptions
+### UIHelpOptions
     UIHelpOptions       record
                                     :15
         UIHO_HIDE_HELP_BUTTONS      :1
@@ -1744,7 +1744,7 @@ Default interpretation: false (i.e., help buttons appear).
 **Library:** ui.def
 
 ----------
-#### UIInterfaceLevel
+### UIInterfaceLevel
     UIInterfaceLevel        etype word
         UIIL_INTRODUCTORY       enum UIInterfaceLevel
         UIIL_BEGINNING          enum UIInterfaceLevel
@@ -1863,7 +1863,7 @@ safety or recoverability are tilted towards performance.
 **Library:** ui.def
 
 ----------
-#### UIInterfaceOptions
+### UIInterfaceOptions
     UIInterfaceOptions      record
         UIIO_OPTIONS_MENU                       :1
         UIIO_DISABLE_POPOUTS                    :1
@@ -1881,7 +1881,7 @@ out. False to allow pop in and pop out behavior.
 **Library:** ui.def
 
 ----------
-#### UILaunchModel
+### UILaunchModel
     UILaunchModel       etype word
         UILM_TRANSPARENT                enum UILaunchModel
         UILM_SINGLE_INSTANCE            enum UILaunchModel
@@ -1955,7 +1955,7 @@ instance.
 **Library:** ui.def
 
 ----------
-#### UILaunchOptions
+### UILaunchOptions
     UILaunchOptions record
         UILO_DESK_ACCESSORIES   :1  ;TRUE if the desk accessory mode is
                                     ; supported (default = TRUE)
@@ -1968,7 +1968,7 @@ instance.
 **Library:** ui.def
 
 ----------
-#### UIWindowOptions
+### UIWindowOptions
     UIWindowOptions     record
         UIWO_MAXIMIZE_ON_STARTUP                            :1
         UIWO_COMBINE_HEADER_AND_MENU_IN_MAXIMIZED_WINDOWS   :1
@@ -2030,7 +2030,7 @@ pixels in y).
 **Library:** ui.def
 
 ----------
-#### UIWindowOptionsInteger
+### UIWindowOptionsInteger
     UIWindowOptionsInteger          record
         UIWOI_MASK              UIWindowOptions:8
         UIWOI_OPTIONS           UIWindowOptions:8
@@ -2048,7 +2048,7 @@ any given bit).
 **Library:** ui.def
 
 ----------
-#### UndoActionDataFlags
+### UndoActionDataFlags
     UndoActionDataFlags         struct
         UADF_flags          dword
         UADF_extraFlags     word
@@ -2057,7 +2057,7 @@ any given bit).
 **Library:** Objects/gProcC.def
 
 ----------
-#### UndoActionDataOptr
+### UndoActionDataOptr
     UndoActionDataOptr          struct
         UADO_optr           optr
     UndoActionDataOptr          ends
@@ -2065,7 +2065,7 @@ any given bit).
 **Library:** Objects/gProcC.def
 
 ----------
-#### UndoActionDataPtr
+### UndoActionDataPtr
     UndoActionDataPtr       struct
         UADP_ptr        fptr
         UADP_size       word
@@ -2074,7 +2074,7 @@ any given bit).
 **Library:** Objects/gProcC.def
 
 ----------
-#### UndoActionDataType
+### UndoActionDataType
     UndoActionDataType      etype word, 0, 2
         UADT_FLAGS          enum UndoActionDataType
         UADT_PTR            enum UndoActionDataType
@@ -2104,7 +2104,7 @@ move, so the optr should be re-dereferenced after sending this message.
 **Library:** Objects/gProcC.def
 
 ----------
-#### UndoActionDataUnion
+### UndoActionDataUnion
     UndoActionDataUnion         union
         UADU_flags          UndoActionDataFlags
         UADU_ptr            UndoActionDataPtr
@@ -2115,7 +2115,7 @@ move, so the optr should be re-dereferenced after sending this message.
 **Library:** Object/gProcC.def
 
 ----------
-#### UndoActionDataVMChain
+### UndoActionDataVMChain
     UndoActionDataVMChain           struct
         UADVMC_vmChain          dword
         UADVMC_file             hptr
@@ -2129,7 +2129,7 @@ MSG_GEN_PROCESS_UNDO_GET_FILE).
 **Library:** Objects/gProcC.def
 
 ----------
-#### UndoActionStruct
+### UndoActionStruct
     UndoActionStruct        struct
         UAS_dataType            UndoActionDataType
         UAS_data                UndoActionDataUnion
@@ -2147,7 +2147,7 @@ undoing.
 **Library:** Objects/gProcC.def
 
 ----------
-#### UndoDescription
+### UndoDescription
     UndoDescription     etype byte
         UD_UNDO             enum UndoDescription
         UD_REDO             enum UndoDescription
@@ -2168,7 +2168,7 @@ undoable. Must pass 0:0 as title.
 **Library:** Objects/gEditCC.def
 
 ----------
-#### UpdateUIDataBlk
+### UpdateUIDataBlk
     UpdateUIDataBlk     struct
         UUIDB_formatDataVMFileHan   word
         UUIDB_formatDataVMBlkHan    word
@@ -2178,7 +2178,7 @@ undoable. Must pass 0:0 as title.
 **Library:** math.def
 
 ----------
-#### UpdateWindowFlags
+### UpdateWindowFlags
     UpdateWindowFlags       record
         UWF_ATTACHING               :1
         UWF_DETACHING               :1
@@ -2209,7 +2209,7 @@ UWF_ATTACHING is also set, i.e. application is attaching)
 **Library:** Objects/metaC.def
 
 ----------
-#### UserDoDialogStruct
+### UserDoDialogStruct
     UserDoDialogStruct          struct
         UDDS_callingThread              hptr
         UDDS_semaphore                  hptr
@@ -2252,7 +2252,7 @@ the dialog.
 **Library:** Objects/gInterC.def
 
 ----------
-#### UtilAsciiToHexError
+### UtilAsciiToHexError
     UtilAsciiToHexError         etype word
         UATH_NON_NUMERIC_DIGIT_IN_STRING    enum UtilAsciiToHexError
         UATH_CONVERT_OVERFLOW               enum UtilAsciiToHexError
@@ -2260,7 +2260,7 @@ the dialog.
 **Library:** system.def
 
 ----------
-#### UtilHexToAsciiFlags
+### UtilHexToAsciiFlags
     UtilHexToAsciiFlags         record
                                         :11
         UHTAF_SBCS_STRING               :1

--- a/TechDocs/Markdown/Asmref/asmstrvz.md
+++ b/TechDocs/Markdown/Asmref/asmstrvz.md
@@ -1,7 +1,7 @@
 ## 3.8 Structures V-Z
 
 ----------
-#### VarDataCHandler
+### VarDataCHandler
     VarDataCHandler     struct
         VDCH_dataType           word
         VDCH_handler            fptr.far
@@ -15,7 +15,7 @@ table, specific vardata routines will call the *VDCH_handler* routine with the
 **Library:** object.def
 
 ----------
-#### VarDataEntry
+### VarDataEntry
     VarDataEntry        struct
         VDE_dataType            word
         VDE_entrySize           word
@@ -34,7 +34,7 @@ otherwise, this field is left null.
 **Library:** object.def
 
 ----------
-#### VarDataFlags
+### VarDataFlags
     VarDataFlags        record
                             :14
         VDF_EXTRA_DATA      :1      ; set if data entry has extra data
@@ -45,7 +45,7 @@ otherwise, this field is left null.
 **Library:** object.def
 
 ----------
-#### VarDataHandler
+### VarDataHandler
     VarDataHandler      struct
         VDH_dataType        word        ; data type for this handler
         VDH_handler         nptr.far    ; handler routine
@@ -56,7 +56,7 @@ This structure defines a handler in a **VarDataHandlerTable**.
 **Library:** object.def
 
 ----------
-#### VarGeoData
+### VarGeoData
     VarGeoData      struct
         VGD_lineWidth           word
         VGD_centerOffset        word
@@ -66,7 +66,7 @@ This structure defines a handler in a **VarDataHandlerTable**.
 **Library:** Objects/visC.def
 
 ----------
-#### VarObjRelocation
+### VarObjRelocation
     VarObjRelocation        struct
         VOR_type        VarObjRelocationType
         VOR_offset      word
@@ -75,7 +75,7 @@ This structure defines a handler in a **VarDataHandlerTable**.
 **Library:** object.def
 
 ----------
-#### VarObjRelocationType
+### VarObjRelocationType
     VarObjRelocationType            record
         VORT_DATA_TYPE      :14     ; high 14 bits of VarData type constant.
         VORT_RELOC_TYPE     ObjRelocationType:2
@@ -84,7 +84,7 @@ This structure defines a handler in a **VarDataHandlerTable**.
 **Library:** object.def
 
 ----------
-#### VChar
+### VChar
     VChar   etype byte
         VC_NULL             enum VChar, 0x0     ;NULL
         VC_CTRL_A           enum VChar, 0x1     ;<ctrl>-A
@@ -225,7 +225,7 @@ high byte is CS_CONTROL.
 **Library:** input.def
 
 ----------
-#### VCR_param
+### VCR_param
     VCR_param       struct
         VCR_routine         dword
         VCR_BP_param            word
@@ -238,7 +238,7 @@ This structure stores stack parameters used in MSG_VIS_CALL_ROUTINE.
 **Library:** Objects/visC.def
 
 ----------
-#### ViewCommandType
+### ViewCommandType
     ViewCommandType     etype   word
         VCT_ZOOM_IN         enum ViewCommandType    ;no other data
         VCT_ZOOM_OUT        enum ViewCommandType    ;no other data
@@ -247,7 +247,7 @@ This structure stores stack parameters used in MSG_VIS_CALL_ROUTINE.
 **Library:** ui.def
 
 ----------
-#### ViewSize
+### ViewSize
     ViewSize        etype word, 8000h
     VS_TYPICAL  enum ViewSize       ;choose size typical of the specific UI
     VS_SMALL    enum ViewSize       ;choose a small size
@@ -256,7 +256,7 @@ This structure stores stack parameters used in MSG_VIS_CALL_ROUTINE.
 **Library:** Objects/gViewC.def
 
 ----------
-#### ViewTargetInfo
+### ViewTargetInfo
     ViewTargetInfo          struct
         VTI_target  TargetReference     ; Final target object within content
         VTI_content TargetReference     ; The content object itself
@@ -265,7 +265,7 @@ This structure stores stack parameters used in MSG_VIS_CALL_ROUTINE.
 **Library:** Objects/gViewC.def
 
 ----------
-#### VisAddRectFlags
+### VisAddRectFlags
     VisAddRectFlags     record
         VARF_NOT_IF_ALREADY_INVALID     :1
         VARF_ONLY_REDRAW_MARGINS        :1
@@ -290,7 +290,7 @@ reasonable (and fast) thing to do.
 **Library:** Objects/visC.def
 
 ----------
-#### VisAddRectParams
+### VisAddRectParams
     VisAddRectParams        struct
         VARP_bounds     Rectangle           ;rect to invalidate
         VARP_flags      VisAddRectFlags
@@ -300,7 +300,7 @@ reasonable (and fast) thing to do.
 **Library:** Objects/visC.def
 
 ----------
-#### VisAttrs
+### VisAttrs
     VisAttrs    record
         VA_VISIBLE                  :1
         VA_FULLY_ENABLED            :1
@@ -376,7 +376,7 @@ set by MSG_VIS_SET_ATTR.
 **Library:** Objects/visC.def
 
 ----------
-#### VisCompGeoAttrs
+### VisCompGeoAttrs
     VisCompGeoAttrs     record
         VCGA_ORIENT_CHILDREN_VERTICALLY         :1
         VCGA_INCLUDE_ENDS_IN_CHILD_SPACING      :1
@@ -445,7 +445,7 @@ margins (that isn't the color of the background).
 **Library:** Objects/vCompC.def
 
 ----------
-#### VisCompGeoDimensionAttrs
+### VisCompGeoDimensionAttrs
     VisCompGeoDimensionAttrs            record
         VCGDA_WIDTH_JUSTIFICATION           WidthJustification:2
         VCGDA_EXPAND_WIDTH_TO_FIT_PARENT    :1
@@ -488,7 +488,7 @@ children can cooperate (the size can only be suggested).
 **Library:** Objects/vCompC.def
 
 ----------
-#### VisCompSpacingMarginsInfo
+### VisCompSpacingMarginsInfo
     VisCompSpacingMarginsInfo               record
         VCSMI_USE_THIS_INFO             :1
         VCSMI_LEFT_MARGIN               :3
@@ -522,7 +522,7 @@ use in lieu of MSG_VIS_COMP_GET_CHILD_SPACING.
 **Library:** Objects/vCompC.def
 
 ----------
-#### VisContentAttrs
+### VisContentAttrs
     VisContentAttrs     record
         VCNA_SAMW_WIDTH_AS_VIEW                         :1
         VCNA_SAME_HEIGHT_AS_VIEW                        :1
@@ -606,7 +606,7 @@ in the view.
 **Library:** Objects/vCntC.def
 
 ----------
-#### VisGeoAttrs
+### VisGeoAttrs
     VisGeoAttrs     record
         ;
         ; Geometry state flags
@@ -672,7 +672,7 @@ another.
 **Library:** Objects/visC.def
 
 ----------
-#### VisInputFlowGrabFlags
+### VisInputFlowGrabFlags
     VisInputFlowGrabFlags           record
         VIFGF_NOT_HERE      :1
                             :1
@@ -728,7 +728,7 @@ If VIFGF_MOUSE, set if ptr events need to be sent.
 **Library:** Objects/visC.def
 
 ----------
-#### VisInputFlowGrabType
+### VisInputFlowGrabType
     VisInputFlowGrabType            etype byte
         VIFGT_ACTIVE            enum VisInputFlowGrabType
         VIFGT_PRE_PASSIVE       enum VisInputFlowGrabType
@@ -737,7 +737,7 @@ If VIFGF_MOUSE, set if ptr events need to be sent.
 **Library:** Objects/visC.def
 
 ----------
-#### VisLargeTextAttrs
+### VisLargeTextAttrs
     VisLargeTextAttrs       record
         VLTA_EXACT_HEIGHT       :1
                                 :15
@@ -746,7 +746,7 @@ If VIFGF_MOUSE, set if ptr events need to be sent.
 **Library:** Objects/vLTextC.def
 
 ----------
-#### VisLargeTextDisplayModes
+### VisLargeTextDisplayModes
     VisLargeTextDisplayModes            etype word
         VLTDM_PAGE                  enum VisLargeTextDisplayModes
         ;
@@ -792,7 +792,7 @@ If VIFGF_MOUSE, set if ptr events need to be sent.
 **Library:** Objects/vLTextC.def
 
 ----------
-#### VisLargeTextFlags
+### VisLargeTextFlags
     VisLargeTextFlags       record
         VLTF_HEIGHT_NOTIFY_PENDING      :1
                                         :15
@@ -801,7 +801,7 @@ If VIFGF_MOUSE, set if ptr events need to be sent.
 **Library:** Objects/vLTextC.def
 
 ----------
-#### VisLargeTextRegionArrayElement
+### VisLargeTextRegionArrayElement
     VisLargeTextRegionArrayElement          struct
         VLTRAE_charCount            dword       ;# characters in region
         VLTRAE_lineCount            dword       ;# lines in region
@@ -818,7 +818,7 @@ If VIFGF_MOUSE, set if ptr events need to be sent.
 **Library:** Objects/vLTextC.def
 
 ----------
-#### VisLargeTextRegionFlags
+### VisLargeTextRegionFlags
     VisLargeTextRegionFlags         record
         VLTRF_ENDED_BY_COLUMN_BREAK     :1
         VLTRF_EMPTY                     :1
@@ -828,7 +828,7 @@ If VIFGF_MOUSE, set if ptr events need to be sent.
 **Library:** Objects/vLTextC.def
 
 ----------
-#### VisMoniker
+### VisMoniker
     VisMoniker      struct
         VM_type         VisMonikerType <>
         VM_width        word
@@ -852,7 +852,7 @@ Otherwise a **VisMonikerText** structure starts here.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerCachedWidth
+### VisMonikerCachedWidth
     VisMonikerCachedWidth   record
         VMCW_HINTED             :1 ;If set then low 15 bits are cache info
         VMCW_BERKELEY_9         :7 ;Cached width for Berkeley 9
@@ -862,7 +862,7 @@ Otherwise a **VisMonikerText** structure starts here.
 **Library:** visC.def
 
 ----------
-#### VisMonikerDataType
+### VisMonikerDataType
     VisMonikerDataType      etype byte
         VMDT_NULL               enum VisMonikerDataType
         VMDT_VIS_MONIKER        enum VisMonikerDataType
@@ -914,7 +914,7 @@ Database.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerGString
+### VisMonikerGString
     VisMonikerGString       struct
         VMGS_height             word        ;cached gstring height
         VMGS_gstring            label byte  ;start of gstring
@@ -926,7 +926,7 @@ visual moniker is a graphics string.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerListEntry
+### VisMonikerListEntry
     VisMonikerListEntry         struct
         VMLE_type           VisMonikerListEntryType <>
         VMLE_moniker        optr
@@ -943,7 +943,7 @@ search to find a desired moniker.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerListEntryType
+### VisMonikerListEntryType
     VisMonikerListEntryType             record
                                     :2
         VMLET_GS_SIZE               DisplaySize:2
@@ -981,7 +981,7 @@ If is a GString, color requirements of GString.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerSearchFlags
+### VisMonikerSearchFlags
     VisMonikerSearchFlags           record
         VMSF_STYLE              VMStyle:4
                                 :1
@@ -1012,7 +1012,7 @@ True if a gstring moniker is expected (i.e. a
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerSourceType
+### VisMonikerSourceType
     VisMonikerSourceType            etype byte
         VMST_FPTR           enum VisMonikerSourceType
         VMST_OPTR           enum VisMonikerSourceType
@@ -1034,7 +1034,7 @@ within the block.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerText
+### VisMonikerText
     VisMonikerText          struct
         VMT_mnemonicOffset      byte            ;offset to mnemonic, -1 if none
         VMT_text                label byte      ;start of null-terminated text
@@ -1046,7 +1046,7 @@ monikers.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMonikerType
+### VisMonikerType
     VisMonikerType      record
         VMT_MONIKER_LIST        :1
         VMT_GSTRING             :1
@@ -1071,7 +1071,7 @@ Color requirements of GString.
 **Library:** Objects/visC.def
 
 ----------
-#### VisMouseGrab
+### VisMouseGrab
     VisMouseGrab        struct
         VMG_object          optr
         VMG_gWin            hptr.Window <>
@@ -1098,7 +1098,7 @@ amount before being sent out.
 **Library:** Objects/vCntC.def
 
 ----------
-#### VisOptFlags
+### VisOptFlags
     VisOptFlags         record
         VOF_GEOMETRY_INVALID        :1
         VOF_GEO_UPDATE_PATH         :1
@@ -1153,7 +1153,7 @@ knowing how to update an object.
 **Library:** Objects/visC.def
 
 ----------
-#### VisRulerAttributes
+### VisRulerAttributes
     VisRulerAttributes      record
         VRA_IGNORE_ORIGIN       :1
         VRA_SHOW_GUIDES         :1
@@ -1167,7 +1167,7 @@ knowing how to update an object.
 **Library:** ruler.def
 
 ----------
-#### VisRulerConstrainStrategy
+### VisRulerConstrainStrategy
     VisRulerConstrainStrategy               record
         VRCS_OVERRIDE                                   :1
                                                         :1
@@ -1190,7 +1190,7 @@ knowing how to update an object.
 **Library:** ruler.def
 
 ----------
-#### VisRulerNotifyGuideChangeBlockHeader
+### VisRulerNotifyGuideChangeBlockHeader
     VisRulerNotifyGuideChangeBlockHeader    struct
         VRNGCBH_header                  LMemBlockHeader
         VRNGCBH_vertGuideArray          word
@@ -1200,7 +1200,7 @@ knowing how to update an object.
 **Library:** ruler.def
 
 ----------
-#### VisRulerType
+### VisRulerType
     VisRulerType        etype byte, 0
         VRT_INCHES          enum VisRulerType
         VRT_CENTIMETERS     enum VisRulerType
@@ -1213,7 +1213,7 @@ knowing how to update an object.
 **Library:** ruler.def
 
 ----------
-#### VisTextAddNameParams
+### VisTextAddNameParams
     VisTextAddNameParams            struct
         VTANP_name          fptr.char       ; pointer to name
         VTANP_size          word            ; length of name (0 if null-terminated)
@@ -1224,7 +1224,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextCachedRunInfo
+### VisTextCachedRunInfo
     VisTextCachedRunInfo            struct
         VTCRI_lastCharAttrRun           dword
         VTCRI_lastParaAttrRun           dword
@@ -1235,7 +1235,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextCachedUndoInfo
+### VisTextCachedUndoInfo
     VisTextCachedUndoInfo           struct
         VTCUI_vmChain           dword
         VTCUI_file              hptr
@@ -1244,7 +1244,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextCharAttr
+### VisTextCharAttr
     VisTextCharAttr     struct
         VTCA_meta               StyleSheetElementHeader
         VTCA_fontID             FontID
@@ -1266,7 +1266,7 @@ knowing how to update an object.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextCharAttrDiffs
+### VisTextCharAttrDiffs
     VisTextCharAttrDiffs            struct
         VTCAD_diffs             VisTextCharAttrFlags
         VTCAD_extendedStyles    VisTextExtendedStyles
@@ -1277,7 +1277,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextCharAttrFlags
+### VisTextCharAttrFlags
     VisTextCharAttrFlags            record
         VTCAF_MULTIPLE_FONT_IDS         :1  ;Set if more than one font
         VTCAF_MULTIPLE_POINT_SIZES      :1  ;Set if more than one point size
@@ -1298,7 +1298,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextClearAllTabsParams
+### VisTextClearAllTabsParams
     VisTextClearAllTabsParams               struct
         VTCATP_range            VisTextRange
     VisTextClearAllTabsParams               ends
@@ -1306,7 +1306,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextClearTabParams
+### VisTextClearTabParams
     VisTextClearTabParams           struct
         VTCTP_range         VisTextRange
         VTCTP_position      word            ; In units of points * 8
@@ -1315,7 +1315,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextContextType
+### VisTextContextType
     VisTextContextType      etype byte
         VTCT_TEXT               enum VisTextContextType
         VTCT_CATEGORY           enum VisTextContextType
@@ -1327,7 +1327,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextCursorPositionChange
+### VisTextCursorPositionChange
     VisTextCursorPositionChange     struct
         VTCPC_lineNumber        dword
         VTCPC_rowNumber         dword
@@ -1336,7 +1336,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextCustomFilterData
+### VisTextCustomFilterData
     VisTextCustomFilterData         struct
         VTCFD_startOfRange              word
         VTCFD_endOfRange                word
@@ -1345,7 +1345,7 @@ knowing how to update an object.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextDefaultCharAttr
+### VisTextDefaultCharAttr
     VisTextDefaultCharAttr          record
         VTDCA_UNDERLINE     :1
         VTDCA_BOLD          :1
@@ -1359,7 +1359,7 @@ knowing how to update an object.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextDefaultDefaultTab
+### VisTextDefaultDefaultTab
     VisTextDefaultDefaultTab            etype byte
         VTDDT_NONE          enum VisTextDefaultDefaultTab
         VTDDT_HALF_INCH     enum VisTextDefaultDefaultTab
@@ -1369,7 +1369,7 @@ knowing how to update an object.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextDefaultFont
+### VisTextDefaultFont
     VisTextDefaultFont      etype byte
         VTDF_BERKELEY               enum VisTextDefaultFont ;Bitmap font
         VTDF_CHICAGO                enum VisTextDefaultFont ;Bitmap font
@@ -1388,7 +1388,7 @@ knowing how to update an object.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextDefaultParaAttr
+### VisTextDefaultParaAttr
     VisTextDefaultParaAttr          record
         VTDPA_JUSTIFICATION     Justification:2
         VTDPA_DEFAULT_TABS      VisTextDefaultDefaultTab:2
@@ -1401,7 +1401,7 @@ knowing how to update an object.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextDefaultSize
+### VisTextDefaultSize
     VisTextDefaultSize      etype byte
         VTDS_8      enum VisTextDefaultSize
         VTDS_9      enum VisTextDefaultSize
@@ -1415,7 +1415,7 @@ knowing how to update an object.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextDropCapInfo
+### VisTextDropCapInfo
     VisTextDropCapInfo          record
         VTDCI_CHAR_COUNT    :4 = 1-1    ; # characters for drop cap charAttr
         VTDCI_LINE_COUNT    :4 = 3-1    ; # lines for drop cap
@@ -1427,7 +1427,7 @@ knowing how to update an object.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextExtendedFilterType
+### VisTextExtendedFilterType
     VisTextExtendedFilterType               etype byte
         VTEFT_REPLACE_PARAMS            enum VisTextExtendedFilterType
         VTEFT_CHARACTER_LEVELER_LEVEL   enum VisTextExtendedFilterType
@@ -1448,7 +1448,7 @@ be sent.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextExtendedStyles
+### VisTextExtendedStyles
     VisTextExtendedStyles           record
         VTES_BOXED              :1
         VTES_BUTTON             :1
@@ -1464,7 +1464,7 @@ be sent.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextFeatures
+### VisTextFeatures
     VisTextFeatures     record
         VTF_NO_WORD_WRAPPING            :1  ; Set: no word-wrapping is desired.
         VTF_AUTO_HYPHENATE              :1  ; Set: if we want to auto hyphenate.
@@ -1490,7 +1490,7 @@ be sent.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextFilters
+### VisTextFilters
     VisTextFilters      record
         VTF_NO_SPACES       :1          ;no spaces allowed
         VTF_NO_TABS         :1          ;no tabs
@@ -1502,7 +1502,7 @@ be sent.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextFilterClass
+### VisTextFilterClass
     VisTextFilterClass      etype byte
         VTFC_NO_FILTER              enum VisTextFilterClass ;no filter
         VTFC_ALPHA                  enum VisTextFilterClass ;alpha chars only
@@ -1525,7 +1525,7 @@ be sent.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextFindNameParams
+### VisTextFindNameParams
     VisTextFindNameParams           struct
         VTFNP_name      fptr.char           ; pointer to name to find
         VTFNP_size      word                ; length of name (0 if null-terminated)
@@ -1537,7 +1537,7 @@ This structure is passed with MSG_VIS_TEXT_FIND_NAME.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextFollowHyperlinkParams
+### VisTextFollowHyperlinkParams
     VisTextFollowHyperlinkParams                struct
         VTFHLP_range    VisTextRange    ; range of characters in the selection
     VisTextFollowHyperlinkParams                ends
@@ -1545,7 +1545,7 @@ This structure is passed with MSG_VIS_TEXT_FIND_NAME.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGenerateNotifyParams
+### VisTextGenerateNotifyParams
     VisTextGenerateNotifyParams             struct
         VTGNP_notificationTypes     VisTextNotificationFlags
         VTGNP_sendFlags             VisTextNotifySendFlags
@@ -1555,7 +1555,7 @@ This structure is passed with MSG_VIS_TEXT_FIND_NAME.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetAttrFlags
+### VisTextGetAttrFlags
     VisTextGetAttrFlags         record
         VTGAF_MERGE_WITH_PASSED     :1  ;If set then merge the attributes for
                                         ;this object with the passed attributes
@@ -1565,7 +1565,7 @@ This structure is passed with MSG_VIS_TEXT_FIND_NAME.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetAttrParams
+### VisTextGetAttrParams
     VisTextGetAttrParams            struct
         VTGAP_range     VisTextRange
         VTGAP_attr      fptr                ; attribute structure
@@ -1576,7 +1576,7 @@ This structure is passed with MSG_VIS_TEXT_FIND_NAME.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetGraphicAtPositionParams
+### VisTextGetGraphicAtPositionParams
     VisTextGetGraphicAtPositionParams                   struct
         VTGGAPP_position                dword
         VTGGAPP_retPtr                  fptr.VisTextGraphic
@@ -1585,7 +1585,7 @@ This structure is passed with MSG_VIS_TEXT_FIND_NAME.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetLineInfoParameters
+### VisTextGetLineInfoParameters
     VisTextGetLineInfoParameters                struct
         VTGLIP_buffer   fptr.LineInfo   ;pointer to buffer to store results
         VTGLIP_bsize    word            ; size of buffer
@@ -1599,7 +1599,7 @@ followed by a variable number of **FieldInfo** structures.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetLineOffsetAndFlagsParameters
+### VisTextGetLineOffsetAndFlagsParameters
     VisTextGetLineOffsetAndFlagsParameters struct
         VTGLOAFP_line       dword           ; line to get information about
         ;
@@ -1613,7 +1613,7 @@ followed by a variable number of **FieldInfo** structures.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetRunBoundsParams
+### VisTextGetRunBoundsParams
     VisTextGetRunBoundsParams       struct
         VTGRBP_position dword               ; Position to check for run around
         VTGRBP_type     word                ; Run offset
@@ -1624,7 +1624,7 @@ followed by a variable number of **FieldInfo** structures.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetTextRangeFlags
+### VisTextGetTextRangeFlags
     VisTextGetTextRangeFlags            record
         VTGTRF_ALLOCATE         :1
         VTGTRF_ALLOCATE_ALWAYS  :1
@@ -1647,7 +1647,7 @@ large enough to hold the text and no larger.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGetTextRangeParameters
+### VisTextGetTextRangeParameters
     VisTextGetTextRangeParameters                   struct
         VTGTRP_range            VisTextRange        ; range to get
         VTGTRP_textReference    TextReference       ; Reference to the text
@@ -1658,7 +1658,7 @@ large enough to hold the text and no larger.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGraphic
+### VisTextGraphic
     VisTextGraphic          struct
         VTG_meta        RefElementHeader        ; basic element header
         VTG_vmChain     dword
@@ -1683,7 +1683,7 @@ size is determined dynamically.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGraphicData
+### VisTextGraphicData
     VisTextGraphicData          union
         VTGD_gstring        VisTextGraphicGString
         VTGD_variable       VisTextGraphicVariable
@@ -1693,7 +1693,7 @@ size is determined dynamically.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGraphicFlags
+### VisTextGraphicFlags
     VisTextGraphicFlags     record
         VTGF_DRAW_FROM_BASELINE :1  ;If set then draw from baseline else
                                     ;draw from top
@@ -1704,7 +1704,7 @@ size is determined dynamically.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGraphicGString
+### VisTextGraphicGString
     VisTextGraphicGString           struct
         VTGG_tmatrix            TransMatrix
         VTGG_drawOffset         XYOffset
@@ -1713,7 +1713,7 @@ size is determined dynamically.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGraphicType
+### VisTextGraphicType
     VisTextGraphicType      etype byte
         VTGT_GSTRING            enum VisTextGraphicType
         VTGT_VARIABLE           enum VisTextGraphicType
@@ -1721,7 +1721,7 @@ size is determined dynamically.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextGraphicVariable
+### VisTextGraphicVariable
     VisTextGraphicVariable          struct
         VTGV_manufacturerID ManufacturerID
         VTGV_type           VisTextVariableType
@@ -1731,7 +1731,7 @@ size is determined dynamically.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextHWRFlags
+### VisTextHWRFlags
     VisTextHWRFlags     record
         VTHWRF_NO_CONTEXT               :1
         VTHWRF_USE_PASSED_CONTEXT       :1
@@ -1746,7 +1746,7 @@ of the object is not useful information for the recognizer.
 **Library:** 
 
 ----------
-#### VisTextHyphenationInfo
+### VisTextHyphenationInfo
     VisTextHyphenationInfo          record
         VTHI_HYPHEN_MAX_LINES           :4 = 3-1
         VTHI_HYPHEN_SHORTEST_WORD       :4 = 5-1
@@ -1757,7 +1757,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextIntFlags
+### VisTextIntFlags
     VisTextIntFlags     record
         VTIF_HAS_LINES              :1  ;Object has valid line structures.
         VTIF_SUSPENDED              :1  ;Set if calculation suspended
@@ -1773,7 +1773,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextIntSelFlags
+### VisTextIntSelFlags
     VisTextIntSelFlags      record
         VTISF_IS_TARGET             :1  ; Set if the object is the target.
         VTISF_IS_FOCUS              :1  ; Set if the object is the focus.
@@ -1790,7 +1790,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextKeepInfo
+### VisTextKeepInfo
     VisTextKeepInfo     record
         VTKI_TOP_LINES      :4      ; # lines at start of PP to keep together
         VTKI_BOTTOM_LINES   :4      ; # lines at end of PP to keep together
@@ -1799,7 +1799,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextKeyFunction
+### VisTextKeyFunction
     VisTextKeyFunction      etype word, 0, 6
         VTKF_FORWARD_LINE                       enum    VisTextKeyFunction
         VTKF_BACKWARD_LINE                      enum    VisTextKeyFunction
@@ -1855,7 +1855,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextLoadFromDBWithStylesParams
+### VisTextLoadFromDBWithStylesParams
     VisTextLoadFromDBWithStylesParams       struct
         VTLFDBWSP_params    fptr.StyleSheetParams
         VTLFDBWSP_dbItem    dword               ; DB item to load from
@@ -1865,7 +1865,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextMaxParaAttr
+### VisTextMaxParaAttr
     VisTextMaxParaAttr      struct
         VTMPA_paraAttr          VisTextParaAttr
         VTMPA_tabs              Tab VIS_TEXT_MAX_TABS dup (<>)
@@ -1874,7 +1874,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextMinimumDimensionsParameters
+### VisTextMinimumDimensionsParameters
     VisTextMinimumDimensionsParameters  struc
         VTMDP_height            WBFixed
         VTMDP_width             WBFixed
@@ -1883,7 +1883,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextMoveTabParams
+### VisTextMoveTabParams
     VisTextMoveTabParams            struct
         VTMTP_range             VisTextRange
         VTMTP_destPosition      word            ; in units of points * 8
@@ -1893,7 +1893,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNameArrayElement
+### VisTextNameArrayElement
     VisTextNameArrayElement         struc
         VTNAE_meta          NameArrayElement
         VTNAE_data          VisTextNameData
@@ -1902,7 +1902,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNameCommonParams
+### VisTextNameCommonParams
     VisTextNameCommonParams         struct
         VTNCP_data      VisTextNameData
         VTNCP_index     word            ; index of name
@@ -1912,7 +1912,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNameData
+### VisTextNameData
     VisTextNameData     struct
         VTND_type           VisTextNameType
         VTND_contextType    VisTextContextType
@@ -1923,7 +1923,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNameType
+### VisTextNameType
     VisTextNameType     etype byte
         VTNT_CONTEXT        enum VisTextNameType
         VTNT_FILE           enum VisTextNameType
@@ -1931,7 +1931,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNotificationFlags
+### VisTextNotificationFlags
     VisTextNotificationFlags            record
         VTNF_SELECT_STATE           :1
         VTNF_CHAR_ATTR              :1
@@ -1951,7 +1951,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNotifyCharAttrChange
+### VisTextNotifyCharAttrChange
     VisTextNotifyCharAttrChange             struct
         VTNCAC_charAttr             VisTextCharAttr
         VTNCAC_charAttrToken        word
@@ -1961,7 +1961,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNotifyCountChange
+### VisTextNotifyCountChange
     VisTextNotifyCountChange            struct
         VTNCC_charCount             dword
         VTNCC_wordCount             dword
@@ -1971,7 +1971,7 @@ of the object is not useful information for the recognizer.
 
 **Library:** Objects/vTextC.def
 ----------
-#### VisTextNotifyNameChange
+### VisTextNotifyNameChange
     VisTextNotifyNameChange         struct
         VTNNC_count         word
     VisTextNotifyNameChange         ends
@@ -1979,7 +1979,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNotifyParaAttrChange
+### VisTextNotifyParaAttrChange
     VisTextNotifyParaAttrChange             struct
         VTNPAC_paraAttr                 VisTextMaxParaAttr
         VTNPAC_paraAttrToken            word
@@ -1992,7 +1992,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNotifySelectionChange
+### VisTextNotifySelectionChange
     VisTextNotifySelectionChange                struct
         VTNSC_selectStart           dword
         VTNSC_selectEnd             dword
@@ -2006,7 +2006,7 @@ of the object is not useful information for the recognizer.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNotifySendFlags
+### VisTextNotifySendFlags
     VisTextNotifySendFlags          record
         VTNSF_UPDATE_APP_TARGET_GCN_LISTS       :1
         VTNSF_NULL_STATUS                       :1
@@ -2044,7 +2044,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNotifyTypeChange
+### VisTextNotifyTypeChange
     VisTextNotifyTypeChange         struct
         VTNTC_type              VisTextType
         VTNTC_typeToken         word
@@ -2055,7 +2055,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextNumberType
+### VisTextNumberType
     VisTextNumberType       etype word
         VTNT_NUMBER                 enum VisTextNumberType
         VTNT_LETTER_UPPER_A         enum VisTextNumberType
@@ -2102,7 +2102,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextParaAttrAttributes
+### VisTextParaAttrAttributes
     VisTextParaAttrAttributes               record
         VTPAA_JUSTIFICATION             Justification:2
         VTPAA_KEEP_PARA_WITH_NEXT       :1
@@ -2119,7 +2119,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextParaAttrBorderFlags
+### VisTextParaAttrBorderFlags
     VisTextParaAttrBorderFlags          record
         VTPABF_MULTIPLE_BORDER_LEFT         :1      ;Match with VTPBF_LEFT
         VTPABF_MULTIPLE_BORDER_TOP          :1      ;Match with VTPBF_TOP
@@ -2140,7 +2140,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextParaAttrDiffs
+### VisTextParaAttrDiffs
     VisTextParaAttrDiffs            struct
         VTPAD_diffs             VisTextParaAttrFlags
         VTPAD_diffs2            VisTextParaAttrFlags2
@@ -2155,7 +2155,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextParaAttrFlags
+### VisTextParaAttrFlags
     VisTextParaAttrFlags            record
         VTPAF_MULTIPLE_LEFT_MARGINS             :1
         VTPAF_MULTIPLE_RIGHT_MARGINS            :1
@@ -2178,7 +2178,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextParaAttrFlags2
+### VisTextParaAttrFlags2
     VisTextParaAttrFlags2           record
         VTPAF2_MULTIPLE_LANGUAGES       :1
                                         :15
@@ -2187,7 +2187,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextParaBorderFlags
+### VisTextParaBorderFlags
     VisTextParaBorderFlags          record
         VTPBF_LEFT              :1      ;Set if a border on the left
         VTPBF_TOP               :1      ;Set if a border on the top
@@ -2203,7 +2203,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** tCommon.def
 
 ----------
-#### VisTextRange
+### VisTextRange
     VisTextRange        struct
         VTR_start   dword       ; start of range
         VTR_end     dword       ; end of range
@@ -2212,7 +2212,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextRangeContext
+### VisTextRangeContext
     VisTextRangeContext         record
         VTRC_PARAGRAPH_CHANGE           :1  ;Change done on paragraph level.
         VTRC_CHAR_ATTR_CHANGE           :1  ; Used for a charAttr change (include 
@@ -2225,7 +2225,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextReplaceFlags
+### VisTextReplaceFlags
     VisTextReplaceFlags         record
         VTRF_FILTER                     :1      ;Set to filter replacement
         VTRF_KEYBOARD_INPUT             :1      ;Set if data is coming from the 
@@ -2244,7 +2244,7 @@ responsible for relaying the message to multiple text objects.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextReplaceParameters
+### VisTextReplaceParameters
     VisTextReplaceParameters            struct
         VTRP_range                  VisTextRange
         VTRP_insCount               dword           ; number of characters to 
@@ -2259,7 +2259,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextReplaceWithHWRParams
+### VisTextReplaceWithHWRParams
     VisTextReplaceWithHWRParams             struct
         VTRWHWRP_range              VisTextRange
         VTRWHWRP_flags              VisTextHWRFlags
@@ -2270,7 +2270,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSaveDBFlags
+### VisTextSaveDBFlags
     VisTextSaveDBFlags          record
         VTSDBF_TEXT         :1                  ;set if text is saved 
                                                 ; (0 means null text)
@@ -2287,7 +2287,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSaveStyleSheetParams
+### VisTextSaveStyleSheetParams
     VisTextSaveStyleSheetParams     struct
         VTSSSP_common               StyleSheetParams
         VTSSSP_graphicsElements     word        ;VM block of graphics elements
@@ -2298,7 +2298,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSaveToDBWithStylesParams
+### VisTextSaveToDBWithStylesParams
     VisTextSaveToDBWithStylesParams         struct
         VTSTDBWSP_params    fptr.VisTextSaveStyleSheetParams
         VTSTDBWSP_dbItem    dword
@@ -2311,7 +2311,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSaveType
+### VisTextSaveType
     VisTextSaveType     etype byte
         VTST_NONE               enum VisTextSaveType    ;nothing saved
         VTST_SINGLE_CHUNK       enum VisTextSaveType    ;single attr structure
@@ -2321,7 +2321,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetBorderBitsParams
+### VisTextSetBorderBitsParams
     VisTextSetBorderBitsParams              struct
         VTSBBP_range                VisTextRange
         VTSBBP_bitsToSet            VisTextParaBorderFlags
@@ -2331,7 +2331,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetBorderWidthParams
+### VisTextSetBorderWidthParams
     VisTextSetBorderWidthParams         struct
         VTSBWP_range            VisTextRange
         VTSBWP_width            byte
@@ -2341,7 +2341,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetCharAttrByDefaultParams
+### VisTextSetCharAttrByDefaultParams
     VisTextSetCharAttrByDefaultParams           struct
         VTSCABDP_range              VisTextRange
         VTSCABDP_charAttr           VisTExtDefaultCharAttr
@@ -2350,7 +2350,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetCharAttrByTokenParams
+### VisTextSetCharAttrByTokenParams
     VisTextSetCharAttrByTokenParams                 struct
         VTSCABTP_range                  VisTextRange
         VTSCABTP_charAttr               word
@@ -2359,7 +2359,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetCharAttrParams
+### VisTextSetCharAttrParams
     VisTextSetCharAttrParams            struct
         VTSCAP_range            VisTextRange
     VTSCAP_charAttr             fptr.VisTextCharAttr
@@ -2368,7 +2368,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetColorParams
+### VisTextSetColorParams
     VisTextSetColorParams           struct
         VTSCP_range         VisTextRange
         VTSCP_color         ColorQuad
@@ -2377,7 +2377,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetContextFlags
+### VisTextSetContextFlags
     VisTextSetContextFlags          record
                         :7
         VTCF_TOKEN      :1      ;TRUE: context and hyperlink are tokens
@@ -2386,7 +2386,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetContextParams
+### VisTextSetContextParams
     VisTextSetContextParams         struct
         VTSCXP_range            VisTextRange
         VTSCXP_context          word
@@ -2397,7 +2397,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetDefaultTabsParams
+### VisTextSetDefaultTabsParams
     VisTextSetDefaultTabsParams             struct
         VTSDTP_range                VisTextRange
         VTSDTP_defaultTabs          word
@@ -2406,7 +2406,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetDropCapPParams
+### VisTextSetDropCapPParams
     VisTextSetDropCapPParams            struct
         VTSDCP_range                VisTextRange
         VTSDCP_bitsToSet            word
@@ -2416,7 +2416,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetFontIDParams
+### VisTextSetFontIDParams
     VisTextSetFontIDParams          struct
         VTSFIDP_range           VisTextRange
         VTSFIDP_fontID          FontID
@@ -2425,7 +2425,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetFontWeightParams
+### VisTextSetFontWeightParams
     VisTextSetFontWeightParams              struct
         VTSFWP_range                VisTextRange
         VTSFWP_fontWeight           byte
@@ -2435,7 +2435,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetFontWidthParams
+### VisTextSetFontWidthParams
     VisTextSetFontWidthParams               struct
         VTSFWIP_range               VisTextRange
         VTSFWIP_fontWidth           byte
@@ -2445,7 +2445,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetGrayScreenParams
+### VisTextSetGrayScreenParams
     VisTextSetGrayScreenParams              struct
         VTSGSP_range                VisTextRange
         VTSGSP_grayScreen           SystemDrawMask
@@ -2455,7 +2455,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetHyperlinkParams
+### VisTextSetHyperlinkParams
     VisTextSetHyperlinkParams               struct
         VTSHLP_range                VisTextRange
         VTSHLP_context              word
@@ -2467,7 +2467,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetHyphenationPParams
+### VisTextSetHyphenationPParams
     VisTextSetHyphenationPParams                struct
         VTSHP_range                 VisTextRange
         VTSHP_bitsToSet             VisTextHyphenationInfo
@@ -2477,7 +2477,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetKeepPParams
+### VisTextSetKeepPParams
     VisTextSetKeepPParams           struct
         VTSKP_range             VisTextRange
         VTSKP_bitsToSet         word
@@ -2487,7 +2487,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetLargerPointSizeParams
+### VisTextSetLargerPointSizeParams
     VisTextSetLargerPointSizeParams                 struct
         VTSLPSP_range                   VisTextRange
         VTSLPSP_maximumSize             word
@@ -2496,7 +2496,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetLeadingParams
+### VisTextSetLeadingParams
     VisTextSetLeadingParams         struct
         VTSLP_range             VisTextRange
         VTSLP_leading           word
@@ -2505,7 +2505,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetLineSpacingParams
+### VisTextSetLineSpacingParams
     VisTextSetLineSpacingParams             struct
         VTSLSP_range                    VisTextRange
         VTSLSP_lineSpacing              BBFixed
@@ -2514,7 +2514,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetMarginParams
+### VisTextSetMarginParams
     VisTextSetMarginParams          struct
         VTSMP_range             VisTextRange
         VTSMP_position          word
@@ -2523,7 +2523,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetParaAttrAttributesParams
+### VisTextSetParaAttrAttributesParams
     VisTextSetParaAttrAttributesParams      struct
         VTSPAAP_range                   VisTextRange
         VTSPAAP_bitsToSet               VisTextParaAttrAttributes
@@ -2533,7 +2533,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetParaAttrByDefaultParams
+### VisTextSetParaAttrByDefaultParams
     VisTextSetParaAttrByDefaultParams                   struct
         VTSPABDP_range                  VisTextRange
         VTSPABDP_paraAttr               VisTextDefaultParaAttr
@@ -2542,7 +2542,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetParaAttrByTokenParams
+### VisTextSetParaAttrByTokenParams
     VisTextSetParaAttrByTokenParams                 struct
         VTSPABTP_range                  VisTextRange
         VTSPABTP_paraAttr               word
@@ -2551,7 +2551,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetParaAttrParams
+### VisTextSetParaAttrParams
     VisTextSetParaAttrParams            struct
         VTSPAP_range                VisTextRange
         VTSPAP_paraAttr             fptr.VisTextParaAttr
@@ -2560,7 +2560,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetParagraphNumberParams
+### VisTextSetParagraphNumberParams
     VisTextSetParagraphNumberParams                 struct
         VTSPNP_range                        VisTextRange
         VTSPNP_startingParaNumber           word
@@ -2569,7 +2569,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetPatternParams
+### VisTextSetPatternParams
     VisTextSetPatternParams         struct
         VTSHAP_range            VisTextRange
         VTSHAP_hatch            GraphicPattern
@@ -2578,7 +2578,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetPointSizeParams
+### VisTextSetPointSizeParams
     VisTextSetPointSizeParams               struct
         VTSPSP_range                VisTextRange
         VTSPSP_pointSize            WWFixed
@@ -2587,7 +2587,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetPrependCharsParams
+### VisTextSetPrependCharsParams
     VisTextSetPrependCharsParams                struct
         VTSPCP_range            VisTextRange
         VTSPCP_chars            char 4 dup (0)
@@ -2596,7 +2596,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetSmallerPointSizeParams
+### VisTextSetSmallerPointSizeParams
     VisTextSetSmallerPointSizeParams                    struct
         VTSSPSP_range                   VisTextRange
         VTSSPSP_minimumSize             word
@@ -2605,7 +2605,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSpaceOnTBParams
+### VisTextSpaceOnTBParams
     VisTextSpaceOnTBParams          struct
         VTSSOTBP_range          VisTextRange
         VTSSOTBP_spacing        BBFixed
@@ -2614,7 +2614,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetTabParams
+### VisTextSetTabParams
     VisTextSetTabParams         struct
         VTSTP_range         VisTextRange
         VTSTP_tab           Tab
@@ -2623,7 +2623,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetTextStyleParams
+### VisTextSetTextStyleParams
     VisTextSetTextStyleParams               struct
         VTSTSP_range                    VisTextRange
         VTSTSP_styleBitsToSet           word
@@ -2635,7 +2635,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSetTrackKerningParams
+### VisTextSetTrackKerningParams
     VisTextSetTrackKerningParams                struct
         VTSTKP_range                    VisTextRange
         VTSTKP_trackKerning             BBFixed
@@ -2645,7 +2645,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextShowSelectionArgs
+### VisTextShowSelectionArgs
     VisTextShowSelectionArgs            struct
         VTSSA_params            MakeRectVisibleParams
         VTSSA_flags             VisTextShowSelectionFlags
@@ -2654,7 +2654,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextShowSelectionFlags
+### VisTextShowSelectionFlags
     VisTextShowSelectionFlags               record
         VTSSF_DRAGGING          :1
                                 :15
@@ -2663,7 +2663,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextStates
+### VisTextStates
     VisTextStates       record
         VTS_EDITABLE                        :1  ; Set: text is editable.
         VTS_SELECTABLE                      :1  ; Set: text is selectable.
@@ -2682,7 +2682,7 @@ This structure is passed with MSG_VIS_TEXT_REPLACE.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextStorageFlags
+### VisTextStorageFlags
     VisTextStorageFlags         record
         VTSF_LARGE                      :1
         VTSF_MULTIPLE_CHAR_ATTRS        :1
@@ -2720,7 +2720,7 @@ use default paraAttr.
 **Library:** Objects/Text/tCommon.def
 
 ----------
-#### VisTextSubstAttrTokenParams
+### VisTextSubstAttrTokenParams
     VisTextSubstAttrTokenParams         struct
         VTSATP_oldToken                     word
         VTSATP_newToken                     word
@@ -2733,7 +2733,7 @@ use default paraAttr.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextSuspendData
+### VisTextSuspendData
     VisTextSuspendData      struct
         VTSD_count              word
         VTSD_recalcRange        VisTextRange    ; range to recalculate
@@ -2745,7 +2745,7 @@ use default paraAttr.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextType
+### VisTextType
     VisTextType     struct
         VTT_meta                RefElementHeader
         VTT_hyperlinkName       word        ; name array element (-1 if none)
@@ -2757,7 +2757,7 @@ use default paraAttr.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextTypeDiffs
+### VisTextTypeDiffs
     VisTextTypeDiffs        record
         VTTD_MULTIPLE_HYPERLINKS    :1
         VTTD_MULTIPLE_CONTEXTS      :1
@@ -2767,7 +2767,7 @@ use default paraAttr.
 **Library:** Objects/vTextC.def
 
 ----------
-#### VisTextVariableType
+### VisTextVariableType
     VisTextVariableType         etype word
         VTVT_PAGE_NUMBER                    enum VisTextVariableType
             ; private data: first word is VisTextNumberType
@@ -2807,7 +2807,7 @@ use default paraAttr.
 **Library:** geoworks.def
 
 ----------
-#### VisTypeFlags
+### VisTypeFlags
     VisTypeFlags        record
         VTF_IS_COMPOSITE                    :1
         VTF_IS_WINDOW                       :1
@@ -2897,7 +2897,7 @@ have this flag set.
 **Library:** Objects/visC.def
 
 ----------
-#### VisUpdateImageFlags
+### VisUpdateImageFlags
     VisUpdateImageFlags         record
         VUIF_ALREADY_INVALIDATED    :1
         VUIF_SEND_TO_ALL_CHILDREN   :1
@@ -2925,7 +2925,7 @@ Internal flag.
 **Library:** Objects/visC.def
 
 ----------
-#### VisUpdateMode
+### VisUpdateMode
     VisUpdateMode       etype byte
         VUM_MANUAL                  enum VisUpdateMode  ;don't update. 
         VUM_NOW                     enum VisUpdateMode  ;update NOW.
@@ -2937,7 +2937,7 @@ Internal flag.
 **Library:** Objects/visC.def
 
 ----------
-#### VisUpwardQueryType
+### VisUpwardQueryType
     VisUpwardQueryType      etype word
         SPEC_VIS_QUERY_START    equ 2000    ; offset to first specific UI query type
         APP_VIS_QUERY_START     equ 4000    ; offset to first app UI query type
@@ -2977,7 +2977,7 @@ Internal flag.
 **Library:** Objects/visC.def
 
 ----------
-#### VisWardMouseEventType
+### VisWardMouseEventType
     VisWardMouseEventType           etype byte, 0
         VWMET_SMALL         enum VisWardMouseEventType
         VWMET_LARGE         enum VisWardMouseEventType
@@ -2985,7 +2985,7 @@ Internal flag.
 **Library:** grobj.def
 
 ----------
-#### VisWardToolActiveStatus
+### VisWardToolActiveStatus
     VisWardToolActiveStatus         etype byte, 0
         VWTAS_ACTIVE            enum VisWardToolActiveStatus
         VWTAS_INACTIVE          enum VisWardToolActiveStatus
@@ -2993,7 +2993,7 @@ Internal flag.
 **Library:** grobj.def
 
 ----------
-#### VMAccessFlags
+### VMAccessFlags
     VMAccessFlags       record
         VMAF_FORCE_READ_ONLY                    :1
         VMAF_FORCE_READ_WRITE                   :1
@@ -3041,7 +3041,7 @@ mark the file SHARED_MULTIPLE, close it, and reopen it again.
 **Library:** vm.def
 
 ----------
-#### VMAttributes
+### VMAttributes
     VMAttributes        record
         VMA_SYNC_UPDATE                 :1
         VMA_BACKUP                      :1
@@ -3087,7 +3087,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMChainLink
+### VMChainLink
     VMChainLink     struct
         VMCL_next       word
     VMChainLink     ends
@@ -3095,7 +3095,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMChainTree
+### VMChainTree
     VMChainTree     struct
         VMCT_meta           VMChainLink
         VMCT_offset         nptr        ;offset to first chain
@@ -3105,7 +3105,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMLinkAndGrObjRelocation
+### VMLinkAndGrObjRelocation
     VMLinkAndGrObjRelocation            struct
         VMLAGOR_link                VMChainLink
         VMLAGOR_relocation          GrObjEntryPointRelocation
@@ -3114,7 +3114,7 @@ optimizations in **VMLock**.
 **Library:** grobj.def
 
 ----------
-#### VMOpenType
+### VMOpenType
     VMOpenType      etype byte
         VMO_OPEN            enum VMOpenType ; Open existing
         VMO_TEMP_FILE       enum VMOpenType ; Create temp file -- name is 
@@ -3128,7 +3128,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMOperation
+### VMOperation
     VMOperation     etype word
         VMO_READ        enum VMOperation    ;default state -- allows
                                             ;readers not to modify the file
@@ -3144,7 +3144,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMRelocType
+### VMRelocType
     VMRelocType     etype word
         VMRT_UNRELOCATE_BEFORE_WRITE        enum VMRelocType
         VMRT_RELOCATE_AFTER_READ            enum VMRelocType
@@ -3155,7 +3155,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMStartExclusiveReturnValue
+### VMStartExclusiveReturnValue
     VMStartExclusiveReturnValue             etype word
         VMSERV_NO_CHANGES           enum VMStartExclusiveReturnValue
         VMSERV_CHANGES              enum VMStartExclusiveReturnValue
@@ -3164,7 +3164,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMStatus
+### VMStatus
     VMStatus        etype word, 256
         VM_OPEN_OK_READ_ONLY                enum VMStatus
         VM_OPEN_OK_TEMPLATE                 enum VMStatus
@@ -3195,7 +3195,7 @@ optimizations in **VMLock**.
 **Library:** vm.def
 
 ----------
-#### VMStyle
+### VMStyle
     VMStyle etype byte
         VMS_TEXT            enum VMStyle    ; normal text moniker
         VMS_ABBREV_TEXT     enum VMStyle    ; abbreviated text moniker i.e. a 
@@ -3211,7 +3211,7 @@ optimizations in **VMLock**.
 **Library:** Objects/visC.def
 
 ----------
-#### VupAlterInputFlowData
+### VupAlterInputFlowData
     VupAlterInputFlowData           struct
         VAIFD_flags             VisInputFlowGrabFlags
         VAIFD_grabType          VisInputFlowGrabType
@@ -3229,13 +3229,13 @@ applied to all mouse data (for mouse grabs only).
 **Library:** Objects/visC.def
 
 ----------
-#### Warnings
+### Warnings
     Warnings        etype word, 0
 
 **Library:** ec.def
 
 ----------
-#### WBFixed
+### WBFixed
     WBFixed struct
         WBF_frac        byte        ;8 bits fraction
         WBF_int         word        ;16 bits integer
@@ -3244,7 +3244,7 @@ applied to all mouse data (for mouse grabs only).
 **Library:** geos.def
 
 ----------
-#### WidthJustification
+### WidthJustification
     WidthJustification      etype byte
         WJ_LEFT_JUSTIFY_CHILDREN                    enum WidthJustification
         WJ_RIGHT_JUSTIFY_CHILDREN                   enum WidthJustification
@@ -3254,7 +3254,7 @@ applied to all mouse data (for mouse grabs only).
 **Library:** Objects/vCompC.def
 
 ----------
-#### WildCard
+### WildCard
     WildCard    etype byte
         WC_MATCH_SINGLE_CHAR            enum WildCard, 0x10
         WC_MATCH_MULTIPLE_CHARS         enum WildCard, 0x11
@@ -3263,7 +3263,7 @@ applied to all mouse data (for mouse grabs only).
 **Library:** Objects/vTextC.def
 
 ----------
-#### WinColorFlags
+### WinColorFlags
     WinColorFlags       record
         WCF_RGB             :1
         WCF_TRASNPARENT     :1
@@ -3290,7 +3290,7 @@ Graphics color mapping mode.
 **Library:** win.def
 
 ----------
-#### WinConstrainType
+### WinConstrainType
     WinConstrainType        etype byte
         WCT_NONE                            enum WinConstrainType
         WCT_KEEP_PARTIALLY_VISIBLE          enum WinConstrainType
@@ -3315,7 +3315,7 @@ WCT_KEEP_VISIBLE_WITH_MARGIN
 **Library:** Objects/visC.def
 
 ----------
-#### WinError
+### WinError
     WinError        etype word, 0, 1
         WE_COORD_OVERFLOW       enum WinError   ; 16-bit coordinate overflow
         WE_WINDOW_CLOSING       enum WinError   ; window is closing
@@ -3324,7 +3324,7 @@ WCT_KEEP_VISIBLE_WITH_MARGIN
 **Library:** win.def
 
 ----------
-#### WinInfoType
+### WinInfoType
     WinInfoType     etype word, 0, 2
         WIT_PRIVATE_DATA        enum WinInfoType
         WIT_COLOR               enum WinInfoType
@@ -3343,7 +3343,7 @@ WCT_KEEP_VISIBLE_WITH_MARGIN
 **Library:** win.def
 
 ----------
-#### WinInvalFlag
+### WinInvalFlag
     WinInvalFlag        etype byte, 0, 1
         WIF_INVALIDATE          enum WinInvalFlag   ; -invalidate the win
         WIF_DONT_INVALIDATE     enum WinInvalFlag   ; -don't
@@ -3351,7 +3351,7 @@ WCT_KEEP_VISIBLE_WITH_MARGIN
 **Library:** win.def
 
 ----------
-#### WinPassFlags
+### WinPassFlags
     WinPassFlags        record
         WPF_CREATE_GSTATE           :1
         WPF_ROOT                    :1
@@ -3404,7 +3404,7 @@ Whether size/offset passed is absolute or relative to current
 **Library:** win.def
 
 ----------
-#### WinPositionType
+### WinPositionType
     WinPositionType     etype byte
         WPT_AT_RATIO                    enum WinPositionType
         WPT_STAGGER                     enum WinPositionType
@@ -3447,7 +3447,7 @@ Reserved for specific-UI use.
 **Library:** Objects/visC.def
 
 ----------
-#### WinPosSizeFlag
+### WinPosSizeFlag
     WinPosSizeFlags     record
         WPSF_PERSIST                                :1
         WPSF_HINT_FOR_ICON                          :1
@@ -3495,7 +3495,7 @@ indicates what sizing algorithm should be used.
 **Library:** Objects/visC.def
 
 ----------
-#### WinPriority
+### WinPriority
     WinPriority     etype byte
         WIN_PRIO_POPUP              enum WinPriority, 4
         WIN_PRIO_MODAL              enum WinPriority, 6
@@ -3525,7 +3525,7 @@ Window stays on bottom.
 **Library:** win.def
 
 ----------
-#### WinPriorityData
+### WinPriorityData
     WinPriorityData     record
         WPD_LAYER   LayerPriority   :4
         WPD_WIN     WinPriority     :4      ; priority value for window.
@@ -3534,7 +3534,7 @@ Window stays on bottom.
 **Library:** win.def
 
 ----------
-#### WinPtrFlags
+### WinPtrFlags
     WinPtrFlags     record
         WPF_PTR_IN_UNIV     :1      ; pointer in universe of window. (RAW)
                                     ; this is not synchronous with the UI 
@@ -3548,7 +3548,7 @@ Window stays on bottom.
 **Library:** win.def
 
 ----------
-#### WinRegFlags
+### WinRegFlags
     WinRegFlags     record
         WRF_DELAYED_WASH        :1
         WRF_DELAYED_V           :1
@@ -3590,7 +3590,7 @@ entire window is already invalidated.
 **Library:** win.def
 
 ----------
-#### WinSizeType
+### WinSizeType
     WinSizeType     etype byte
         WST_AS_RATIO_OF_PARENT              enum WinSizeType
         WST_AS_RATIO_OF_FIELD               enum WinSizeType
@@ -3623,7 +3623,7 @@ window. The margin is determined by the specific UI.
 **Library:** Objects/visC.def
 
 ----------
-#### WordAndAHalf
+### WordAndAHalf
     WordAndAHalf        struct
         WAAH_low            word
         WAAH_high           byte
@@ -3632,7 +3632,7 @@ window. The margin is determined by the specific UI.
 **Library:** geos.def
 
 ----------
-#### WWFixed
+### WWFixed
     WWFixed struct
         WWF_frac        word        ;16 bits fraction
         WWF_int         word        ;16 bits integer
@@ -3641,7 +3641,7 @@ window. The margin is determined by the specific UI.
 **Library:** geos.def
 
 ----------
-#### XYOffset
+### XYOffset
     XYOffset        struct
         XYO_x   sword
         XYO_y   sword
@@ -3650,7 +3650,7 @@ window. The margin is determined by the specific UI.
 **Library:** graphics.def
 
 ----------
-#### XYSize
+### XYSize
     XYSize  struct
         XYS_width       word
         XYS_height      word

--- a/TechDocs/Markdown/Asmref/asmv_z.md
+++ b/TechDocs/Markdown/Asmref/asmv_z.md
@@ -1,7 +1,7 @@
 ## 2.7 Routines V-Z
 
 ----------
-#### VisCompInitialize
+### VisCompInitialize
 This routine initializes a VisComp object. This does parent class 
 initialization first, followed by an initialization of the VisComp part. It 
 initializes the composite linkage and marks the visible object as a composite.
@@ -20,7 +20,7 @@ ax, bx, cx, dx, bp, si, di, ds, es.
 **Library:** vCompC.def
 
 ----------
-#### VisCompMakePressesInk
+### VisCompMakePressesInk
 This routine is a handler for subclasses of VisCompClass that wish to make 
 presses that are not on a child to be ink.
 
@@ -41,7 +41,7 @@ Nothing.
 **Library:** vCompC.def
 
 ----------
-#### VisCompMakePressesNotInk
+### VisCompMakePressesNotInk
 This routine is a handler for subclasses of VisCompClass that wish to make 
 presses that are not on a child to be normal (i.e., not ink).
 
@@ -62,7 +62,7 @@ Nothing.
 **Library:** vCompC.def
 
 ----------
-#### VisInitialize
+### VisInitialize
 This routine initializes the VisInstance part of a visual object's instance data. 
 This includes setting the size of the object to zero (bounds being (0, 0) to 
 (-1, -1)) and marking the object invalid in all ways (image, window, and 
@@ -82,7 +82,7 @@ ax, cx, dx, bp.
 **Library:** visC.def
 
 ----------
-#### VisObjectHandlesInkReply
+### VisObjectHandlesInkReply
 This is a message handler to be used by those objects that want ink.
 
 **Pass:**  
@@ -100,7 +100,7 @@ ax, cx, di.
 **Library:** visC.def
 
 ----------
-#### VisTextGraphicCompressGraphic
+### VisTextGraphicCompressGraphic
 This routine compresses the bitmaps in a VisTextGraphic.
 
 **Pass:**  
@@ -118,7 +118,7 @@ Nothing
 **Library:** vTextC.def
 
 ----------
-#### VMAlloc
+### VMAlloc
 Creates and allocates space for a VM block within a previously existing VM 
 file. The block will not be initialized.
 
@@ -143,7 +143,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMAllocLMem
+### VMAllocLMem
 Allocates a VM block and initializes it to contain a local memory heap. If you 
 want a fixed data header space, you must pass the total size to allocate 
 (including the **LMemBlockHeader**; otherwise, pass zero indicating that 
@@ -167,7 +167,7 @@ Destroyed.
 **Library:** vm.def
 
 ----------
-#### VMAttach
+### VMAttach
 Attaches an existing block of memory to a VM block, deleting whatever data 
 was stored there before.
 
@@ -186,7 +186,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMCheckForModifications
+### VMCheckForModifications
 Checks whether a VM file has been marked as modified.
 
 **Pass:**  
@@ -201,7 +201,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMClose
+### VMClose
 Closes a VM file. This routine updates all dirty blocks, frees all global memory 
 blocks attached to the file and closes the file.
 
@@ -223,7 +223,7 @@ bx (if file was actually closed).
 **Library:** vm.def
 
 ----------
-#### VMCompareVMChains
+### VMCompareVMChains
 Compares two VM chains or DB items.
 
 **Pass:**  
@@ -241,7 +241,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMCopyVMBlock
+### VMCopyVMBlock
 Creates a duplicate of a VM block into the specified destination file. This 
 destination file may be the same as the source file. The duplicate VM block 
 user ID will remain the same as the original block's user.
@@ -260,7 +260,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMCopyVMChain
+### VMCopyVMChain
 Creates a duplicate of a VM chain (or DB item) in the specified destination 
 file. This destination file may be the same as the source file. All blocks in the 
 duplicate will have the same user ID number.
@@ -280,7 +280,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMDetach
+### VMDetach
 Detaches a VM block from a VM file, returning the handle of the detached 
 global memory block (which may have been allocated). The VM block will 
 contain no data after the detach.
@@ -299,7 +299,7 @@ ax
 **Library:** vm.def
 
 ----------
-#### VMDirty
+### VMDirty
 Marks a locked VM block as dirty.
 
 **Pass:**  
@@ -314,7 +314,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMFind
+### VMFind
 Given a VM block's user ID, locates and returns the first VM block handle 
 whose user ID matches.
 
@@ -334,7 +334,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMFree
+### VMFree
 Frees a VM block handle. If a global memory block is attached to the VM 
 block, that is freed also.
 
@@ -351,7 +351,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMFreeVMChain
+### VMFreeVMChain
 Frees a VM chain (or DB item). If freeing a VM chain, all blocks in the chain 
 will be freed.
 
@@ -368,7 +368,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMGetAttributes
+### VMGetAttributes
 Returns the **VMAttributes** associated with the specified VM file.
 
 **Pass:**  
@@ -383,7 +383,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMGetDirtyState
+### VMGetDirtyState
 Returns the dirty state of a VM file, in a word-length value that specifies both 
 if the file has been dirtied since the last save and whether it has been dirtied 
 since the last save, auto-save, or update.
@@ -402,7 +402,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMGetMapBlock
+### VMGetMapBlock
 Returns the VM block handle of the VM file's map block.
 
 **Pass:**  
@@ -417,7 +417,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMGrabExclusive
+### VMGrabExclusive
 Provides the current thread with exclusive access to the VM file.
 
 **Pass:**  
@@ -437,7 +437,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMInfo
+### VMInfo
 Fetches information about a VM block. Returns the memory handle, block 
 size, and user ID of the specified VM block.
 
@@ -461,7 +461,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMLock
+### VMLock
 Locks the given VM block into the global memory heap.
 
 **Pass:**  
@@ -478,7 +478,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMMemBlockToVMBlock
+### VMMemBlockToVMBlock
 Returns the VM block and VM file associated with a given VM memory 
 handle.
 
@@ -495,7 +495,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMModifyUserID
+### VMModifyUserID
 Changes the user ID of the passed VM block.
 
 **Pass:**  
@@ -512,7 +512,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMOpen
+### VMOpen
 Opens (or creates) a VM file, returning the handle of the opened file. 
 **VMOpen** looks for the file in the thread's current working directory (unless 
 creating a temporary file). 
@@ -535,7 +535,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMPreserveBlocksHandle
+### VMPreserveBlocksHandle
 Keeps the same global memory block with this VM block until the block is 
 explicitly detached or the VM block is freed.
 
@@ -552,7 +552,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMReleaseExclusive
+### VMReleaseExclusive
 Relinquishes a thread's exclusive access to a VM file.
 
 **Pass:**  
@@ -567,7 +567,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMRevert
+### VMRevert
 Reverts a file to its last-saved state.
 
 **Pass:**  
@@ -582,7 +582,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMSave
+### VMSave
 Updates and saves a VM file, freeing all backup blocks.
 
 **Pass:**  
@@ -598,7 +598,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMSaveAs
+### VMSaveAs
 Saves a VM file under a new name. The old file is reverted to its last-saved 
 state.
 
@@ -621,7 +621,7 @@ cx, dx
 **Library:** vm.def
 
 ----------
-#### VMSetAttributes
+### VMSetAttributes
 Changes a VM file's **VMAttributes** settings, also returning the new 
 attributes in a word-length record.
 
@@ -639,7 +639,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMSetExecThread
+### VMSetExecThread
 Sets the thread that will execute methods of all objects within the passed VM 
 file.
 
@@ -656,7 +656,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMSetMapBlock
+### VMSetMapBlock
 Sets the map block of a VM file.
 
 **Pass:**  
@@ -672,7 +672,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMSetReloc
+### VMSetReloc
 Sets the (fixed-memory) data relocation routine to be called whenever a block 
 is brought into memory from a VM file (or written to memory).
 
@@ -702,7 +702,7 @@ ax, bx, cx, dx, si, di, bp, ds, es
 **Library:** vm.def
 
 ----------
-#### VMUnlock
+### VMUnlock
 Unlocks a locked VM block. Note that the block's global memory handle is 
 passed (not it's VM handle).
 
@@ -722,7 +722,7 @@ procedure.)
 **Library:** vm.def
 
 ----------
-#### VMUpdate
+### VMUpdate
 Updates all dirty blocks within a VM file to the disk. (This is known as 
 flushing all changes onto disk.)
 
@@ -739,7 +739,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VMVMBlockToMemBlock
+### VMVMBlockToMemBlock
 Returns the handle of the global memory block attached to a specified VM 
 block. If no global block is currently attached, it will allocate and attach one.
 
@@ -756,7 +756,7 @@ Nothing.
 **Library:** vm.def
 
 ----------
-#### VTFClearSmartQuotes
+### VTFClearSmartQuotes
 Clear the variable that prohibits smart quotes.
 
 **Pass:**  
@@ -771,7 +771,7 @@ Nothing
 **Library:** vTextC.def
 
 ----------
-#### WarningNotice
+### WarningNotice
 A place for Swat to place a breakpoint to catch taken invocations of the 
 WARNING family of macros
 
@@ -787,7 +787,7 @@ Nothing.
 **Library:** ec.def
 
 ----------
-#### WinAckUpdate
+### WinAckUpdate
 Acknowledges an update in the window without performing any visual 
 updating. This is equivalent to calling **GrBeginUpdate**, then 
 **GrEndUpdate** but does not require a GState to do so. 
@@ -807,7 +807,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinApplyRotation
+### WinApplyRotation
 Applies the passed rotation to the window's transformation matrix.
 
 **Pass:**  
@@ -826,7 +826,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinApplyScale
+### WinApplyScale
 Applies the passed scale factor to the window's transformation matrix.
 
 **Pass:**  
@@ -846,7 +846,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinApplyTransform
+### WinApplyTransform
 Concatenates the passed transformation matrix (**TMatrix**) with the 
 window's current transformation matrix, forming the window's new 
 transformation matrix.
@@ -867,7 +867,7 @@ ax, bx
 **Library:** win.def
 
 ----------
-#### WinApplyTranslation
+### WinApplyTranslation
 Applies the passed translation to the window's transformation matrix.
 
 **Pass:**  
@@ -887,7 +887,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinApplyTranslationDWord
+### WinApplyTranslationDWord
 Applies a 32-bit translation to a window's transformation matrix.
 
 **Pass:**  
@@ -907,7 +907,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinChangeAck
+### WinChangeAck
 Called to acknowledge a MSG_META_WIN_CHANGE, this function generates 
 "Enter" and "Leave" events for any windows which the mouse may have 
 moved across. 
@@ -931,7 +931,7 @@ and invalidating stored segment pointers and current register or stored
 offsets to them.
 
 ----------
-#### WinChangePriority
+### WinChangePriority
 Changes a window's priority.
 
 **Pass:**  
@@ -948,7 +948,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinClose
+### WinClose
 Closes and frees the specified window.
 
 **Pass:**  
@@ -963,7 +963,7 @@ di
 **Library:** win.def
 
 ----------
-#### WinDecRefCount
+### WinDecRefCount
 Handle acknowledge of window death. To be called by whoever receives a 
 MSG_META_WIN_DEC_REF_COUNT.
 
@@ -979,7 +979,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinEnsureChangeNotification
+### WinEnsureChangeNotification
 Ensures that if the window that has the implied mouse grab has changed 
 since the last MSG_META_WIN_CHANGE, then another 
 MSG_META_WIN_CHANGE will be sent out to update the system.
@@ -996,7 +996,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeGetFlags
+### WinGeodeGetFlags
 Returns the **GeodeWinFlags** associated with a geode.
 
 **Pass:**  
@@ -1011,7 +1011,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeGetInputObj
+### WinGeodeGetInputObj
 Returns the optr of the input object associated with the specified geode. (If 
 there is no such object, this routine returns a null optr.)
 
@@ -1027,7 +1027,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeGetParentObj
+### WinGeodeGetParentObj
 Returns the optr of the parent object associated with the passed geode. (If 
 there is no such parent object, this routine returns a null optr.)
 
@@ -1043,7 +1043,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeSetActiveWin
+### WinGeodeSetActiveWin
 Sets the passed window within the specified geode to be that geode's "active" 
 window.
 
@@ -1060,7 +1060,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeSetFlags
+### WinGeodeSetFlags
 Sets the GeodeWinFlags associated with the specified geode.
 
 **Pass:**  
@@ -1076,7 +1076,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeSetInputObj
+### WinGeodeSetInputObj
 Sets the passed geode's input object to the specified optr.
 
 **Pass:**  
@@ -1092,7 +1092,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeSetParentObj
+### WinGeodeSetParentObj
 Sets the passed geode's parent object to the specified optr.
 
 **Pass:**  
@@ -1108,7 +1108,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGeodeSetPtrImage
+### WinGeodeSetPtrImage
 Sets the pointer image of the specified geode to the passed **PointerDef**.
 
 **Pass:**  
@@ -1125,7 +1125,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGetInfo
+### WinGetInfo
 Returns information (including any private data) associated with a window.
 
 **Pass:**  
@@ -1168,7 +1168,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGetTransform
+### WinGetTransform
 Returns the transformation matrix of the specified window.
 
 **Pass:**  
@@ -1191,7 +1191,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGetWinScreenBounds
+### WinGetWinScreenBounds
 Returns the bounds of the on-screen portion of the specified window.
 
 **Pass:**  
@@ -1210,7 +1210,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinGrabChange
+### WinGrabChange
 Allows an object to grab pointer events for windows within the system.
 
 **Pass:**  
@@ -1226,7 +1226,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinInvalReg
+### WinInvalReg
 Invalidates a portion of the specified window, indicated by the passed region 
 (or rectangle).
 
@@ -1245,7 +1245,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinLocatePoint
+### WinLocatePoint
 Searches through a window tree, returning the window in which the passed 
 point lies within, along with other information about the window.
 
@@ -1267,7 +1267,7 @@ ax, bx, cx, dx
 **Library:** win.def
 
 ----------
-#### WinMove
+### WinMove
 Moves a window, either relative to its current position or in an absolute 
 manner (relative to the parent).
 
@@ -1287,7 +1287,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinOpen
+### WinOpen
 Allocates and initializes a window and (optionally) its associated GState.
 
 The region/rectangle passed is expressed in units relative to the parent's 
@@ -1327,7 +1327,7 @@ ax, cx, dx, si, bp
 **Library:** win.def
 
 ----------
-#### WinRealizePalette
+### WinRealizePalette
 Realize the palette for this window in hardware.
 
 **Pass:**  
@@ -1342,7 +1342,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinReleaseChange
+### WinReleaseChange
 Releases an object from being notified of window changes.
 
 **Pass:**  
@@ -1357,7 +1357,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinResize
+### WinResize
 Resizes a window. It is also possible to move it at the same time.
 
 **Pass:**  
@@ -1378,7 +1378,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinScroll
+### WinScroll
 Scrolls a document within a window by the passed values. Actual 
 displacement values may be different than the passed values due to rounding 
 and optimizations.
@@ -1400,7 +1400,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinSetInfo
+### WinSetInfo
 Sets information within a window. Passed register arguments depend on the 
 **WinInfoType** passed in **si**.
 
@@ -1430,7 +1430,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinSetNullTransform
+### WinSetNullTransform
 Replaces a window's transformation matrix with a null (identity) 
 transformation.
 
@@ -1449,7 +1449,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinSetPtrImage
+### WinSetPtrImage
 Sets the pointer image within the range of the passed window.
 
 **Pass:**  
@@ -1467,7 +1467,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinSetTransform
+### WinSetTransform
 Sets the transformation matrix of a window. Any previous transformation 
 matrix is lost.
 
@@ -1487,7 +1487,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinSuspendUpdate
+### WinSuspendUpdate
 
 Suspends the sending of update messages to the window. If an update is 
 already in progress, it will be allowed to continue and suspend behavior will 
@@ -1505,7 +1505,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinSysSetActiveGeode
+### WinSysSetActiveGeode
 Sets the passed geode to be the system's "active" geode.
 
 **Pass:**  
@@ -1520,7 +1520,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinTransform
+### WinTransform
 Translates the passed document coordinates into screen coordinates, 
 ignoring the effect of any transformation in the associated GState.
 
@@ -1542,7 +1542,7 @@ Nothing (except possibly **bx**, see above).
 **Library:** win.def
 
 ----------
-#### WinTransformDWord
+### WinTransformDWord
 Translates the passed 32-bit document coordinates into 32-bit screen 
 coordinates.
 
@@ -1562,7 +1562,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinUnSuspendUpdate
+### WinUnSuspendUpdate
 Cancels any previous **WinSuspendUpdate** call, allowing update drawing to 
 the window.
 
@@ -1578,7 +1578,7 @@ Nothing.
 **Library:** win.def
 
 ----------
-#### WinUntransform
+### WinUntransform
 Translates a coordinate pair from screen coordinates into document 
 coordinates, ignoring the effects in the associated GState.
 
@@ -1598,7 +1598,7 @@ Nothing (except possibly **bx**; see above).
 **Library:** win.def
 
 ----------
-#### WinUntransformDWord
+### WinUntransformDWord
 Translates a 32-bit coordinate pair into 32-bit screen coordinates.
 
 **Pass:**  

--- a/TechDocs/Markdown/Concepts/cappl.md
+++ b/TechDocs/Markdown/Concepts/cappl.md
@@ -1,4 +1,4 @@
-## 6 Applications and Geodes
+# 6 Applications and Geodes
 
 This chapter discusses the life of an application as well as several topics most 
 application programmers will want to cover at one time or another. Before 
@@ -39,7 +39,7 @@ change another application's data dynamically-the recipient
 application is automatically started if it is not already running. (This is 
 an advanced topic; most programmers will not need to read this section.)
 
-### 6.1 Geodes
+## 6.1 Geodes
 
 Geode is the term used to describe a GEOS executable. Just as DOS has 
 executables (programs) that reside in files on a disk, so too does GEOS. GEOS 
@@ -136,7 +136,7 @@ block list (e.g. a geode is being loaded while it has just been freed), GEOS
 maintains an internal semaphore. The geode loading and freeing routines 
 automatically maintain this semaphore.
 
-#### 6.1.1 Geode Components and Structures
+### 6.1.1 Geode Components and Structures
 
 A geode is simply a special type of GEOS file. It has a special file header that 
 gets loaded in as the geode's core block. This file header contains the geode's 
@@ -197,7 +197,7 @@ keep the import and export specifics available. Additionally, each geode
 must keep track of the resources it owns. All this information is stored in 
 tables referenced from within the core block.
 
-##### 6.1.1.1 Geode Attributes
+#### 6.1.1.1 Geode Attributes
 
 Each geode has in its core block a record of type **GeodeAttrs**. This record 
 defines several things about the geode, including which aspects it uses and 
@@ -260,13 +260,13 @@ GA_ENTRY_POINTS_IN_C
 This geode has its library entry routine in C rather than 
 assembly language.
 
-##### 6.1.1.2 Geode Token
+#### 6.1.1.2 Geode Token
 
 As stated above, every geode is associated with a token in the token database. 
 This token is defined by the use of a **GeodeToken** structure. This structure 
 and its uses are discussed in [section 6.2](#62-creating-icons).
 
-#### 6.1.2 Launching an Application
+### 6.1.2 Launching an Application
 
 GeodeLoad(), UserLoadApplication(), 
 MSG_GEN_PROCESS_OPEN_APPLICATION
@@ -347,7 +347,7 @@ MSG_GEN_PROCESS_OPEN_APPLICATION-two others are received (when
 restoring from state and when opening in engine mode), but they should not 
 be intercepted.
 
-#### 6.1.3 Shutting Down an Application
+### 6.1.3 Shutting Down an Application
 
 MSG_GEN_PROCESS_CLOSE_APPLICATION, 
 MSG_GEN_PROCESS_CLOSE_ENGINE, 
@@ -400,7 +400,7 @@ for notification on the notification list GCNSLT_SHUTDOWN_CONTROL
 When the system shuts down or task-switches, the object will then receive a 
 MSG_META_CONFIRM_SHUTDOWN, at which time the object must call **SysShutdown()**.
 
-#### 6.1.4 Saving and Restoring State
+### 6.1.4 Saving and Restoring State
 
 ObjMarkDirty(), ObjSaveBlock()
 
@@ -494,7 +494,7 @@ instead; it will erase the backup and lock in the user's changes to the
 document.) If you are not using GEOS VM files, it is up to you how and if you 
 will save the document's state.
 
-#### 6.1.5 Using Other Geodes
+### 6.1.5 Using Other Geodes
 
 Often, geodes will have to use other geodes. For example, a communications 
 program will use the Serial Driver, and a draw application will use the 
@@ -505,7 +505,7 @@ Other times, however, an application will have to load libraries or drivers on
 the fly and then free them some time later. This section describes how to load, 
 use, and free libraries and drivers.
 
-##### 6.1.5.1 Using Libraries
+#### 6.1.5.1 Using Libraries
 
 GeodeUseLibrary(), GeodeFreeLibrary()
 
@@ -525,7 +525,7 @@ increment the library's reference count. When you are done using a library
 loaded with **GeodeUseLibrary()**, you must free the library's instance with 
 **GeodeFreeLibrary()**.
 
-##### 6.1.5.2 Using Drivers
+#### 6.1.5.2 Using Drivers
 
 GeodeUseDriver(), GeodeInfoDriver(), 
 GeodeGetDefaultDriver(), GeodeSetDefaultDriver(), GeodeFreeDriver()
@@ -686,7 +686,7 @@ geode handle and a driver type and sets the system default for that type.
 Typically, system defaults will be set only by the Preferences Manager 
 application.
 
-#### 6.1.6 Writing Your Own Libraries
+### 6.1.6 Writing Your Own Libraries
 
 Creating a library geode is a simple step beyond creating a normal 
 application. Libraries can have their own process threads or not; most 
@@ -743,7 +743,7 @@ type driver, library, single
 entry SoundEntry
 ~~~
 
-#### 6.1.7 Working with Geodes
+### 6.1.7 Working with Geodes
 
 The system provides a number of utility routines for getting information and 
 setting attributes of geodes. These are loosely organized throughout the 
@@ -816,7 +816,7 @@ owns the code block from which it was called.
 
 **ProcInfo()** returns the thread handle of the first thread of a given process.
 
-##### 6.1.7.3 Managing Geode Event Queues
+#### 6.1.7.3 Managing Geode Event Queues
 
 GeodeAllocQueue(), GeodeFreeQueue(), GeodeInfoQueue(), 
 GeodeFlushQueue(), ObjDispatchMessage(), QueueGetMessage(), 
@@ -846,7 +846,7 @@ it's handling a message.
 
 **QueuePostMessage()** adds an event to the specified queue. 
 
-#### 6.1.8 Geode Protocols and Release Levels
+### 6.1.8 Geode Protocols and Release Levels
 
 Every GEOS geode and VM file has both a release level and a protocol level as 
 extended attributes of the file. These two items help ease the transitions for 
@@ -855,7 +855,7 @@ drivers, system software, etc. To control release and protocol numbers, use
 the GREV tool and a REV file as described in "Grev" on page 444 of "Using 
 Tools," Chapter 10 of the Tools Reference Manual.
 
-##### 6.1.8.1 Release Numbers
+#### 6.1.8.1 Release Numbers
 
 The release number is a **ReleaseNumber** structure which consists of four 
 components: The RN_major and RN_minor numbers are the most significant. 
@@ -882,7 +882,7 @@ To retrieve the release number of a given geode, use the routine
 **GeodeGetInfo()**. Release levels should be set at compile time and are not 
 changeable at run-time.
 
-##### 6.1.8.2 Protocol Numbers
+#### 6.1.8.2 Protocol Numbers
 
 The protocol number is a structure of type **ProtocolNumber** stored in the 
 file's FEA_PROTOCOL extended attribute. Each GEOS geode and data file has 
@@ -959,7 +959,7 @@ increment the major protocol.
 major protocol. Otherwise, the flags will be restored from the state file 
 and will override the changes you made.
 
-#### 6.1.9 Temporary Geode Memory
+### 6.1.9 Temporary Geode Memory
 
 GeodePrivAlloc(), GeodePrivFree(), GeodePrivWrite(), 
 GeodePrivRead()
@@ -1004,7 +1004,7 @@ know that other geodes are also using the same routines.
 data. It needs to be passed only the number of words to be freed and the tag 
 as returned by **GeodePrivAlloc()**.
 
-### 6.2 Creating Icons
+## 6.2 Creating Icons
 
 Every geode can have an icon associated with it. Typically, only applications 
 will have special icons; other geodes (libraries and drivers) generally use one 
@@ -1018,7 +1018,7 @@ The GEOS development kit includes an icon editor tool so you can easily
 create icons of various color and resolution characteristics and install them 
 into your applications.
 
-#### 6.2.1 The Token Database
+### 6.2.1 The Token Database
 
 TokenOpenLocalTokenDB(), TokenCloseLocalTokenDB()
 
@@ -1162,7 +1162,7 @@ returns a dword. The lower word of the return value is the handle of the
 global memory block; the upper word is the number of **GeodeToken** 
 structures in that block.
 
-### 6.3 Saving User Options
+## 6.3 Saving User Options
 
 Almost all users enjoy configuring their systems to their own tastes, whether 
 it's setting the background bitmap or choosing a default font. Most 
@@ -1176,7 +1176,7 @@ However, sometimes you will want to set additional options not managed by
 UI objects. This is not difficult to do in GEOS: You can have your application 
 save its options directly to the local initialization file, GEOS.INI.
 
-#### 6.3.1 Saving Generic Object Options
+### 6.3.1 Saving Generic Object Options
 
 All appropriate generic UI objects have the ability to save their options. For 
 example, a properties GenInteraction could save which of its options are on 
@@ -1242,7 +1242,7 @@ Code Display 6-2 Saving Generic Object Options
 }
 ~~~
 
-#### 6.3.2 The GEOS.INI File
+### 6.3.2 The GEOS.INI File
 
 GEOS can use multiple initialization files in network situations, but only the 
 local GEOS.INI is editable. The local GEOS.INI (referred to hereafter simply 
@@ -1254,7 +1254,7 @@ then in any others in the order they were loaded. When it reaches what it
 wants, it stops searching. Thus, multiple entries are allowed but are not 
 used, and the local INI file has precedence over all others.
 
-##### 6.3.2.1 Configuration of the INI File
+#### 6.3.2.1 Configuration of the INI File
 
 The GEOS.INI file has a very specific format and syntax. It is segmented into 
 categories, each of which contains several keys that determine how GEOS will 
@@ -1343,7 +1343,7 @@ blob of text with curly
 brace ({,\}) characters \}\} in it}
 ~~~
 
-##### 6.3.2.2 Managing the INI File
+#### 6.3.2.2 Managing the INI File
 
 InitFileSave(), InitFileRevert(), 
 InitFileGetTimeLastModified(), InitFileCommit()
@@ -1373,7 +1373,7 @@ the last time GEOS.INI was modified.
 modified and flushes them to disk. This commits all the changes and should 
 be used only from the kernel. It should not be used by applications.
 
-##### 6.3.2.3 Writing Data to the INI File
+#### 6.3.2.3 Writing Data to the INI File
 
 InitFileWriteData(), InitFileWriteString(), 
 InitFileWriteStringSection(), InitFileWriteInteger(), 
@@ -1415,7 +1415,7 @@ with a text editor, the Boolean value will appear as a text string of either
 "true" or "false"; it will, however, be interpreted as a Boolean rather than a 
 text string.
 
-##### 6.3.2.4 Getting Data from the INI File
+#### 6.3.2.4 Getting Data from the INI File
 
 InitFileReadDataBuffer(), InitFileReadDataBlock(), 
 InitFileReadStringBuffer(), InitFileReadStringBlock(), 
@@ -1470,7 +1470,7 @@ routine if you don't know the approximate size of the string section.
 **InitFileEnumStringSection()** enumerates the specified blob, executing a 
 specified callback routine on each string section within the blob.
 
-##### 6.3.2.5 Deleting Items from the INI File
+#### 6.3.2.5 Deleting Items from the INI File
 
 InitFileDeleteEntry(), InitFileDeleteCategory(), 
 InitFileDeleteStringSection()
@@ -1488,14 +1488,14 @@ blob as well as the index of the string section, and it deletes the string secti
 If the string section does not exist or if either the key or category can not be 
 found, the routine will return an error flag.
 
-### 6.4 General System Utilities
+## 6.4 General System Utilities
 
 The kernel provides a number of routines that fulfill general needs for system 
 utilities. These range from setting the system's date and time to retrieving 
 the amount of swap memory used to shutting down the system in order to 
 execute a DOS-based program.
 
-#### 6.4.1 Changing the System Clock
+### 6.4.1 Changing the System Clock
 
 TimerGetDateAndTime(), TimerSetDateAndTime()
 
@@ -1506,7 +1506,7 @@ minute, and second. **TimerSetDateAndTime()** sets the current date and
 time to the values in the passed structure. It is unusual for any application 
 other than the Preferences Manager to change the system clock.
 
-#### 6.4.2 Using Timers
+### 6.4.2 Using Timers
 
 TimerStart(), TimerStop(), TimerSleep(), TimerGetCount()
 
@@ -1552,7 +1552,7 @@ An additional routine, **TimerGetCount()**, returns the current system
 counter. The system counter contains the number of ticks counted since 
 GEOS was started.
 
-#### 6.4.3 System Statistics and Utilities
+### 6.4.3 System Statistics and Utilities
 
 SysStatistics(), SysGetInfo(), SysGetConfig(), 
 SysGetPenMode(), SysGetDosEnvironment()
@@ -1586,7 +1586,7 @@ pen-based machine.
 variable. It is passed a string representing the variable name and returns a 
 string representing the value.
 
-#### 6.4.4 Shutting the System Down
+### 6.4.4 Shutting the System Down
 
 DosExec(), SysShutdown()
 
@@ -1631,7 +1631,7 @@ with SST_CONFIRM_END to release exclusive access). This is useful if your
 application or library has an ongoing operation and wants to verify the 
 shutdown with the user.
 
-### 6.5 The Error-Checking Version
+## 6.5 The Error-Checking Version
 
 GEOS has two versions of its system software. The normal version as shipped 
 retail is the "non-error-checking" version. The other, used for debugging 
@@ -1647,7 +1647,7 @@ their entries in the Routine Reference Book. In addition to the full error
 checking provided by the EC versions of the system geodes, you can add your 
 own error-checking code to your programs. 
 
-#### 6.5.1 Adding EC Code to Your Program
+### 6.5.1 Adding EC Code to Your Program
 
 When compiling your code, you can include certain extra lines in either the 
 EC version or the non-EC version of your program. For example, during 
@@ -1717,7 +1717,7 @@ Code Display 6-4 EC Macros
      EC_BOUNDS(myPointer)
 ~~~
 
-#### 6.5.2  Special EC Routines
+### 6.5.2  Special EC Routines
 
 SysGetECLevel(), SysSetECLevel(), SysNotify(), EC-(), 
 CFatalError(), CWarningNotice()
@@ -1744,7 +1744,7 @@ Swat, causes Swat to hit a breakpoint so you can debug the error.
 **CWarningNotice()** may be put in error-checking code to make the compiler 
 put up a compile-time warning note.
 
-### 6.6 Inter-Application Communication
+## 6.6 Inter-Application Communication
 
 Applications do not usually need to communicate with each other. Most 
 applications will interact only with the kernel and with libraries; such 
@@ -1769,7 +1769,7 @@ The GEOS Inter-Application Communications Protocol (IACP) specifies how
 to open communications with another application, and how to send messages 
 back and forth.
 
-#### 6.6.1 IACP Overview
+### 6.6.1 IACP Overview
 
 There is a major difference between sending a message within an 
 application, and sending one to a different application. When you send a 
@@ -1843,7 +1843,7 @@ every server for a list is assigned a distinct **ServerNumber**. If it chooses t
 a client can specify that a message be sent only to the server with a specific 
 number.
 
-#### 6.6.2 GenApplicationClass Behavior
+### 6.6.2 GenApplicationClass Behavior
 
 **GenApplicationClass** is built to support IACP automatically. If a server or 
 client object is subclassed from GenApplicationClass, most of the work of 
@@ -1893,7 +1893,7 @@ down all IACP links the Application object has open, whether it is a client
 or a server on those links. You can subclass this message if you need to 
 take some additional action when the IACP connections are severed.
 
-#### 6.6.3 Messages Across an IACP Link
+### 6.6.3 Messages Across an IACP Link
 
 IACPSendMessage(), IACPSendMessageToServer()
 
@@ -1941,13 +1941,13 @@ returns the number of times the message was dispatched. This will
 ordinarily be one; however, if the specified server is no longer registered, it 
 will be zero.
 
-#### 6.6.4 Being a Client
+### 6.6.4 Being a Client
 
 Any object can register as a client for an IACP server list. When an object is 
 a client, it can send messages to the server list, which will pass them along 
 to the servers for that list.
 
-##### 6.6.4.1 Registering as a Client
+#### 6.6.4.1 Registering as a Client
 
 IACPConnect(), IACPCreateDefaultLaucnhBlock()
 
@@ -2083,7 +2083,7 @@ instruct it to print the file. To make the server open a document, pass the
 document's name in ALB_dataFile. The server will open the file when you 
 register, and close it when you unregister.
 
-##### 6.6.4.2 Unregistering as a Client
+#### 6.6.4.2 Unregistering as a Client
 
 IACPShutdown(), IACPShutdownAll()
 
@@ -2107,7 +2107,7 @@ objects on the other side of the link; that is, if a client calls
 The Application object automatically calls this routine when the application 
 is exiting.
 
-#### 6.6.5 Being a Server
+### 6.6.5 Being a Server
 
 Every time an application is launched, its Application object automatically 
 registers as a server for the server list that shares its **GeodeToken**. The 
@@ -2121,7 +2121,7 @@ of object, **MetaClass** does not come with handlers for these messages; if the
 server is not subclassed from **GenApplicationClass**, you will have to write 
 the handlers yourself. This is discussed below.
 
-##### 6.6.5.1 Registering and Unregistering a Server
+#### 6.6.5.1 Registering and Unregistering a Server
 
 IACPRegisterServer(), IACPUnregisterServer()
 
@@ -2185,7 +2185,7 @@ server object can find out its server number by calling
 **GeodeToken** of the server list, and the optr to the server object. It returns 
 the object's server number.
 
-##### 6.6.5.2 Non-Application Servers and Clients
+#### 6.6.5.2 Non-Application Servers and Clients
 
 MSG_META_IACP_PROCESS_MESSAGE, IACPProcessMessage(), 
 MSG_META_IACP_NEW_CONNECTION, 

--- a/TechDocs/Markdown/Concepts/carch.md
+++ b/TechDocs/Markdown/Concepts/carch.md
@@ -1,4 +1,4 @@
-## 3 System Architecture
+# 3 System Architecture
 
 This chapter describes the structure of GEOS and the various system 
 components and services used by applications. Nearly all programmers will 
@@ -6,7 +6,7 @@ want at least to browse this chapter before continuing with GEOS application
 development. The structures and architectures of the 8088 and 80x86 
 processors are reviewed in [Appendix A](chardw.md).
 
-### 3.1 GEOS Overview
+## 3.1 GEOS Overview
 
 GEOS is a state-of-the-art graphical operating system combining the latest 
 software technology with numerous innovations. Its tightly coded assembly 
@@ -57,7 +57,7 @@ developer's kit. This chapter provides the background information necessary,
 however, to take full advantage of all that GEOS has to offer the application 
 developer.
 
-### 3.2 The System Architecture
+## 3.2 The System Architecture
 
 The GEOS system as a whole consists of several layers. The topmost layer 
 contains applications. Users interact directly with these applications, which 
@@ -79,7 +79,7 @@ and libraries. Note that this is a simplified diagram, and not all system
 components are represented._
 
 
-#### 3.2.1 Applications
+### 3.2.1 Applications
 
 A GEOS application can take advantage of the various kernel and UI 
 mechanisms to provide some set of functionality to the user. An application 
@@ -88,7 +88,7 @@ interface using objects and functions provided by the User Interface Library.
 The second part consists of the code of the application including procedures, 
 functions, and object-specific code.
 
-#### 3.2.2 Libraries
+### 3.2.2 Libraries
 
 GEOS libraries are bodies of code or collections of objects that are 
 dynamically loaded into memory when called for by applications or by other 
@@ -102,7 +102,7 @@ developers. Among these are a text object library, a graphic object library, a
 an import/export library and others. In addition, developers can easily create 
 their own libraries with the developer kit tools.
 
-#### 3.2.3 The Kernel
+### 3.2.3 The Kernel
 
 The GEOS kernel is the core of the operating system, providing all the basic 
 services needed by the system. It provides multitasking, memory 
@@ -112,7 +112,7 @@ dispatching, and scores of basic graphic primitives. The kernel provides
 nearly 1000 routines usable by applications and libraries, though most 
 applications will use only a portion of them.
 
-#### 3.2.4 Device Drivers
+### 3.2.4 Device Drivers
 
 GEOS device drivers isolate the system and applications from the specific 
 needs and foibles of a user's hardware. Drivers translate the generic actions 
@@ -130,7 +130,7 @@ able to develop their own drivers for new hardware and file systems.
 Most applications and libraries will access drivers through kernel calls. 
 Drivers are also accessible to applications and libraries directly.
 
-#### 3.2.5 The User Interface
+### 3.2.5 The User Interface
 
 The GEOS User Interface (UI) is a special entity. While it consists primarily 
 of dynamic libraries, it can be thought of as a user interface driver.
@@ -165,7 +165,7 @@ For example, a dialog box that has three buttons within it may have the hint
 HINT_ORIENT_CHILDREN_VERTICALLY to indicate the buttons should 
 appear in a column rather than a row.
 
-### 3.3 Object-Oriented Programming
+## 3.3 Object-Oriented Programming
 
 Object-Oriented Programming (OOP) is a popular way of organizing 
 programs, especially programs using graphical user interfaces. GEOS is an 
@@ -208,7 +208,7 @@ implemented again and again. Instead, one version of the code can exist
 in a particular class and be inherited by other classes, thus reducing 
 coding and debugging time.
 
-#### 3.3.1 Objects, Messages, and Methods
+### 3.3.1 Objects, Messages, and Methods
 
 Procedural programming uses routines that act with globally-accessible or 
 locally-defined data. Those routines must know about other routines in the 
@@ -324,7 +324,7 @@ Requestor then does other tasks while the Calculator performs the calculation
 (State B). When the calculation is finished, the Calculator sends the result 
 back to the Requestor with MSG_RETURN_RESULT (State C)._
 
-#### 3.3.2 Classes and Inheritance
+### 3.3.2 Classes and Inheritance
 
 If every object had to be coded and debugged once for each time it was used, 
 OOP would provide few benefits over standard procedural programming. 
@@ -389,7 +389,7 @@ not initially know what their superclass is; instead, the superclass is
 determined by context for each instance of the variant class. This is a 
 complicated topic that is discussed later in the documentation.
 
-### 3.4 Multitasking and Multithreading
+## 3.4 Multitasking and Multithreading
 
 Multitasking is the ability to have multiple processes running 
 simultaneously on a single system. In actuality, PCs have only one processor 
@@ -434,7 +434,7 @@ can make the application appear to be extraordinarily fast; the user can
 continue to navigate menus and use other UI gadgetry while the application 
 is also doing something else.
 
-### 3.5 The GEOS User Interface
+## 3.5 The GEOS User Interface
 
 The GEOS User Interface (UI) maintains the interaction between each 
 application and the user. It provides several necessary and many extra 
@@ -442,7 +442,7 @@ services for applications, relieving programmers from building much of the
 basic UI functionality into their applications. The structure, components, and 
 services of the GEOS UI are outlined below.
 
-#### 3.5.1 The Generic User Interface
+### 3.5.1 The Generic User Interface
 
 A User Interface (UI) specification is, essentially, a set of rules and 
 conventions used to determine the interaction between a user and an 
@@ -478,7 +478,7 @@ each generic object (for example, a GenPrimary window object can have
 special sizing restrictions suggested with various hints such as 
 HINT_FIXED_SIZE and HINT_INITIAL_SIZE).
 
-##### 3.5.1.1 Attributes
+#### 3.5.1.1 Attributes
 
 Attributes represent objective information which does not change with the 
 specific UI in use. In general, attributes determine the basic functionality of 
@@ -494,7 +494,7 @@ specifying whether it is scrollable or not. Attributes are used, therefore,
 primarily for determining the object's functionality rather than its 
 appearance.
 
-##### 3.5.1.2 Hints
+#### 3.5.1.2 Hints
 
 Hints represent subjective or contextual information about objects. Hints are 
 different from attributes in two main aspects: First, hints may be ignored by 
@@ -510,7 +510,7 @@ fewer hints use less memory. Attributes, on the other hand, must exist in the
 object's instance data whether they are used or not, and they therefore 
 require a given amount of memory.
 
-##### 3.5.1.3 The Generic UI Classes
+#### 3.5.1.3 The Generic UI Classes
 
 The Generic UI Library contains a number of object classes that implement 
 nearly all the UI functions an application will ever need. For a full description 
@@ -518,7 +518,7 @@ of the API of each of these classes, see the [Objects Book](../objects.md). Some
 the more common implementations (e.g. menus, dialog boxes, and scrolling views) of 
 these objects are outlined in the sections below.
 
-#### 3.5.2 The Scalable User Interface
+### 3.5.2 The Scalable User Interface
 
 As application technology advances, applications gain more and more 
 features. Despite recent improvements in user-friendliness, however, 
@@ -530,7 +530,7 @@ application, each version at a different level of complexity. Scalability of
 applications is shown in Geoworks Pro-the appliances are all created from 
 exactly the same source code as the advanced versions of those applications.
 
-#### 3.5.3 Windows and Window Management
+### 3.5.3 Windows and Window Management
 
 A window is an object that defines an area on the screen in which drawing 
 and user interaction can occur. Windows may be resizable and movable, and 
@@ -562,7 +562,7 @@ in order to ensure the proper portion of the data is drawn. Additionally,
 applications can modify any of the scrolling, scaling, or sizing behavior with 
 a little effort to provide custom functionality.
 
-#### 3.5.4 Input
+### 3.5.4 Input
 
 GEOS has an input manager that tracks the mouse, gets keyboard input, and 
 passes the input events on to the proper windows and objects on the screen. 
@@ -589,7 +589,7 @@ applications likely will want to filter certain input or handle special cases.
 Simple applications or utilities will probably not have to deal with input 
 (keyboard or mouse events) directly at all.
 
-#### 3.5.5 Menus and Dialog Boxes
+### 3.5.5 Menus and Dialog Boxes
 
 Among the generic objects of the GEOS UI library is GenInteraction. This 
 object can be used to implement menus, dialog boxes, and error boxes, and it 
@@ -608,7 +608,7 @@ The sections below outline some of the practical functionality of these objects;
 for a full description of what these do and how they can be used, see the 
 Object Reference Book.
 
-##### 3.5.5.1 Menus
+#### 3.5.5.1 Menus
 
 Menus in GEOS are subject to the rules and conventions of the specific UI in 
 use by the user. However, several basic concepts are supported. (See 
@@ -669,7 +669,7 @@ given the ability to be pinned in place and moved around the screen.
 Because this is a function of the specific UI, applications are completely 
 unaware of the fact.
 
-##### 3.5.5.2 Dialog Boxes
+#### 3.5.5.2 Dialog Boxes
 
 Dialog boxes are standard ways of having an application interact with the 
 user. For example, a dialog box may contain a number of controls that 
@@ -721,7 +721,7 @@ includes several standard dialog box types accessible through the use of
 UI routines. These include errors, warnings, and questions. Also, you can 
 call up custom dialog boxes with special kernel routines.
 
-#### 3.5.6 Scrolling Views
+### 3.5.6 Scrolling Views
 
 Although the basic generic objects provided by GEOS are powerful and useful 
 in many situations, applications still need a way to display their own specific 
@@ -793,7 +793,7 @@ This can, however, be set to any RGB value or to any GEOS color index.
 This is used, for example, in Solitaire to create the green background (so 
 the application does not have to draw green under all the other objects).
 
-#### 3.5.7 Visible Object Classes
+### 3.5.7 Visible Object Classes
 
 Many applications will need to create objects that draw themselves and 
 interact directly with the user. Rather than forcing the programmer to create 
@@ -803,7 +803,7 @@ application needs a visible object, it simply defines a subclass of one of these
 visible classes, thus ensuring that his object will handle all the UI messages 
 that may be sent to it.
 
-#### 3.5.8 Geometry Manager
+### 3.5.8 Geometry Manager
 
 The GEOS User Interface includes a sophisticated Geometry Manager that 
 does all the calculations for organization of objects on the screen. The 
@@ -811,7 +811,7 @@ Geometry Manager manages the positions of generic UI objects in dialog
 boxes and windows, for example, and it can be used to automatically position 
 visible objects within a view.
 
-#### 3.5.9 Lists
+### 3.5.9 Lists
 
 The GenItem, GenItemGroup, GenBoolean, GenBooleanGroup, and 
 GenDynamicList objects can be used to provide several different types and 
@@ -839,7 +839,7 @@ Non-exclusive lists with an override have a non-exclusive list with an
 additional element that overrides all the others (an example is the text 
 styles menu-the "Plain" option overrides each of the others).
 
-#### 3.5.10 Other Gadgets
+### 3.5.10 Other Gadgets
 
 Besides the objects listed above, the generic UI supplies a number of other 
 gadgets. These include
@@ -872,7 +872,7 @@ The GenFileSelector provides all the features of a file selector dialog box
 that allows the user to traverse their file system's directories and select 
 a file.
 
-#### 3.5.11 Managing Documents and Files
+### 3.5.11 Managing Documents and Files
 
 Most applications will save data files. GEOS provides a convenient storage 
 format for data files and an even more convenient mechanism for managing 
@@ -890,7 +890,7 @@ take basic functionality common to most applications and implement it in the
 system software. Using a Document Control for your data file management 
 can save weeks of coding and debugging time.
 
-#### 3.5.12 Multiple Document Interface
+### 3.5.12 Multiple Document Interface
 
 Some applications may benefit from allowing the user to have multiple data 
 files open at any given time. GeoWrite and GeoDraw, for example, allow the 
@@ -905,7 +905,7 @@ proper data files are being operated on at all times. The Display Control also
 creates and maintains the Window menu, just as the Document Control 
 creates and maintains the File menu.
 
-#### 3.5.13 Clipboard and Quick-Transfer
+### 3.5.13 Clipboard and Quick-Transfer
 
 A common feature of GUIs is the Clipboard. Users can copy or cut data out of 
 documents for pasting into other documents (or even the same document) 
@@ -927,7 +927,7 @@ automatically by all text edit and display objects. Applications may define
 their own custom data formats (transfer items) for use with both the 
 Clipboard and the quick-transfer mechanism.
 
-#### 3.5.14 General Change Notification
+### 3.5.14 General Change Notification
 
 In a multithreaded system, one thread may change some information that 
 another thread depends on. In this case, the thread that makes the change 
@@ -943,7 +943,7 @@ network game depended on each user knowing a certain status flag,
 automatic notification could be set up to notify all the users whenever any 
 user changed it.
 
-#### 3.5.15 Help Object
+### 3.5.15 Help Object
 
 On-line help is a convenient and powerful way to provide documentation to 
 your users. Because graphical user interfaces are easy to understand, many 
@@ -957,14 +957,14 @@ defined by the application. The application simply has to provide the help
 text and a few other attributes of the help object, and the system will take 
 care of displaying the help when the user requests it.
 
-### 3.6 System Services
+## 3.6 System Services
 
 GEOS provides a number of services useful or necessary to applications. 
 These services range from dynamic memory management to an item 
 database to a sophisticated graphics system and a print spooler. Many of the 
 most useful or integral services are described in this section.
 
-#### 3.6.1 Memory
+### 3.6.1 Memory
 
 GEOS uses all RAM available to the system, even expanded and extended 
 memory. Memory is managed by the kernel and is accessed in the segmented 
@@ -976,7 +976,7 @@ The GEOS Memory Manager is sophisticated. It uses dynamic allocation and
 access of blocks on a global heap to provide high performance, optimized to 
 run very efficiently even on systems with only 640 K.
 
-##### 3.6.1.1 Handles
+#### 3.6.1.1 Handles
 
 GEOS maintains control of all the memory, objects, and other entities in the 
 system through the Handle Table. The Handle Table is a section of memory 
@@ -999,7 +999,7 @@ single execution of GEOS. Applications and libraries may allocate handles
 dynamically for most of the above-mentioned purposes (e.g. memory and file 
 reference).
 
-##### 3.6.1.2 The Global Heap
+#### 3.6.1.2 The Global Heap
 
 A certain amount of memory is set aside for the file system (DOS, typically), 
 the GEOS kernel (approximately 64 K), and any TSRs the user may have 
@@ -1037,7 +1037,7 @@ Swapable blocks may be swapped at any time by the Memory Manager.
 When a subsequent access is made to a swapped block, the Memory 
 Manager will automatically read the block back into memory.
 
-##### 3.6.1.3 Allocating Memory
+#### 3.6.1.3 Allocating Memory
 
 The GEOS kernel provides several routines to allocate memory. Some 
 memory is allocated automatically, such as memory for code resources as 
@@ -1062,7 +1062,7 @@ When an application is done with a memory block, it can free the block with
 the routine **MemFree()**. This will allow the Memory Manager to free up that 
 memory space and re-use the block's handle if required.
 
-##### 3.6.1.4 Accessing Memory
+#### 3.6.1.4 Accessing Memory
 
 If a block is allocated as fixed, an application can use a far pointer to access 
 any byte within the block. However, because fixed blocks are not always 
@@ -1077,7 +1077,7 @@ far pointer to the block. When access to the block is finished, the thread that
 locked the block must call **MemUnlock()**, which marks the block as 
 unlocked so it may once again be moved or swapped.
 
-#### 3.6.2 Virtual Memory
+### 3.6.2 Virtual Memory
 
 GEOS implements a powerful virtual memory concept to accomplish both 
 memory block swapping and data file storage. Virtual memory (VM) can be 
@@ -1090,7 +1090,7 @@ memory and locks it on the global heap.
 VM is extremely useful for data file storage; indeed, the Document Control 
 objects use it extensively.
 
-#### 3.6.3 Local Memory and Object Blocks
+### 3.6.3 Local Memory and Object Blocks
 
 Often applications will want to store large numbers of very small data items. 
 In these cases, it's cumbersome and inefficient to allocate a global handle and 
@@ -1120,7 +1120,7 @@ global handle and chunk handle of an object is known as the Object Pointer
 (optr) of the object. The optr is used to identify the object uniquely in the 
 system for all types of access.
 
-#### 3.6.4 Item Database Library
+### 3.6.4 Item Database Library
 
 The GEOS database library allows applications to use LMem heaps and VM 
 files together easily and cleanly. The database library allows applications to 
@@ -1136,14 +1136,14 @@ Additionally, items may be allocated as "ungrouped," in which case the
 database manager will intelligently distribute these items among the various 
 VM blocks in the database file for efficient access.
 
-#### 3.6.5 Graphics System
+### 3.6.5 Graphics System
 
 The graphics system provided in the GEOS kernel is extremely powerful and 
 is designed to make creating graphics simple and fast for applications. It 
 includes some advanced concepts and state-of-the-art technology that make 
 GEOS rise well above most other GUIs.
 
-##### 3.6.5.1 The Coordinate Space
+#### 3.6.5.1 The Coordinate Space
 
 The GEOS graphics system uses a single imaging model like that used by 
 PostScript. Applications and libraries draw their graphics on a generic 
@@ -1162,7 +1162,7 @@ can be up to 900 miles on a side! Large documents, however, can incur a
 certain amount of additional overhead; if you do not need to use large 
 documents, you probably should not.
 
-##### 3.6.5.2 Graphic States
+#### 3.6.5.2 Graphic States
 
 To simplify complex drawing, the graphics system maintains a graphics 
 state, or GState. GStates can be created or destroyed dynamically to allow 
@@ -1185,7 +1185,7 @@ Programs may apply transformations to GStates-rotation, translation, or
 scaling. You can also define custom transformation matrixes to apply to your 
 GStates if complex operations (e.g. shearing) are required.
 
-##### 3.6.5.3 Graphic Primitives and Graphic Objects
+#### 3.6.5.3 Graphic Primitives and Graphic Objects
 
 GEOS provides a complete set of graphics drawing primitives including lines, 
 arcs, B\E9zier curves, splines, outline-defined text, rectangles, ellipses, 
@@ -1198,7 +1198,7 @@ and to resize, reshape, reposition, and rotate themselves. These objects are
 available to all applications and other libraries, and they provide a powerful 
 base of user-interactive graphics tools.
 
-##### 3.6.5.4 Paths
+#### 3.6.5.4 Paths
 
 A graphics path in GEOS is a continuous trail that defines the outline of an 
 area. A path is an outline description of an arbitrarily shaped area, useful 
@@ -1210,14 +1210,14 @@ One example of the powerful application of paths is creation of arbitrary
 clipping regions. It is possible, for example, to clip drawings to an ellipse, to 
 a bezier curve, or even to text.
 
-##### 3.6.5.5 Regions
+#### 3.6.5.5 Regions
 
 Regions perform essentially the same function as paths-definition of an 
 arbitrarily shaped area or clipping region. However, because regions are 
 defined as resolution-dependent, they are typically used only for optimized 
 drawing of UI gadgetry.
 
-##### 3.6.5.6 Graphics Strings
+#### 3.6.5.6 Graphics Strings
 
 A graphics string (or GString) is a collection of graphics commands; GStrings 
 are useful for saving complex graphic operations and playing them back 
@@ -1233,7 +1233,7 @@ the GString data format for cut, copy, and paste operations. GStrings are also
 flexible-they may contain comments and may be set up to be executed with 
 parameters.
 
-##### 3.6.5.7 Bitmaps
+#### 3.6.5.7 Bitmaps
 
 Bitmaps are pixel-by-pixel images defined at a specific resolution; they are 
 automatically scaled to match the resolution of the display. Bitmaps are used 
@@ -1244,7 +1244,7 @@ be created off-screen and may be edited with standard graphics system
 commands. Bitmaps are used mainly as monikers of generic objects and as 
 icons for applications and data files.
 
-##### 3.6.5.8 Color
+#### 3.6.5.8 Color
 
 GEOS allows applications to specify colors in two ways: with the system 
 palette and with RGB values. The palette contains 256 entries, each of which 
@@ -1254,7 +1254,7 @@ than 256 colors, it can specify any RGB value for any given graphics
 operation. The palette may also be expanded to support other color models. 
 If the system palette is not sufficient, each application may create its own.
 
-#### 3.6.6 Text
+### 3.6.6 Text
 
 Text in GEOS is handled by the Text Object, a sophisticated and powerful 
 object that is the base for both the GenText and the VisText classes. The Text 
@@ -1302,7 +1302,7 @@ the UI and handles the cut, copy, and paste commands of the Edit menu.
 For full feature listings and how to use the text object, see ["The Text 
 Objects," Chapter 10 of the Object Reference Book](../Objects/otext.md).
 
-#### 3.6.7 Print Spooler and Printing
+### 3.6.7 Print Spooler and Printing
 
 GEOS contains a print spooler that manages printing for all applications in 
 the system. The spooler executes in its own threads and manages a print 
@@ -1322,7 +1322,7 @@ necessary to print the document properly. For example, a document eleven
 inches by seventeen inches will be rotated and printed on two standard-sized 
 sheets of paper.
 
-#### 3.6.8 Timers
+### 3.6.8 Timers
 
 The GEOS kernel allows applications and libraries to set up different types of 
 timers that can be used for various purposes. When a timer ticks, it calls a 
@@ -1345,7 +1345,7 @@ of time.
 (if the thread does not gain the semaphore in the given length 
 of time, it is removed from the queue).
 
-#### 3.6.9 Streams
+### 3.6.9 Streams
 
 Streams are like one-way pipes that allow a thread to send data to or receive 
 data from another thread or I/O port. Typically, streams are used when 
@@ -1356,7 +1356,7 @@ GEOS has a Stream Driver that manages input to and output from streams.
 Additionally, a Parallel Driver manages output to a parallel port, and a Serial 
 Driver manages input from and output to a serial port.
 
-#### 3.6.10 Math support
+### 3.6.10 Math support
 
 GEOS has a number of routines that accomplish complex mathematical 
 calculations. There are also routines that do matrix manipulation and 
@@ -1364,7 +1364,7 @@ complicated linear algebra operations. In addition, the system provides a
 library of routines to implement simple fixed-point math and complicated 
 floating-point operations.
 
-#### 3.6.11 International Support
+### 3.6.11 International Support
 
 International markets are extremely important to Geoworks due to the large 
 number of PCs in use in countries other than the United States. Therefore, 
@@ -1381,7 +1381,7 @@ to access different DOS character sets. These routines ensure that an
 English-language program will work on machines with different DOS 
 character sets.
 
-### 3.7 Libraries
+## 3.7 Libraries
 
 The use of dynamically-linkable libraries is key to the efficiency of GEOS 
 applications. Several libraries are included in addition to the libraries 
@@ -1419,7 +1419,7 @@ functionality of a spreadsheet application.
 The CD ROM Library ("cdrom") provides all the routines necessary to 
 interface with standard Microsoft CD ROM extensions.
 
-### 3.8 Device Drivers
+## 3.8 Device Drivers
 
 GEOS does as much as possible to isolate applications from the hardware in 
 use. Not only does this allow applications to run with thousands of different 

--- a/TechDocs/Markdown/Concepts/cbuild.md
+++ b/TechDocs/Markdown/Concepts/cbuild.md
@@ -1,4 +1,4 @@
-## 2 Building Your Application
+# 2 Building Your Application
 
 The GEOS system is complex and provides so many services that the 
 documentation at first may seem rather daunting. This chapter is meant to 
@@ -9,7 +9,7 @@ This chapter is by no means a comprehensive list of all functions supported
 by GEOS. It is intended to be a guide to the chapters that cover some of the 
 more widely-used functions and features.
 
-### 2.1 What Everyone Should Read
+## 2.1 What Everyone Should Read
 
 Anyone who wants to program a GEOS application should read at least the 
 first several chapters of the Concepts Book. Among the chapters you should 
@@ -44,13 +44,13 @@ user to drag them around the screen. The sample application also
 illustrates how to create your own objects from the base GEOS visual 
 classes.
 
-### 2.2 Topics Listing
+## 2.2 Topics Listing
 
 Listed below are many of the topics related to creating an application. 
 Accompanying the topic is a list of chapters you will probably want to read to 
 fully understand that topic.
 
-#### 2.2.1 Defining Your User Interface
+### 2.2.1 Defining Your User Interface
 
 ["The GEOS User Interface", Chapter 10](cuiover.md), gives an overview of the User 
 Interface and which objects you will want to use. Many user interface 
@@ -124,7 +124,7 @@ Library", Chapter 15 of the Object Reference Book](../Objects/ohelp.md).
 Many applications may want to track mouse or keyboard input. Input 
 management is discussed in ["Input", Chapter 11](cinput.md).
 
-#### 2.2.2 Providing Other User Interface
+### 2.2.2 Providing Other User Interface
 
 Besides the generic UI functions and objects described above, GEOS provides 
 a number of sophisticated graphics commands and powerful graphic objects. 
@@ -153,7 +153,7 @@ know how to position, resize, and draw themselves as well as handle user
 input. This library is described in ["Drawing Graphics", Chapter 24](cshapes.md) and 
 ["Graphic Object Library", Chapter 18 of the Object Reference Book](../Objects/ogrobj.md).
 
-#### 2.2.3 Documents and Data Structures
+### 2.2.3 Documents and Data Structures
 
 Applications that save files, print documents, or display multiple documents 
 will be concerned with several of the topics listed below.
@@ -195,7 +195,7 @@ Chapter 20 of the Object Reference Book](../Objects/ossheet.md).
 If your application will print anything to a printer or to a file, you should 
 read ["The Spool Library", Chapter 17 of the Object Reference Book](../Objects/oprint.md).
 
-#### 2.2.4 Accessing Hardware
+### 2.2.4 Accessing Hardware
 
 GEOS is designed to allow applications to be as device-independent as 
 possible. Some applications will need to access hardware directly, however.
@@ -220,7 +220,7 @@ In general, GEOS takes care of all video driver operations; applications
 deal with the graphics system, which sends commands to the video 
 drivers. For more information, see ["Graphics Environment", Chapter 23](cgraph.md).
 
-#### 2.2.5 Programming Topics
+### 2.2.5 Programming Topics
 
 A number of programming topics specific to Goc are described in ["GEOS 
 Programming", Chapter 5](ccoding.md). This chapter discusses the various Goc keywords 
@@ -231,7 +231,7 @@ chapter if you plan on programming for GEOS using the C programming language.
 For information on programming in assembly, see the Esp manual. It 
 explains GEOS's extensions to standard 80x86 assembly-language programming
 
-#### 2.2.6 Other Topics
+### 2.2.6 Other Topics
 
 Many other topics are discussed throughout the documentation. Some of 
 those more commonly used are listed below.

--- a/TechDocs/Markdown/Concepts/cclipb.md
+++ b/TechDocs/Markdown/Concepts/cclipb.md
@@ -1,4 +1,4 @@
-## 7 The Clipboard
+# 7 The Clipboard
 
 For an application to survive in the GUI world today, it must support at least 
 the ever-present "Cut, Copy, and Paste" functions to which users have grown 
@@ -15,7 +15,7 @@ of mouse input. However, the concepts of the Clipboard and quick-transfer
 mechanisms are simple and may be understood without having read those 
 sections.
 
-### 7.1 Overview
+## 7.1 Overview
 
 The user understands two ways to cut and paste information: The first is to 
 use the Edit menu and the Cut, Copy, and Paste functions. The second is to 
@@ -34,7 +34,7 @@ if you are not familiar with the features and rules governing the Edit menu
 and the quick-transfer operations, you most likely will want to read this 
 section.
 
-#### 7.1.1 Cut, Copy, and Paste
+### 7.1.1 Cut, Copy, and Paste
 
 Even the simplest, text-using applications provide an Edit menu with the 
 Cut, Copy, and Paste options. A sample Edit menu is shown in Figure 7-1.
@@ -72,7 +72,7 @@ this is where the cursor was last placed); if something is already selected, the
 selection will be replaced with the pasted material. If there is nothing on the 
 Clipboard, then there is nothing to paste; therefore, the option is disabled.
 
-#### 7.1.2 Quick-Transfer
+### 7.1.2 Quick-Transfer
 
 The user can copy and move selected items without using the Edit menu; he 
 simply drags the item using the quick-transfer button of his mouse, and the 
@@ -110,7 +110,7 @@ changes. For example, a drawing program may wish to alter the shape or
 color of an object while it is being quick-moved but leave it normal during a 
 quick-copy or no-operation transfer.
 
-### 7.2 Transfer Data Structures
+## 7.2 Transfer Data Structures
 
 Both the Clipboard and quick-transfer mechanisms use similar structures to 
 accomplish data transfer. These data structures are owned and managed by 
@@ -132,7 +132,7 @@ and graphics strings are special formats that are described below. Geodes can
 create their own specific formats; for example, GeoManager uses a special 
 format for quick-transfer of files between disks and directories.
 
-#### 7.2.1 The Transfer VM File Format
+### 7.2.1 The Transfer VM File Format
 
 The Transfer VM File is a normal VM file, managed by the UI. It contains several 
 components, each of which is accessed through special routines that take care of 
@@ -215,7 +215,7 @@ Clipboard and one for the quick-transfer mechanism (see Figure 7-3). When
 calling **ClipboardQueryItem()**, the requesting geode must specify which 
 item it wants. See [section 7.3](#73-using-the-clipboard) and [section 7.4](#74-using-quick-transfer).
 
-#### 7.2.2 ClipboardItemFormatInfo
+### 7.2.2 ClipboardItemFormatInfo
 
 This structure contains information about a specific format of the transfer 
 item. The Transfer VM File will support up to ten formats of a given item at 
@@ -293,7 +293,7 @@ word TypeFromFormatID(type);
 This macro extracts the format ID from the given clipboard format ID and 
 manufacturer value.
 
-#### 7.2.3 Transfer Data Structures
+### 7.2.3 Transfer Data Structures
 
 Two structures are used with specific routines when dealing with the transfer 
 mechanisms. The **ClipboardQueryArgs** structure is returned by 
@@ -356,7 +356,7 @@ This macro extracts the file handle from the given **TransferBlockID** value.
 ~~~
 This macro extracts the block handle from the given **TransferBlockID** value.
 
-#### 7.2.4 Clipboard Item Formats
+### 7.2.4 Clipboard Item Formats
 
 There are several built-in transfer formats that many GEOS applications 
 may support; each of these types is an enumeration of 
@@ -399,7 +399,7 @@ To create a custom format, simply define these two items as appropriate (your
 Manufacturer ID should be set already). Then define your format to fit within 
 the structures used by the Clipboard (shown above).
 
-### 7.3 Using The Clipboard
+## 7.3 Using The Clipboard
 
 ClipboardQueryItem(), ClipboardRegisterItem(), 
 ClipboardDoneWithItem()
@@ -452,7 +452,7 @@ should use **ClipboardQueryItem()**. Since you have no changes to register,
 you must later use **ClipboardDoneWithItem()** to give up your exclusive 
 access to the transfer VM file.
 
-#### 7.3.1 Registering with the Clipboard
+### 7.3.1 Registering with the Clipboard
 
 ClipboardAddToNotificationList()
 
@@ -470,7 +470,7 @@ handler. If the object handling the Clipboard operations is the application's
 Process object, however, it may call **ClipboardAddToNotificationList()** in 
 its MSG_GEN_PROCESS_OPEN_APPLICATION handler.
 
-#### 7.3.2 Managing the Edit Menu
+### 7.3.2 Managing the Edit Menu
 
 MSG_META_CLIPBOARD_NOTIFY_NORMAL_TRANSFER_ITEM_CHANGED, 
 ClipboardTestItemFormat()
@@ -600,7 +600,7 @@ Code Display 7-5 Handling Clipboard Changes
 }
 ~~~
 
-#### 7.3.3 The GenEditControl
+### 7.3.3 The GenEditControl
 
 As stated above, most applications will simply let a GenEditControl object 
 create and maintain their Edit menu. **GenEditControlClass** is a subclass 
@@ -693,7 +693,7 @@ typedef WordFlags GECToolboxFeatures;
     @default GI_attrs = (@default | GA_KBD_SEARCH_PATH);
 ~~~
 
-#### 7.3.4 Handling Cut and Copy
+### 7.3.4 Handling Cut and Copy
 
 MSG_META_CLIPBOARD_CUT, MSG_META_CLIPBOARD_COPY
 
@@ -834,7 +834,7 @@ Code Display 7-8 MSG_META_CLIPBOARD_COPY
 }
 ~~~
 
-#### 7.3.5 Handling Paste
+### 7.3.5 Handling Paste
 
 ClipboardRequestItemFormat(), MSG_META_CLIPBOARD_PASTE
 
@@ -942,7 +942,7 @@ Code Display 7-9 MSG_META_CLIPBOARD_PASTE
 }
 ~~~
 
-#### 7.3.6 Unregistering with the Clipboard
+### 7.3.6 Unregistering with the Clipboard
 
 ClipboardRemoveFromNotificationList()
 
@@ -954,7 +954,7 @@ MSG_GEN_PROCESS_CLOSE_APPLICATION handler you should make a call
 to the routine **ClipboardRemoveFromNotificationList()**, which removes 
 the passed object from the notification list.
 
-#### 7.3.7 Implementing Undo
+### 7.3.7 Implementing Undo
 
 For the most part, implementation of Undo is left up to the application. This 
 is due to the fact that operations that may be undone are typically very 
@@ -964,7 +964,7 @@ MSG_META_UNDO. For more information on Undo and how it works in
 GEOS, see ["UI Messages" of "System Classes," Chapter 1 of the 
 Object Reference Book](../Objects/osyscla.md#1133-ui-messages).
 
-#### 7.3.8 Transfer File Information
+### 7.3.8 Transfer File Information
 
 ClipboardTestItemFormat(), ClipboardEnumItemFormats(), 
 ClipboardGetItemInfo(), ClipboardGetNormalItemInfo(), 
@@ -1000,7 +1000,7 @@ item header for the "Undo" transfer item.
 Return the VM file handle of the UI transfer file (the one 
 typically used when copying, cutting, and pasting).
 
-#### 7.3.9 Undoing a Clipboard Change
+### 7.3.9 Undoing a Clipboard Change
 
 ClipboardUnregisterItem()
 
@@ -1010,7 +1010,7 @@ more than one change to the clipboard. This routine can not "undo" itself;
 that is, calling this routine twice in a row will leave the clipboard in a state 
 other than the original state.
 
-### 7.4 Using Quick-Transfer
+## 7.4 Using Quick-Transfer
 
 An application must understand the Clipboard and its structure before being 
 able to support the quick-transfer feature of the UI. However, because 
@@ -1028,7 +1028,7 @@ a quick transfer is made with the flag CIF_QUICK. When passed to the
 transfer mechanism's routines, this flag indicates that the quick-transfer 
 item should be accessed and the Clipboard data should remain intact.
 
-#### 7.4.1 Supporting Quick-Transfer
+### 7.4.1 Supporting Quick-Transfer
 
 In order for an application to support the quick-transfer mechanism, it must 
 be able to handle several situations. The list below enumerates all the tasks 
@@ -1069,7 +1069,7 @@ of a quick-transfer:
 + Transfers in a format not supported by the destination are "no operation" 
 transfers.
 
-#### 7.4.2 Quick-Transfer Procedure
+### 7.4.2 Quick-Transfer Procedure
 
 Although applications must handle several situations to support the 
 quick-transfer mechanism, the procedure involved in a quick-transfer is 
@@ -1135,14 +1135,14 @@ quick-transfer and must know when the transfer is concluded. If the
 operation is a quick-move, the source must delete the information or 
 object that was moved.
 
-#### 7.4.3 Quick-Transfer Data Structures
+### 7.4.3 Quick-Transfer Data Structures
 
 The quick-transfer mechanism uses the same structures as the Clipboard. 
 However, there are special data structures that are used exclusively by the 
 quick-transfer mechanism. These data structures are used by individual UI 
 routines and are documented with those routines.
 
-#### 7.4.4 Source Object Responsibility
+### 7.4.4 Source Object Responsibility
 
 MSG_META_START_MOVE_COPY, ClipboardStartQuickTransfer(), 
 MSG_META_CLIPBOARD_NOTIFY_QUICK_TRANSFER_FEEDBACK
@@ -1208,7 +1208,7 @@ extra visual feedback to the user. This behavior is not required of the source
 object but can be beneficial to your application. It is also supplemental to the 
 destination-related feedback that must be provided.
 
-##### 7.4.4.1 Responsibilities of a Potential Destination
+#### 7.4.4.1 Responsibilities of a Potential Destination
 
 ClipboardGetQuickTransferStatus(), 
 ClipboardSetQuickTransferFeedback(), 
@@ -1272,7 +1272,7 @@ The object then becomes oblivious to future quick-transfer events until the
 pointer returns to its window (or unless it was registered for notification of 
 quick-transfer conclusion).
 
-##### 7.4.4.2 Responsibilities of the Destination Object
+#### 7.4.4.2 Responsibilities of the Destination Object
 
 MSG_META_END_MOVE_COPY, ClipboardEndQuickTransfer()
 
@@ -1293,13 +1293,13 @@ notification to be sent to the transfer's source and allow it to complete its
 actions properly. To finish the transfer, the object should call 
 **ClipboardEndQuickTransfer()**.
 
-##### 7.4.4.3 Getting More Information
+#### 7.4.4.3 Getting More Information
 
 In addition to the routines above, you can use one other to retrieve 
 information about a quick-transfer item. **ClipboardGetQuickItemInfo()** 
 returns a set of handles for the transfer VM file and the file's header block.
 
-##### 7.4.4.4 When the Transfer Is Concluded
+#### 7.4.4.4 When the Transfer Is Concluded
 
 MSG_META_CLIPBOARD_NOTIFY_QUICK_TRANSFER_CONCLUDED
 
@@ -1311,7 +1311,7 @@ indicating what type of operation the transfer ended up being. The source
 object should then follow the rules of quick transfer and act appropriately 
 (e.g. delete the source object on a quick-move operation).
 
-### 7.5 Shutdown Issues
+## 7.5 Shutdown Issues
 
 ClipboardClearQuickTransferNotification(), 
 ClipboardAbortQuickTransfer(), 

--- a/TechDocs/Markdown/Concepts/ccoding.md
+++ b/TechDocs/Markdown/Concepts/ccoding.md
@@ -1,4 +1,4 @@
-## 5 GEOS Programming
+# 5 GEOS Programming
 
 Because GEOS implements its own messaging and object system, standard C 
 programming must be supplemented with GEOS-specific programming. This 
@@ -10,7 +10,7 @@ concepts-you should be familiar with both before continuing. Additionally,
 you should have read both ["System Architecture," Chapter 3](carch.md) and 
 ["First Steps: Hello World," Chapter 4](cgetsta.md).
 
-### 5.1 Basic Data Types and Structures
+## 5.1 Basic Data Types and Structures
 
 In addition to the standard data types available in C, the Goc preprocessor 
 handles several other types specific to GEOS. These are all defined in the file 
@@ -41,7 +41,7 @@ from your functions and methods. Do not compare Boolean variables,
 however, against these constants. A Boolean may be true without actually 
 equaling the TRUE value.
 
-#### 5.1.1 Records and Enumerated Types
+### 5.1.1 Records and Enumerated Types
 
 GEOS objects and routines make extensive use of flag records and 
 enumerated types. A flag record is a byte, word, or dword in which each bit 
@@ -114,7 +114,7 @@ typedef ByteEnum USCity;
 #define USC_ORLANDO         0x04
 ~~~
 
-#### 5.1.2 Handles and Pointers
+### 5.1.2 Handles and Pointers
 
 Handles and pointers are present everywhere in GEOS-they are the 
 essential elements that make dynamic linking and efficient memory 
@@ -127,7 +127,7 @@ pointers (optrs) and segment pointers. Object pointers are described below;
 segment pointers are 16-bit addresses described in ["Memory Management", 
 Chapter 15](cmemory.md).
 
-##### 5.1.2.1 Handles
+#### 5.1.2.1 Handles
 
 Handles are 16-bit, unsigned values used for several purposes. They provide 
 abstraction when the exact address of a data structure or other item is not 
@@ -199,7 +199,7 @@ _The internal structure of every handle type is opaque and can not be accessed
 except by the kernel. Swat, the GEOS debugger, provides commands that allow 
 you to access the data referenced by the various handles._
 
-##### 5.1.2.2 Chunk Handles and Object Pointers
+#### 5.1.2.2 Chunk Handles and Object Pointers
 
 Objects and small data structures are stored in small memory pieces called 
 chunks. Chunks are stored in memory blocks known as local memory heaps, 
@@ -228,7 +228,7 @@ This macro extracts the MemHandle portion of the given optr.
 + **OptrToChunk()**  
 This macro extracts the chunk handle portion of a given optr.
 
-##### 5.1.2.3 Pointers
+#### 5.1.2.3 Pointers
 
 Pointers can be used normally as in C. All Goc-generated pointers are far 
 pointers; that is, they are 32-bits long, composed of a 16-bit segment and a 
@@ -250,7 +250,7 @@ call routines through pointers, you must take special measures to see to it
 that the routine is properly loaded into memory. This is discussed below in 
 [section 5.2.4](#534-using-routine-pointers-in-goc).
 
-#### 5.1.3 Fixed Point Structures
+### 5.1.3 Fixed Point Structures
 
 When you want to represent non-integral numbers (i.e., real numbers), you 
 can use either the standard C floating-point format or the following special 
@@ -338,7 +338,7 @@ This macro returns the integral portion of a **WWFixedAsDword** structure.
 + **FractionOf()**  
 This macro returns the fractional portion of a **WWFixedAsDword** structure.
 
-### 5.2 Goc and C
+## 5.2 Goc and C
 
 Goc is a superset of the standard C programming language. Goc actually acts 
 as a sort of preprocessor before the code is run through a standard C compiler. 
@@ -346,7 +346,7 @@ There are several differences you must be aware of, though. These
 differences are covered in the following sections as well as throughout the 
 documentation.
 
-#### 5.2.1 Goc File Types
+### 5.2.1 Goc File Types
 
 @include, @optimize
 
@@ -401,7 +401,7 @@ unchanged since the last compilation. You may choose to leave the
 **@optimize** directive out while the header is being developed, then put it in 
 when the header is fairly stable.
 
-#### 5.2.2 Conditional Code in Goc
+### 5.2.2 Conditional Code in Goc
 
 @if, @ifdef, @ifndef, @endif
 
@@ -436,7 +436,7 @@ expressions are shown below:
 @endif
 ~~~
 
-#### 5.2.3 Macros in Goc
+### 5.2.3 Macros in Goc
 
 @define
 
@@ -483,7 +483,7 @@ The above would equate to the following:
 Using "defChunk" without the "@" marker would most likely result in a 
 compilation error in the C compiler.
 
-#### 5.2.4 Using Routine Pointers in Goc
+### 5.2.4 Using Routine Pointers in Goc
 
 ProcCallFixedOrMovable_cdecl(), 
 ProcCallFixedOrMovable_pascal()
@@ -541,7 +541,7 @@ ProcCallFixedOrMovable_cdecl(funcPtr,       /* The pointer to the routine */
             1, 2, "Franklin T. Poomm");
 ~~~
 
-### 5.3 The GEOS Object System
+## 5.3 The GEOS Object System
 
 GEOS is almost entirely object-oriented. Its object system supports true 
 object-oriented principles such as encapsulation, inheritance, and message 
@@ -551,7 +551,7 @@ The following section describes the class and object structures of GEOS, how
 to declare and define classes and objects, and how the messaging system and 
 the kernel's message dispatcher work.
 
-#### 5.3.1 GEOS Terminology
+### 5.3.1 GEOS Terminology
 
 Though you should be familiar with general object-oriented programming 
 terms, there are quite a few for which the meaning is slightly different in 
@@ -559,7 +559,7 @@ GEOS, and there are others which are entirely new to GEOS. This section is
 divided into four categories: General Terms, Class Terms, Object Terms, and 
 Messaging Terms.
 
-##### 5.3.1.1 General Terms
+#### 5.3.1.1 General Terms
 
 **chunk**  
 A chunk is a small section of memory located in a Local 
@@ -593,7 +593,7 @@ procedural code or one or more objects. If a thread is
 "event-driven," it executes code for a given set of objects, 
 receiving messages and dispatching them to the proper objects.
 
-##### 5.3.1.2 Class Terms
+#### 5.3.1.2 Class Terms
 
 **class**  
 A class is the definition of a set of instance data structures and 
@@ -653,7 +653,7 @@ given moment. The use of variant classes can provide much the
 same functionality as the multiple inheritance found in some 
 other object systems.
 
-##### 5.3.1.3 Object Terms
+#### 5.3.1.3 Object Terms
 
 **child**  
 A child object is one that sits below another object in an object 
@@ -708,7 +708,7 @@ from the state file. Generic UI objects have this functionality
 built in automatically; other objects may manage their own 
 state saving by managing the state file.
 
-##### 5.3.1.4 Messaging Terms
+#### 5.3.1.4 Messaging Terms
 
 blocking    A thread "blocks" when it must wait for resources or return 
 values from messages sent to objects in another thread. 
@@ -748,7 +748,7 @@ Messages that return information or pass pointers should
 never be dispatched with the send command; use the call 
 command in those cases.
 
-#### 5.3.2 Object Structures
+### 5.3.2 Object Structures
 
 You do not need to know what data structures are used to store objects and 
 classes; understanding them can make programming GEOS much easier, 
@@ -776,7 +776,7 @@ Additionally, each class dynamically accesses its superclass' code, so any
 class may be accessed by all the objects of the subclasses as well. Class 
 structures are shown in [section 5.3.2.3](#5323-master-classes).
 
-##### 5.3.2.1 Instance Chunk Structures
+#### 5.3.2.1 Instance Chunk Structures
 
 Each object's instance data is stored in a Local Memory chunk. Several 
 chunks are stored in one memory block, called a local memory heap. (See 
@@ -885,7 +885,7 @@ its use are discussed in full in [section 5.4.1.4](#5414-defining-and-working-wi
 _All objects have class pointers, though only those with master classes in their 
 ancestries have master groups and master group offsets._
 
-##### 5.3.2.2 Master Classes
+#### 5.3.2.2 Master Classes
 
 A master class provides a conceptual break between levels within a class 
 tree. Each master class is the head of a class subtree, and all its subclasses 
@@ -922,7 +922,7 @@ The functionality of master classes is required to implement GEOS variant classe
 to have a version of "multiple inheritance" in that it can have different 
 superclasses depending on the system context.
 
-##### 5.3.2.3 Class Structure and Class Trees
+#### 5.3.2.3 Class Structure and Class Trees
 
 For the most part, you won't ever need or want to know the internal structure 
 of a class as implemented in memory. The class structure is created and 
@@ -1134,7 +1134,7 @@ executed immediately. (If the message number is not found in the table, the
 kernel will either execute the class' default handler or pass the message on 
 to the class' superclass.)
 
-##### 5.3.2.4 Variant Classes
+#### 5.3.2.4 Variant Classes
 
 A variant class is one which has no set superclass. The variant's superclass 
 is determined at run-time based on context and other criteria. Note that 
@@ -1253,7 +1253,7 @@ is resolved, the pointer (the first four bytes of the Gen master part) points to
 the proper superclass for this object (in this case, **OLMenuWinClass**). The 
 object, with its full class tree, is shown in Figure 5-11.
 
-##### 5.3.2.5 An In-Depth Example
+#### 5.3.2.5 An In-Depth Example
 
 This section gives an example of a GenTrigger object after its variant part 
 has been resolved. This example provides in-depth diagrams of the class and 
@@ -1399,14 +1399,14 @@ kernel checks the second part of the method table for the code pointer. It
 follows this pointer to the method's entry point and begins executing the code 
 there.
 
-#### 5.3.3 The GEOS Message System
+### 5.3.3 The GEOS Message System
 
 Because objects are independent entities, they must have some means of 
 communicating with other objects in the system. As shown in the example of 
 the calculator and requestor objects in "System Architecture," Chapter 3, 
 communication is implemented through the use of messages and methods.
 
-##### 5.3.3.1 The Messaging Process
+#### 5.3.3.1 The Messaging Process
 
 When an object needs to notify another object of some event, retrieve data 
 from another object, or send data to another object, it sends a message to that 
@@ -1483,7 +1483,7 @@ with a MSG_RETURNING_REQUESTED_INFORMATION (or something
 similar). With this scheme, the application's object is free to use call 
 whenever it wants, but the UI object must always use send.
 
-##### 5.3.3.2 Message Structures and Conventions
+#### 5.3.3.2 Message Structures and Conventions
 
 A message is simply a 16-bit number determined at compile time. 
 Specifically, it is an enumerated type-this ensures that no two messages in 
@@ -1495,7 +1495,7 @@ When an object sends a message, the kernel automatically builds out the
 event structure (generally stored in the handle table for speed and efficiency). 
 You will never have to know the structure of an event.
 
-### 5.4 Using Classes and Objects
+## 5.4 Using Classes and Objects
 
 The previous sections dealt with the internals of the GEOS object system. 
 This section describes how you can create classes and objects and manage 
@@ -1585,7 +1585,7 @@ gcnList(<manufID>, <ltype>) = <oname> [, <oname>]*;
 @define <mname> <macro>
 ~~~
 
-#### 5.4.1 Defining a New Class or Subclass
+### 5.4.1 Defining a New Class or Subclass
 
 @class, @classdecl, @endc, @default, @uses
 
@@ -1703,7 +1703,7 @@ Code Display 5-6 Defining Classes
 @classdecl MyNewVariantClass;
 ~~~
 
-##### 5.4.1.1 Defining New Messages for a Class
+#### 5.4.1.1 Defining New Messages for a Class
 
 @message, @stack, @reserveMessages, @exportMessages, 
 @importMessage, @alias, @prototype
@@ -1925,7 +1925,7 @@ Code Display 5-8 Aliasing Messages
 @classdecl MyClass;
 ~~~
 
-##### 5.4.1.2 Defining Instance Data Fields
+#### 5.4.1.2 Defining Instance Data Fields
 
 @instance, @composite, @link, @visMoniker, @kbdAccelerator, 
 @activeList
@@ -2039,7 +2039,7 @@ Code Display 5-9 Declaring Instance Data Fields
 @endc
 ~~~
 
-##### 5.4.1.3 New Defaults for Subclassed Instance Data Fields
+#### 5.4.1.3 New Defaults for Subclassed Instance Data Fields
 
 @default
 
@@ -2075,7 +2075,7 @@ its superclass, except with the GS_USABLE flag turned off:
 @default GI_states = @default & ~GS_USABLE;
 ~~~
 
-##### 5.4.1.4 Defining and Working With Variable Data Fields
+#### 5.4.1.4 Defining and Working With Variable Data Fields
 
 @vardata, @vardataAlias, ObjVarAddData(), 
 ObjVarDeleteData(), ObjVarDeleteDataAt(), ObjVarScanData(), 
@@ -2366,7 +2366,7 @@ static VarDataCHandler varDataInteractionHandlerTable[] = {
 };
 ~~~
 
-##### 5.4.1.5 Defining Relocatable Data
+#### 5.4.1.5 Defining Relocatable Data
 
 @reloc
 
@@ -2423,7 +2423,7 @@ relocation.
 **ptrType** This is the type of relocatable data contained in the field. It 
 may be one of optr, ptr, or handle.
 
-#### 5.4.2 Non-relocatable Data
+### 5.4.2 Non-relocatable Data
 
 @noreloc
 
@@ -2439,7 +2439,7 @@ Code Display 5-13 Use of the @noreloc Keyword
     @noreloc MCI_ruler;        /* -but now it isn't. */
 ~~~
 
-#### 5.4.3 Defining Methods
+### 5.4.3 Defining Methods
 
 @method, @extern
 
@@ -2668,7 +2668,7 @@ extern int _pascal HelloCounterRecalculateValue(
 }
 ~~~
 
-#### 5.4.4 Declaring Objects
+### 5.4.4 Declaring Objects
 
 In GEOS programs, you can instantiate objects in two ways: You can declare 
 them in your source code with the **@object** keyword, or you can instantiate 
@@ -2681,7 +2681,7 @@ of declarations in their definition (.goh) files; these declarations (**@deflib*
 and **@endlib**) indicate that the code contained between them is part of the 
 specified library.
 
-##### 5.4.4.1 Defining Library Code
+#### 5.4.4.1 Defining Library Code
 
 @deflib, @endlib
 
@@ -2709,7 +2709,7 @@ Note that these two keywords are only necessary in files that define classes
 in the library. Files that have just code or data used in the library do not 
 require them (though they are allowed).
 
-##### 5.4.4.2 Declaring Segment Resources and Chunks
+#### 5.4.4.2 Declaring Segment Resources and Chunks
 
 @start, @end, @header, @chunk, @chunkArray, @elementArray, 
 @extern
@@ -2834,7 +2834,7 @@ typedef struct {
 @end StudentBlock                   /* end of resource block */
 ~~~
 
-##### 5.4.4.3 Declaring an Object
+#### 5.4.4.3 Declaring an Object
 
 @object, @default, @specificUI, gcnList
 
@@ -3159,7 +3159,7 @@ Code Display 5-17 Declaring Objects with @object
 @end Interface
 ~~~
 
-#### 5.4.5 Sending Messages
+### 5.4.5 Sending Messages
 
 @send, @call, @callsuper, @record, @dispatch, @dispatchcall
 
@@ -3518,7 +3518,7 @@ using **@<obj>**, where <obj> represents the name of the object. This syntax
 gets translated by Goc into (optr)&<obj>; this is similar to using the 
 ampersand (&) to pass a pointer.
 
-#### 5.4.6 Managing Objects
+### 5.4.6 Managing Objects
 
 In addition to knowing how to declare objects and classes, you need to know 
 how to manage objects during execution. This includes instantiating new 
@@ -3531,7 +3531,7 @@ probably not have to or want to use all these routines and methods, but
 understanding what they do and how they work can help you understand the 
 object system as a whole.
 
-##### 5.4.6.1 Creating New Objects
+#### 5.4.6.1 Creating New Objects
 
 ObjDuplicateResource(), ObjInstantiate(), 
 MSG_META_INITIALIZE, MSG_GEN_COPY_TREE
@@ -3699,7 +3699,7 @@ destroyed with MSG_GEN_DESTROY.
 For an example of MSG_GEN_COPY_TREE use, see the SDK_C\GENTREE 
 sample application.
 
-##### 5.4.6.2 Working With Object Blocks
+#### 5.4.6.2 Working With Object Blocks
 
 ObjIncInUseCount(), ObjDecInUseCount(), ObjLockObjBlock(), 
 ObjFreeObjBlock(), ObjFreeDuplicate(), 
@@ -3723,7 +3723,7 @@ indicating whether the calling thread runs a given object block.
 of the object set to receive output messages (i.e., messages sent with travel 
 option TO_OBJ_BLOCK_OUTPUT) from all the objects within the object block.
 
-##### 5.4.6.3 Working With Individual Objects
+#### 5.4.6.3 Working With Individual Objects
 
 ObjIsObjectInClass(), ObjGetFlags(), ObjSetFlags(), 
 ObjDoRelocation(), ObjDoUnRelocation(), ObjResizeMaster(), 
@@ -3746,7 +3746,7 @@ to build all master groups above and including the passed level. (This will
 also resolve variant classes.) **ObjResizeMaster()** resizes a given master 
 part of the instance chunk, causing the chunk to be resized.
 
-##### 5.4.6.4 Managing Object Trees
+#### 5.4.6.4 Managing Object Trees
 
 ObjLinkFindParent(), ObjCompAddChild(), 
 ObjCompRemoveChild(), ObjCompMoveChild(), 
@@ -3815,7 +3815,7 @@ _An object's composite field points to its first child, and its link field point
 either to its next sibling or back to the parent. You can see that, by following 
 these links, any object is accessible from any other object in the tree._
 
-##### 5.4.6.5 Detaching and Destroying Objects
+#### 5.4.6.5 Detaching and Destroying Objects
 
 MSG_META_DETACH, MSG_META_DETACH_COMPLETE, MSG_META_ACK, 
 MSG_META_OBJ_FLUSH_INPUT_QUEUE, MSG_META_OBJ_FREE, 

--- a/TechDocs/Markdown/Concepts/cdb.md
+++ b/TechDocs/Markdown/Concepts/cdb.md
@@ -1,4 +1,4 @@
-## 19 Database Library
+# 19 Database Library
 
 Some applications need to keep track of many small pieces of data. For 
 example, a database might use thousands of items of data, each of them only 
@@ -15,7 +15,7 @@ and ["Memory Management", Chapter 15](cmemory.md). You should also be familiar w
 basic LMem principles (see ["Local Memory", Chapter 16](clmem.md)) and with Virtual 
 Memory files (see ["Virtual Memory", Chapter 18](cvm.md)).
 
-### 19.1 Design Philosophy
+## 19.1 Design Philosophy
 
 A database manager should be flexible, allowing applications to store a 
 variety of data items. It should be efficient, with minimal overhead in 
@@ -53,14 +53,14 @@ Since DB items are stored in VM files, the files can be shared between
 applications. All of the standard VM synchronization routines work for 
 DB files.
 
-### 19.2 Database Structure
+## 19.2 Database Structure
 
 The Database Library uses a Database Manager to access and create DB 
 items. These items are stored in a standard VM file. This chapter will 
 sometimes refer to a "Database File"; this simply means a VM file which 
 contains DB items.
 
-#### 19.2.1 DB Items
+### 19.2.1 DB Items
 
 The basic unit of data is the item. Items are simply chunks in special LMem 
 heaps which are managed by the DB Manager; these heaps are called item 
@@ -83,7 +83,7 @@ Since DB items are chunks, their addresses are somewhat volatile. If you allocat
 an item in a group, other items in that group may move even if they are locked. 
 (See [section 16.2.2 of chapter 16](clmem.md#1622-chunks-and-chunk-handles).)
 
-#### 19.2.2 DB Groups
+### 19.2.2 DB Groups
 
 Each DB item is a member of a DB group. The DB group is a collection of VM 
 blocks; the group comprises a single group block and zero or more item 
@@ -116,7 +116,7 @@ according to the first letter of the last name, thus speeding up alphabetical
 access. If you have no logical way to group items, see ["Ungrouped DB Items"]
 (#1924-ungrouped-db-items).
 
-#### 19.2.3 Allocating Groups and Items
+### 19.2.3 Allocating Groups and Items
 
 When you need a new DB group, call the DB routine DBGroupAlloc() (see 
 [19.3.2 Allocating and Freeing Groups](#1932-allocatin-and-freeing-groups). 
@@ -146,7 +146,7 @@ Once an item has been allocated, it will stay in the same item block (and have
 the same chunk handle) until it is freed or resized. If it is resized to a larger 
 size, it may be moved to a different item block belonging to the same group.
 
-#### 19.2.4 Ungrouped DB Items
+### 19.2.4 Ungrouped DB Items
 
 Sometimes there is no natural way to group DB items. For these situations, 
 the DB manager allows you to allocate ungrouped items. These items actually 
@@ -170,7 +170,7 @@ Ungrouped Items"](#1937-routines-for-ungrouped-items). This section also
 describes macros which combine a group-handle and item-handle into a 
 **DBGroupAndItem** and which break a **DBGroupAndItem** into its constituent parts.
 
-#### 19.2.5 The DB Map Item
+### 19.2.5 The DB Map Item
 
 You can designate a "map item" for a VM file with the routine **DBSetMap()**. 
 You can recover the map item's group and handle at will by calling 
@@ -180,7 +180,7 @@ locked, and changed independently.
 
 The map routines are described in detail in [section 19.3.6](#1936-setting-and-using-the-map-item).
 
-### 19.3 Using Database Routines
+## 19.3 Using Database Routines
 
 GEOS provides a wide range of routines for working with databases. The 
 routines all require that the calling thread have the VM file open. Most 
@@ -197,7 +197,7 @@ on DB items. Simply cast the **DBGroupAndItem** structure to type
 (**VMCopyVMChain()** will allocate the duplicate item as "ungrouped.") For 
 more information about **VMChain** routines, see [section 18.4 of chapter 18](cvm.md#184-vm-chains).
 
-#### 19.3.1 General Rules to Follow
+### 19.3.1 General Rules to Follow
 
 There are certain rules of "memory etiquette" you should follow when using 
 DB files. For the most part, these rules are the same as the general rules of 
@@ -229,7 +229,7 @@ keep items from getting too large. If individual items get into the
 multi-kilobyte range, you should consider storing them a different way; for 
 example, you could make each f the larger items a VM block or a VM chain.
 
-#### 19.3.2 Allocating and Freeing Groups
+### 19.3.2 Allocating and Freeing Groups
 
 DBGroupAlloc(), DBGroupFree()
 
@@ -249,7 +249,7 @@ blocks will also be freed. Naturally, all items in the group will be freed as
 well. You can free a group even if some of its items are locked; those items will 
 be freed immediately.
 
-#### 19.3.3 Allocating and Freeing Items
+### 19.3.3 Allocating and Freeing Items
 
 DBAlloc(), DBFree()
 
@@ -277,7 +277,7 @@ block will never be unlocked). Always unlock an item before freeing it. (You
 need not, however, unlock items before freeing their group; when a group is 
 freed, all of its items are automatically freed, whether they are locked or not.)
 
-#### 19.3.4 Accessing DB Items
+### 19.3.4 Accessing DB Items
 
 DBLock(), DBLockGetRef(), DBDeref(), DBUnlock(), DBDirty()
 
@@ -329,7 +329,7 @@ the item-block containing that item. As with VM blocks, you must dirty the
 item before you unlock it, as the memory manager can discard any clean 
 block from memory as soon as it is unlocked.
 
-#### 19.3.5 Resizing DB Items
+### 19.3.5 Resizing DB Items
 
 DBReAlloc(), DBInsertAt(), DBDeleteAt()
 
@@ -369,7 +369,7 @@ takes five arguments: the file handle, the group-handle, the item-handle, the
 offset (within the item) of the first byte to delete, and the number of bytes to 
 delete. The routine does not return anything.
 
-#### 19.3.6 Setting and Using the Map Item
+### 19.3.6 Setting and Using the Map Item
 
 DBSetMap(), DBGetMap(), DBLockMap()
 
@@ -394,7 +394,7 @@ routine **DBLockMap()**. This routine takes one argument, namely the
 file handle. It locks the map item and returns the map's address. When 
 you are done with the map item, unlock it normally with a call to **DBUnlock()**.
 
-#### 19.3.7 Routines for Ungrouped Items
+### 19.3.7 Routines for Ungrouped Items
 
 DBAllocUngrouped(), DBFreeUngrouped(), DBLockUngrouped(), 
 DBLockGetRefUngrouped(), DBReAllocUngrouped(), 
@@ -424,7 +424,7 @@ Conversely, if you allocate a normal "grouped" item, you are free to combine
 the two handles into a DBGroupAndItem token and pass that token to the 
 "ungrouped" routines.
 
-#### 19.3.8 Other DB Utilities
+### 19.3.8 Other DB Utilities
 
 DBCopyDBItem(), DBCopyDBItemUngrouped(), 
 DBGroupFromGroupAndItem(), DBItemFromGroupAndItem(), 
@@ -466,7 +466,7 @@ the component handles from a **DBGroupAndItem** value, use the macros
 These macros are passed a **DBGroupAndItem** value and return the 
 appropriate component.
 
-### 19.4 The Cell Library
+## 19.4 The Cell Library
 
 The database library lets applications organize data into groups. This is an 
 intuitive way to organize data for many applications. However, for some 
@@ -489,7 +489,7 @@ correspondence between cell files and the VM files which contain them.
 However, this correspondence is optional. There is nothing to stop an 
 application from maintaining several distinct cell files in a single VM file.
 
-#### 19.4.1 Structure and Design
+### 19.4.1 Structure and Design
 
 Most of the internal structure of a cell file is transparent to the geode which 
 uses it. A geode can, for example, lock a cell with **CellLock()**, specifying the 
@@ -581,14 +581,14 @@ one row) than to shift the rest of the column down (which involves accessing
 every visible row). Similarly, you can access groups of cells faster if they 
 belong to the same row block.
 
-#### 19.4.2 Using the Cell Library
+### 19.4.2 Using the Cell Library
 
 The cell library is versatile. The basic cell access routines are very simple, 
 but more advanced utilities give you a wide range of actions. This section will 
 explain the techniques used to set up and use a cell file, as well as the more 
 advanced techniques available.
 
-##### 19.4.2.1 The CellFunctionParameters Structure
+#### 19.4.2.1 The CellFunctionParameters Structure
 
 The cell library needs to have certain information about any cell file on which 
 it acts; for example, it needs to know the handles of the VM file and of the row 
@@ -655,7 +655,7 @@ the structure be an ungrouped item. Remember, all the cells are ungrouped
 DB items; allocating or resizing a cell can potentially move any or all of the 
 ungrouped DB items in that file.
 
-##### 19.4.2.2 Basic Cell Array Routines
+#### 19.4.2.2 Basic Cell Array Routines
 
 CellReplace(), CellLock(), CellLockGetRef(), CellDirty(), 
 CellGetDBItem(), CellGetExtent()
@@ -748,7 +748,7 @@ typedef struct {
 } Rectangle;
 ~~~
 
-##### 19.4.2.3 Actions on a Range of Cells
+#### 19.4.2.3 Actions on a Range of Cells
 
 RangeExists(), RangeInsert(), RangeEnum(), RangeSort(), 
 RangeInsertParams

--- a/TechDocs/Markdown/Concepts/cfile.md
+++ b/TechDocs/Markdown/Concepts/cfile.md
@@ -1,4 +1,4 @@
-## 17 File System
+# 17 File System
 
 Every operating system needs a way to interact with files. Files are used to 
 hold both data and executable code. They are also the simplest way of 
@@ -29,7 +29,7 @@ Before reading this section, you should have read ["System Architecture",
 Chapter 3](carch.md), and ["First Steps: Hello World", Chapter 4](cgetsta.md). 
 You should also be familiar with GEOS handles (discussed in ["Handles", Chapter 14](chandle.md)).
 
-### 17.1 Design Philosophy
+## 17.1 Design Philosophy
 
 The GEOS file system was designed to meet two goals. First, the file system 
 should insulate geodes from differences in hardware, making them device 
@@ -76,7 +76,7 @@ the raw files. If a geode wants to access any file as a sequence of bytes (the
 DOS model), it may do so. Similarly, geodes may work with physical DOS 
 directories if they wish to.
 
-### 17.2 File System Overview
+## 17.2 File System Overview
 
 The GEOS file system manages all access to files on any type of storage. 
 Whenever a geode needs to access a data file, it calls a file system routine. 
@@ -180,7 +180,7 @@ directory at a time, regardless of how many drives you have. If you need to
 switch back and forth between directories on different drives, you can use the 
 directory stack (see [section 17.4.2](#1742-current-path-and-directory-stack)).
 
-### 17.3 Disks and Drives
+## 17.3 Disks and Drives
 
 GEOS provides an easy interface to storage devices. Every drive (or analogous 
 storage device) is identified by a token. Every volume is also identified by a 
@@ -198,7 +198,7 @@ navigate among disks and directories; when the user selects a file, the
 document control will automatically open the file and return its handle to the 
 application.
 
-#### 17.3.1 Accessing Drives
+### 17.3.1 Accessing Drives
 
 DriveGetStatus(), DriveGetExtStatus(), 
 DriveGetDefaultMedia(), DriveTestMediaSupport(), 
@@ -336,14 +336,14 @@ buffer as a null-terminated string; it returns a pointer to that trailing null. 
 the buffer was not large enough, or the drive does not exist, it returns a null 
 pointer.
 
-#### 17.3.2 Accessing Disks
+### 17.3.2 Accessing Disks
 
 Applications will work with disks more than they will work with drives. Once 
 a geode knows a disk's handle, it can ignore such questions as whether the 
 disk is in a drive; it need merely provide the disk's handle. If necessary, the 
 system will prompt the user to insert the disk in the appropriate drive.
 
-##### 17.3.2.1 Registering Disks
+#### 17.3.2.1 Registering Disks
 
 DiskRegisterDisk(), DiskRegisterDiskSilently()
 
@@ -385,7 +385,7 @@ label. You can suppress this notification by calling the system routine
 **DiskRegisterDiskSilently()**. This routine has the same arguments and 
 return values as **DiskRegisterDisk()**.
 
-##### 17.3.2.2 Getting Information about a Disk
+#### 17.3.2.2 Getting Information about a Disk
 
 DiskGetVolumeInfo(), DiskGetVolumeFreeSpace(), 
 DiskGetDrive(), DiskGetVolumeName(), DiskFind(), 
@@ -507,7 +507,7 @@ information the file-system stores about all registered disks. This means that
 course, the callback routine may need to examine the disks, in which case the 
 user will be prompted when necessary.
 
-##### 17.3.2.3 Saving and Restoring a Disk Handle
+#### 17.3.2.3 Saving and Restoring a Disk Handle
 
 DiskSave(), DiskRestore(), DiskRestoreError
 
@@ -609,7 +609,7 @@ DRE_REMOVABLE_DRIVE_IS_BUSY
 The appropriate drive exists but is unavailable due to some 
 time-consuming operation (e.g. a disk format).
 
-##### 17.3.2.4 Other Disk Utilities
+#### 17.3.2.4 Other Disk Utilities
 
 DiskSetVolumeName(), DiskFormat(), DiskCopy(), FormatError, 
 DiskCopyCallback, DiskCopyError
@@ -809,7 +809,7 @@ non-zero value, thus aborting the copy.
 
 ERR_CANT_FORMAT_DEST   
 
-### 17.4 Directories and Paths
+## 17.4 Directories and Paths
 
 Information, whether code or data, is always stored in files. However, storage 
 volumes are not simply collections of files. Rather, they are organized into 
@@ -859,7 +859,7 @@ usage; an application might, for example, keep a certain data file in the
 standard PRIVDATA directory, leaving the user to decide where that 
 PRIVDATA directory may be. This is covered in detail in the following section.
 
-#### 17.4.1 Standard Paths
+### 17.4.1 Standard Paths
 
 The GEOS system is designed to run on a wide variety of architectures. For 
 example, it can be stored on a hard disk, recorded in ROM chips, or resident 
@@ -1031,7 +1031,7 @@ SP_BACKUP
 This directory contains backup files made by the document 
 control. It is commonly \PRIVDATA\BACKUP.
 
-#### 17.4.2 Current Path and Directory Stack
+### 17.4.2 Current Path and Directory Stack
 
 FileSetCurrentPath(), FileGetCurrentPath(), 
 FileConstructFullPath(), FileParseStandardPath(), 
@@ -1157,7 +1157,7 @@ Files are often specified "by their paths." This simply means specifying them
 with a string containing the directory path and ending with the file name. 
 This path may be either relative or absolute. 
 
-#### 17.4.3 Creating and Deleting Directories
+### 17.4.3 Creating and Deleting Directories
 
 FileCreateDir(), FileDeleteDir()
 
@@ -1235,7 +1235,7 @@ The drive that disk was on has been removed.
 ERROR_DISK_UNAVAILABLE  
 The validation of the disk in that drive was aborted by the user.
 
-### 17.5 Files
+## 17.5 Files
 
 When data is not actually in a computer's memory, it needs to be grouped 
 together in a manageable form. Most storage devices group data together 
@@ -1252,7 +1252,7 @@ Operations" (section 17.5.6) is important only if you will be using DOS files or
 GEOS byte files. Most applications will work with GEOS Virtual Memory (VM) 
 files.
 
-#### 17.5.1 DOS Files and GEOS Files
+### 17.5.1 DOS Files and GEOS Files
 
 Most file systems have a simple convention of what a file is. Applications 
 treat files as if they were a sequence of bytes. They can read the bytes in order 
@@ -1309,7 +1309,7 @@ information is stored in a special header which is transparent to geodes. If
 you use one of the bytewise file operations, you will not be able to affect the 
 header.
 
-#### 17.5.2 Files and File Handles
+### 17.5.2 Files and File Handles
 
 FileDuplicateHandle()
 
@@ -1338,7 +1338,7 @@ handle; that is, it can be used on the handles of DOS files, GEOS byte files, or
 VM files. Note that the duplicate handle will have the same read/write 
 position as the original.
 
-#### 17.5.3 GEOS Extended Attributes
+### 17.5.3 GEOS Extended Attributes
 
 FileGetHandleExtAttributes(), FileGetPathExtAttributes(), 
 FileSetHandleExtAttributes(), FileSetPathExtAttributes(), 
@@ -1754,7 +1754,7 @@ This attribute contains the **DriveExtendedStatus** word for the drive
 containing the file. The **DriveExtendedStatus** value is described in [section 
 17.3.1](#1731-accessing-drives).
 
-#### 17.5.4 File Utilities
+### 17.5.4 File Utilities
 
 FileDelete(), FileRename(), FileCopy(), 
 FileMove(),FileGetDiskHandle()
@@ -1841,7 +1841,7 @@ disk handle with **FileGetDiskHandle()**, then save that handle with **DiskSave(
 this information (and the file name), the geode will be able to reopen the file 
 when it restarts.
 
-#### 17.5.5 FileEnum()
+### 17.5.5 FileEnum()
 
 FileEnum(), FileEnumLocateAttr(), FileEnumWildcard(), 
 FileEnumAttrs, FileEnumSearchFlags, 
@@ -2133,7 +2133,7 @@ the letters "doc" and ends with a period, whereas a DOS wildcard string
 "doc*." would match only those files whose name start with "doc" and which 
 have no extension.
 
-#### 17.5.6 Bytewise File Operations
+### 17.5.6 Bytewise File Operations
 
 There are several routines designed for working with files as a string of bytes. 
 These routines may be used to work with DOS files or with GEOS byte files. 
@@ -2143,7 +2143,7 @@ however, be aware that if you make any changes to such files, you could
 invalidate them. For this reason, if you open a VM or executable file for 
 byte-level access, you should open it for read-only use.
 
-##### 17.5.6.1 Opening and Closing Files
+#### 17.5.6.1 Opening and Closing Files
 
 FileOpen(), FileCreate(), FileCreateTempFile(), 
 FileClose(), FileAccessFlags
@@ -2323,7 +2323,7 @@ successfully close the file. (This should only be used during development; the
 flag should never be passed in a finished program.) The routine returns zero 
 if successful; otherwise, it returns a **FileError** value.
 
-##### 17.5.6.2 Reading From and Writing To Files
+#### 17.5.6.2 Reading From and Writing To Files
 
 FileRead(), FileWrite(), FilePos(), FileCommit()
 
@@ -2412,7 +2412,7 @@ after the move (relative to the start of the file). To find out the current file
 position without changing it, call **FilePos()** with mode FILE_POS_RELATIVE 
 and offset zero.
 
-##### 17.5.6.3 Getting and Setting Information about a Byte File
+#### 17.5.6.3 Getting and Setting Information about a Byte File
 
 FileGetDateAndTime(), FileSetDateAndTime(), 
 FileGetAttributes(), FileSetAttributes()
@@ -2446,7 +2446,7 @@ of a null-terminated path string and a **FileAttrs** record. It returns zero if 
 successful; otherwise, it returns an error condition. Note that a file's attributes 
 cannot be changed if the file is open.
 
-##### 17.5.6.4 Data-Access Synchronization
+#### 17.5.6.4 Data-Access Synchronization
 
 FileLockRecord(), FileUnlockRecord()
 

--- a/TechDocs/Markdown/Concepts/cgcn.md
+++ b/TechDocs/Markdown/Concepts/cgcn.md
@@ -1,4 +1,4 @@
-## 9 General Change Notification
+# 9 General Change Notification
 
 In a multitasking environment, threads may need to know of condition 
 changes that might affect them. In most cases where shared resources or 
@@ -12,7 +12,7 @@ processes and objects manually, the GCN mechanism eliminates the need to
 keep track of all processes that depend on the particular change and to keep 
 track of all messages sent out to the various processes and objects.
 
-### 9.1 Design Goals
+## 9.1 Design Goals
 
 General Change Notification allows you to keep track of both system and 
 application events. Objects or processes interested in a particular change 
@@ -37,7 +37,7 @@ objects may sign up for application-specific notification supported by
 **GenApplicationClass**. These application specific notifications should only 
 be sent to the GenApplication object.
 
-### 9.2 The Mechanics of GCN
+## 9.2 The Mechanics of GCN
 
 The basic GCN functionality manages lists of objects that are interested in 
 specific changes. For each particular change that needs to be monitored, a 
@@ -68,7 +68,7 @@ Many messages sent by the system expect a GCN mechanism to intercept
 them. Although you can intercept these messages manually, it is easier 
 to take advantage of GCN's built-in functions.
 
-### 9.3 System Notification
+## 9.3 System Notification
 
 GCNListAdd(), GCNListSend()
 
@@ -96,7 +96,7 @@ parties with **GCNListSend()**.
 If you need to perform some work related to this change, you should have 
 a message handler to intercept the system messages.
 
-#### 9.3.1 Registering for System Notification
+### 9.3.1 Registering for System Notification
 
 Whenever an object or process needs to be notified of some system change, it 
 must call the routine **GCNListAdd()** to add itself to the list for that 
@@ -227,7 +227,7 @@ Code Display 9-1 Adding a Process Object to a GCN List
 }
 ~~~
 
-#### 9.3.2 Handling System Notification
+### 9.3.2 Handling System Notification
 
 MSG_NOTIFY_FILE_CHANGE, MSG_NOTIFY_DRIVE_CHANGE, 
 MSG_NOTIFY_APP_STARTED, MSG_NOTIFY_APP_EXITED, 
@@ -364,7 +364,7 @@ occurs. MSG_NOTIFY_USER_DICT_CHANGED passes the MemHandle of the
 Spell Box causing the change and the MemHandle of the user dictionary 
 being changed, both of which you may access in your message handler.
 
-#### 9.3.3 Removal from a System List
+### 9.3.3 Removal from a System List
 
 You should use **GCNListRemove()** to remove an object from a system GCN 
 list. You must pass the notification ID (**GCNStandardListType** and 
@@ -391,7 +391,7 @@ Code Display 9-2 Removing a Process from a GCN list
 }
 ~~~
 
-### 9.4 Application Local GCN Lists
+## 9.4 Application Local GCN Lists
 
 The GCN mechanism not only allows you to keep track of system changes but 
 also allows you to keep track of changes within a specific application. These 
@@ -443,7 +443,7 @@ MSG_META_NOTIFY_WITH_DATA_BLOCK. If you need to perform some
 work related to this change, you should have a message handler to 
 intercept these messages.
 
-#### 9.4.1 Creating Types and Lists
+### 9.4.1 Creating Types and Lists
 
 It is a relatively simple matter to create your own notification types. Within 
 an appropriate company-specific file merely create your own types and lists. 
@@ -474,7 +474,7 @@ typedef enum {
 } <yourCompanyName>GenAppGCNListTypes;
 ~~~
 
-#### 9.4.2 Registering for Notification
+### 9.4.2 Registering for Notification
 
 MSG_META_GCN_LIST_ADD 
 
@@ -521,7 +521,7 @@ Code Display 9-4 Adding Yourself to a Custom GCN List
 }
 ~~~
 
-#### 9.4.3 Handling Application Notification
+### 9.4.3 Handling Application Notification
 
 MSG_META_NOTIFY, MSG_META_NOTIFY_WITH_DATA_BLOCK, 
 MSG_META_GCN_LIST_SEND
@@ -672,7 +672,7 @@ Code Display 9-7 Intercepting an Application Notification Change
 }
 ~~~
 
-#### 9.4.4 Removal from Application Lists
+### 9.4.4 Removal from Application Lists
 
 You should use MSG_META_GCN_LIST_REMOVE to remove an object from an 
 application GCN list. You must pass the routine the notification ID 

--- a/TechDocs/Markdown/Concepts/cgeom.md
+++ b/TechDocs/Markdown/Concepts/cgeom.md
@@ -1,4 +1,4 @@
-## 12 Managing UI Geometry
+# 12 Managing UI Geometry
 
 One of the more difficult aspects of programming a graphically oriented 
 application is positioning the user interface components on the screen. 
@@ -19,7 +19,7 @@ Interface in general and the generic UI in specific. For most of this chapter,
 information; for other sections, you should at least read ["The GEOS User 
 Interface," Chapter 10](cuiover.md).
 
-### 12.1 Geometry Manager Overview
+## 12.1 Geometry Manager Overview
 
 The GEOS geometry manager is an algorithmic mechanism which interacts 
 directly with the UI to position and size objects of all types. The geometry 
@@ -47,7 +47,7 @@ you can apply to window objects, see [section 12.3](#123-positioning-and-sizing-
 For descriptions of managing the geometry of visible object trees and composites, see 
 ["VisClass," Chapter 23 of the Object Reference Book](../Objects/ovis.md).
 
-#### 12.1.1 Geometry Manager Features
+### 12.1.1 Geometry Manager Features
 
 The geometry manager, used effectively, can take nearly all the work out of 
 displaying, sizing, and positioning objects on the screen. Many of the tasks 
@@ -97,7 +97,7 @@ The system does all the dirty work of drawing and managing the objects on
 the screen, leaving you free to work on your application rather than on its 
 graphical screen representation.
 
-#### 12.1.2 How Geometry Is Managed
+### 12.1.2 How Geometry Is Managed
 
 The geometry manager is one part of the system that draws objects on the 
 screen and redraws them when necessary. This system is called the "visual 
@@ -201,7 +201,7 @@ on the attributes of the view. For example, if the view is set to follow the siz
 of its content, it will grow, bumping the size of its parent in the process. If the 
 view is scrollable, it likely will stay the same size.
 
-### 12.2 Arranging Your Generic Objects
+## 12.2 Arranging Your Generic Objects
 
 The process of arranging user interface elements for a GEOS application 
 differs drastically from that of traditional user interface programming 
@@ -220,7 +220,7 @@ positions in the generic object tree; GEOS does the rest, determining the
 position and visual effects of each object. You can even fine-tune the 
 appearance of each object with the use of hints.
 
-#### 12.2.1 General Geometry Rules
+### 12.2.1 General Geometry Rules
 
 You may feel at first that the use of generic UI components limits your control 
 over the UI of your application. Actually, just the opposite is true: Your 
@@ -250,14 +250,14 @@ Third, an object's behavior can be fine-tuned through the use of hints. Hints
 may or may not be implemented for each object that has them, and they 
 control less strictly how the object works.
 
-##### 12.2.1.1 Generic Tree Structure
+#### 12.2.1.1 Generic Tree Structure
 
 As stated above, the structure of your application's generic object tree 
 determines how the generic UI objects will be organized. A simple example of 
 a generic tree including a menu, a dialog box, and a GenView can be found in 
 ["First Steps: Hello World," Chapter 4](cgetsta.md).
 
-##### 12.2.1.2 How Hints Work
+#### 12.2.1.2 How Hints Work
 
 Nearly all geometry of generic UI objects is determined by hints. You can 
 position, size, and limit generic objects with different hints. All these hints 
@@ -283,7 +283,7 @@ this chapter follows a series of examples accompanied with diagrams. For the
 most part, you should be able to "plug and play" the examples in the following 
 sections.
 
-#### 12.2.2 Orienting Children
+### 12.2.2 Orienting Children
 
 HINT_ORIENT_CHILDREN_HORIZONTALLY, 
 HINT_ORIENT_CHILDREN_VERTICALLY, 
@@ -410,7 +410,7 @@ Code Display 12-2 A Complex Dialog Box
 }
 ~~~
 
-#### 12.2.3 Justifying and Centering Children
+### 12.2.3 Justifying and Centering Children
 
 Although child justification defaults to whatever the specific UI normally 
 uses, you can set the justification of a composite's children with several 
@@ -420,7 +420,7 @@ Typically, horizontal composites will have their children top-justified and
 vertical composites will have left-justified children (as shown in the previous 
 examples).
 
-##### 12.2.3.1 Edge Justification
+#### 12.2.3.1 Edge Justification
 
 HINT_TOP_JUSTIFY_CHILDREN, HINT_BOTTOM_JUSTIFY_CHILDREN, 
 HINT_LEFT_JUSTIFY_CHILDREN, HINT_RIGHT_JUSTIFY_CHILDREN
@@ -439,7 +439,7 @@ justification are shown in Figure 12-3.
 _From left to right (clockwise): Left justification, right justification, top 
 justification, bottom justification._
 
-##### 12.2.3.2 Edge Alignment with Other Objects
+#### 12.2.3.2 Edge Alignment with Other Objects
 
 HINT_ALIGN_LEFT_EDGE_WITH_OBJECT, 
 HINT_ALIGN_TOP_EDGE_WITH_OBJECT, 
@@ -451,7 +451,7 @@ object; the optr of the other object is the hint's argument. The other object
 does not necessarily have to be a direct sibling or parent, but the result must 
 not cause the object to stray outside its parent's bounds. 
 
-##### 12.2.3.3 Centering Children
+#### 12.2.3.3 Centering Children
 
 HINT_CENTER_CHILDREN_VERTICALLY, 
 HINT_CENTER_CHILDREN_HORIZONTALLY
@@ -468,7 +468,7 @@ _Vertically oriented composites may be centered
 horizontally; horizontally-oriented composites may be 
 centered vertically._
 
-##### 12.2.3.4 Full Justification
+#### 12.2.3.4 Full Justification
 
 HINT_FULL_JUSTIFY_CHILDREN_HORIZONTALLY, 
 HINT_FULL_JUSTIFY_CHILDREN_VERTICALLY, 
@@ -503,7 +503,7 @@ spacing is also typically not turned on by default; you can ensure that added
 spacing will not be included (where possible) by applying the hint 
 HINT_DONT_INCLUDE_ENDS_IN_CHILD_SPACING to your composite.
 
-#### 12.2.4 Sizing Objects
+### 12.2.4 Sizing Objects
 
 Sizing can occur in essentially one of two ways: First, the composite can size 
 itself based on its children. Second, the children can size themselves based 
@@ -517,7 +517,7 @@ _The reply bar interaction object is specified as horizontally full-justified. I
 the upper example, it does not include ends in child spacing; in the lower 
 example, it does. Unchanged portions of the dialog box are cut out._
 
-##### 12.2.4.1 Sizing the Parent
+#### 12.2.4.1 Sizing the Parent
 
 HINT_NO_TALLER_THAN_CHILDREN_REQUIRE, 
 HINT_NO_WIDER_THAN_CHILDREN_REQUIRE
@@ -528,7 +528,7 @@ keep them from growing into any extra space in their parents. You can set the
 width and height restrictions independently; to set them both, use both hints 
 in the composite.
 
-##### 12.2.4.2 Sizing the Children
+#### 12.2.4.2 Sizing the Children
 
 HINT_EXPAND_HEIGHT_TO_FIT_PARENT, 
 HINT_EXPAND_WIDTH_TO_FIT_PARENT, 
@@ -641,7 +641,7 @@ total size of the children and then attempt to divide up its children's space,
 rather than the maximum allotted size for the parent, which is probably not 
 desired.
 
-##### 12.2.4.3 Maximum, Minimum, Fixed, and Initial Sizes
+#### 12.2.4.3 Maximum, Minimum, Fixed, and Initial Sizes
 
 HINT_INITIAL_SIZE, HINT_MAXIMINUM_SIZE, HINT_MINIMUM_SIZE, 
 HINT_FIXED_SIZE
@@ -717,7 +717,7 @@ HINT_MINIMUM_SIZE = {
         0 };
 ~~~
 
-#### 12.2.5 Outlining the Composite
+### 12.2.5 Outlining the Composite
 
 HINT_DRAW_IN_BOX
 
@@ -732,7 +732,7 @@ bounds as shown in Figure 12-8.
 _When HINT_DRAW_IN_BOX is used for the upper composites, the object 
 groupings become much easier to distinguish._
 
-#### 12.2.6 Using Monikers
+### 12.2.6 Using Monikers
 
 Nearly all generic objects will have visual monikers (usually text labels) that 
 get drawn somewhere in or near the object. The moniker helps the user 
@@ -740,7 +740,7 @@ distinguish between different objects; for example, each trigger should have
 a text (or graphical) moniker giving some indication of what happens when 
 the trigger is pressed.
 
-##### 12.2.6.1 Placing Monikers in Relation to Children
+#### 12.2.6.1 Placing Monikers in Relation to Children
 
 HINT_PLACE_MONIKER_ABOVE, HINT_PLACE_MONIKER_BELOW, 
 HINT_PLACE_MONIKER_TO_LEFT, HINT_PLACE_MONIKER_TO_RIGHT, 
@@ -785,7 +785,7 @@ moniker edge coincides with the left edge of the first child below that
 moniker. This is usually the default behavior anyway, but different specific 
 UIs may have different default behavior.
 
-##### 12.2.6.2 Justifying or Centering on Monikers
+#### 12.2.6.2 Justifying or Centering on Monikers
 
 HINT_CENTER_CHILDREN_ON_MONIKERS, 
 HINT_LEFT_JUSTIFY_MONIKERS
@@ -810,7 +810,7 @@ Note that the two hints HINT_CENTER_CHILDREN_ON_MONIKERS and
 HINT_LEFT_JUSTIFY_MONIKERS are valid only for composites with one or 
 more child composites, all of which have monikers placed to their left.
 
-##### 12.2.6.3 Removing Moniker Borders
+#### 12.2.6.3 Removing Moniker Borders
 
 HINT_NO_BORDERS_ON_MONIKERS
 
@@ -821,7 +821,7 @@ these borders. It may be useful in cases where a custom border should be
 implemented, but in general should not be used to override the specific UI, as 
 this may confuse the user.
 
-#### 12.2.7 Using Custom Child Spacing
+### 12.2.7 Using Custom Child Spacing
 
 HINT_CUSTOM_CHILD_SPACING, 
 HINT_CUSTOM_CHILD_SPACING_IF_LIMITED_SPACE, 
@@ -890,7 +890,7 @@ HINT_MINIMIZE_CHILD_SPACING ensures that child spacing is kept to an
 absolute minimum, even if this means that object's edges will touch (in color 
 systems) or even overlap (in black and white systems). 
 
-#### 12.2.8 Allowing Children to Wrap
+### 12.2.8 Allowing Children to Wrap
 
 HINT_ALLOW_CHILDREN_TO_WRAP, HINT_WRAP_AFTER_CHILD_COUNT, 
 HINT_DONT_ALLOW_CHILDREN_TO_WRAP, 
@@ -936,7 +936,7 @@ allows you to allow child wrapping based on whether or not the screen is
 "vertical." If the screen is taller than it is wide, this hint will have an effect 
 like HINT_WRAP_AFTER_CHILD_COUNT; if not, the hint will have no effect.
 
-#### 12.2.9 Object Placement
+### 12.2.9 Object Placement
 
 As we have seen, generic objects can be arranged and distributed in several 
 ways. You may also place generic objects within certain areas of your user 
@@ -946,7 +946,7 @@ or "Apply" are located. You may specify objects to generically place
 themselves within such a reply bar, even though you may not know the exact 
 location of that reply bar as the specific UI creates it.
 
-##### 12.2.9.1 Reply Bars
+#### 12.2.9.1 Reply Bars
 
 HINT_MAKE_REPLY_BAR, HINT_SEEK_REPLY_BAR
 
@@ -999,7 +999,7 @@ to seek placement in the dialog box's reply bar. The specific UI will try to
 place the trigger in the reply bar of the first dialog box GenInteraction it finds 
 that is not GIT_ORGANIZATIONAL.
 
-##### 12.2.9.2 Placing Objects in Menu Bars
+#### 12.2.9.2 Placing Objects in Menu Bars
 
 HINT_SEEK_MENU_BAR, HINT_AVOID_MENU_BAR
 
@@ -1009,7 +1009,7 @@ window's menu bar by placing HINT_SEEK_MENU_BAR on that object.
 Similarly, you can place HINT_AVOID_MENU_BAR on an object to suggest 
 that it not be placed within the window's menu bar.
 
-##### 12.2.9.3 Placing Objects in Scroller Areas
+#### 12.2.9.3 Placing Objects in Scroller Areas
 
 HINT_SEEK_X_SCROLLER_AREA, HINT_SEEK_Y_SCROLLER_AREA, 
 HINT_SEEK_LEFT_OF_VIEW, HINT_SEEK_TOP_OF_VIEW, 
@@ -1027,7 +1027,7 @@ HINT_SEEK_LEFT_OF_VIEW, HINT_SEEK_TOP_OF_VIEW,
 HINT_SEEK_RIGHT_OF_VIEW and HINT_SEEK_BOTTOM_OF_VIEW suggest 
 that the generic object be placed alongside the respective side of the GenView.
 
-##### 12.2.9.4 Placing Objects in Window Title Bars
+#### 12.2.9.4 Placing Objects in Window Title Bars
 
 HINT_SEEK_TITLE_BAR_LEFT, HINT_SEEK_TITLE_BAR_RIGHT
 
@@ -1037,7 +1037,7 @@ objects involved should fit within the title bar area (i.e., be equivalent to to
 bar icons). For each window with a title bar, only one object may have each of 
 these hints, and the object must be a direct child of the windowed object.
 
-##### 12.2.9.5 Placement of Objects Popped Up
+#### 12.2.9.5 Placement of Objects Popped Up
 
 HINT_POPS_UP_TO_RIGHT, HINT_POPS_UP_BELOW
 
@@ -1051,7 +1051,7 @@ This hint instructs the specific UI to bring up the object below
 its activating gadget. This is usually the default behavior for 
 objects that are popped up.
 
-### 12.3 Positioning and Sizing Windows
+## 12.3 Positioning and Sizing Windows
 
 A generic object that appears as a window, such as an 
 independently-displayable GenInteraction or a GenPrimary, has special 
@@ -1117,7 +1117,7 @@ and one:
 To specify a constant offset, just use that offset, not setting the SWSS_RATIO 
 flag. Not all windows will use the **SpecWinSizePair** structure.
 
-#### 12.3.1 Window Positioning
+### 12.3.1 Window Positioning
 
 HINT_POSITION_WINDOW_AT_RATIO_OF_PARENT, 
 HINT_POSITION_WINDOW_AT_MOUSE, HINT_STAGGER_WINDOW, 
@@ -1169,7 +1169,7 @@ This hint removes all constraints upon the positioning of a
 window. It should only be used as the final attempt to position 
 the window if other methods do not work to your satisfaction.
 
-#### 12.3.2 Determining Initial Size
+### 12.3.2 Determining Initial Size
 
 HINT_EXTEND_WINDOW_TO_BOTTOM_RIGHT, 
 HINT_EXTEND_WINDOW_NEAR_BOTTOM_RIGHT, 
@@ -1216,7 +1216,7 @@ This hint instructs the window to come on-screen with its
 original values rather than the state of the window when it was 
 saved to state.
 
-#### 12.3.3 On-Screen Behavior
+### 12.3.3 On-Screen Behavior
 
 HINT_KEEP_INITIALLY_ONSCREEN, 
 HINT_DONT_KEEP_INITIALLY_ONSCREEN, 
@@ -1261,7 +1261,7 @@ HINT_NOT_MOVABLE
 This hint instructs the specific UI to make the windowed object 
 not movable. This hint should be avoided if at all possible. 
 
-#### 12.3.4 Window Look and Feel
+### 12.3.4 Window Look and Feel
 
 HINT_WINDOW_NO_TITLE_BAR, HINT_WINDOW_NO_SYS_MENU
 

--- a/TechDocs/Markdown/Concepts/cgetsta.md
+++ b/TechDocs/Markdown/Concepts/cgetsta.md
@@ -1,4 +1,4 @@
-## 4 First Steps: Hello World
+# 4 First Steps: Hello World
 
 This chapter provides you with an application shell to which you can add as 
 you learn more about GEOS programming. It describes each portion of the 
@@ -48,7 +48,7 @@ the Goc preprocessor. C header files do not have to go through the Goc
 preprocessor. Simple geodes might have none of their own header files. 
 These files are also described in [section 4.4](#44-the-source-file-and-source-code).
 
-### 4.2 Hello World
+## 4.2 Hello World
 
 The Hello World sample application (Hello3) is very simple and yet 
 accomplishes a great deal. With just a few simple steps, this program does 
@@ -74,7 +74,7 @@ may not be familiar yet. This section will describe each of those constructs
 and will refer to other sections of the documentation for complete 
 information.
 
-#### 4.2.1 Features of Hello World
+### 4.2.1 Features of Hello World
 
 To the user, the Hello World program is very simple. It consists of a primary 
 window with a single menu and a scrollable window within the primary. In 
@@ -95,7 +95,7 @@ _The Hello World application draws text in a scrolling View and has one menu
 and one dialog box. The Blue trigger changes the text to blue; the Gold trigger 
 changes the text to yellow._
 
-#### 4.2.2 Strategy and Internals
+### 4.2.2 Strategy and Internals
 
 The code for Hello World, as you will see, is quite simple. It consists mainly 
 of User Interface gadgetry and uses just a few message handlers.
@@ -124,7 +124,7 @@ it by the UI triggers and View. The other UI gadgets operate completely
 independently of the application's code; all of their functionality is 
 implemented within the UI._
 
-##### 4.2.2.1 The Menu and Dialog Box
+#### 4.2.2.1 The Menu and Dialog Box
 
 Both the menu and the dialog box, once defined in the source code as objects, 
 are implemented automatically by the system software. The application does 
@@ -138,7 +138,7 @@ modify the trigger objects, it must handle messages sent out by them when
 they are pressed by the user. This is discussed below, under ["Changing the 
 Text Color"](#4223-changing-the-text-color).
 
-##### 4.2.2.2 The Scrolling View and Drawing the Text
+#### 4.2.2.2 The Scrolling View and Drawing the Text
 
 Almost everything is handled automatically by the User Interface for the 
 Hello World application. This includes implementation of the system menus 
@@ -160,7 +160,7 @@ text is visible or what portion of the screen the view window occupies. The
 view will automatically clip the text properly and display it within the 
 window's bounds.
 
-##### 4.2.2.3 Changing the Text Color
+#### 4.2.2.3 Changing the Text Color
 
 In all, the Process object can handle six events specific to this application: 
 MSG_META_CONTENT_VIEW_WIN_OPENED (sent by the view when it first 
@@ -194,7 +194,7 @@ When the window closes, the view will send
 MSG_META_CONTENT_VIEW_WIN_CLOSED in which Hello World destroys 
 the cached window handle.
 
-#### 4.2.3 Naming Conventions
+### 4.2.3 Naming Conventions
 
 You might have noticed some of the names of variables, messages, and 
 routines and seen a pattern of naming. Geoworks has developed a few 
@@ -248,7 +248,7 @@ two portions are separated by an underscore. For example,
 GI_visMoniker is a field of **GenClass** (hence the GI_), and 
 visMoniker is the variable name of the field.
 
-### 4.3 Geode Parameters File
+## 4.3 Geode Parameters File
 
 Code Display 4-1 shows the Geode Parameters (hello3.gp) file for the Hello 
 World sample application. Each of the components of the parameters file is 
@@ -354,7 +354,7 @@ usernotes "Sample application for GEOS version 2.0."
 ~~~
 
 
-### 4.4 The Source File and Source Code
+## 4.4 The Source File and Source Code
 
 The Hello World program's source code resides in a single file, hello3.goc. 
 Portions of this file are presented throughout this section.
@@ -388,7 +388,7 @@ This discussion assumes you have a solid understanding of general
 programming concepts and C constructions. If you don't, you should most 
 likely get to know the C programming language before continuing.
 
-#### 4.4.1 Inclusions and Global Variables
+### 4.4.1 Inclusions and Global Variables
 
 As Code Display 4-2 shows, the first thing in a .goc file is a list of other files 
 and libraries that must be included. These are designated in the standard C 
@@ -462,7 +462,7 @@ WindowHandle    winHan;
 ~~~
 
 
-#### 4.4.2 The Process Object
+### 4.4.2 The Process Object
 
 Every GEOS application has an object called the Process object. This object is 
 run by the application's primary thread and is an instance of a subclass of 
@@ -533,7 +533,7 @@ This code display is part of hello3.goc and follows the previous display directl
 @classdecl HelloProcessClass, neverSaved;
 ~~~
 
-#### 4.4.3 UI Objects
+### 4.4.3 UI Objects
 
 As stated earlier, the bulk of the Hello World application consists of User 
 Interface objects. These objects are defined just after the Process object in 
@@ -552,7 +552,7 @@ takes up very little memory when iconified (minimized). Menus for complex
 applications are usually put in a menu resource. Most other UI gadgetry is 
 put in a resource called "Interface" (though this name is not required).
 
-##### 4.4.3.1 The Application Object
+#### 4.4.3.1 The Application Object
 
 Every application must have an application object, an instance of the class 
 **GenApplicationClass**. The application object handles and manages many 
@@ -603,7 +603,7 @@ This display is part of hello3.goc and follows the previous display directly.
 @end    AppResource                     /* End definition of objects in AppResource. */
 ~~~
 
-##### 4.4.3.2 The Primary Window and the View Window
+#### 4.4.3.2 The Primary Window and the View Window
 
 Every application must have a primary window object of class 
 **GenPrimaryClass**. This object will draw and manage the primary window 
@@ -710,7 +710,7 @@ This display is part of hello3.goc and directly follows the previous display.
 @end    Interface               /* End definition of objects in this resource. */
 ~~~
 
-##### 4.4.3.3 The Hello World Menu
+#### 4.4.3.3 The Hello World Menu
 
 The Hello World program has one menu, called "Menu" and located in the 
 primary window's menu bar. Menus are instances of **GenInteractionClass** 
@@ -747,7 +747,7 @@ This display is part of hello3.goc and follows the previous display directly.
 }
 ~~~
 
-##### 4.4.3.4 The Dialog Box and Its Triggers
+#### 4.4.3.4 The Dialog Box and Its Triggers
 
 Code Display 4-7 shows the code for the dialog box and its triggers.
 
@@ -833,7 +833,7 @@ This display is part of hello3.goc and follows the previous display directly.
 }
 ~~~
 
-#### 4.4.4 Code and Message Handlers
+### 4.4.4 Code and Message Handlers
 
 One of the first things a C programmer might notice when looking at the 
 Hello World program is that it has no main() routine. This illustrates the 
@@ -909,7 +909,7 @@ void HelloDrawText(GStateHandle gstate);
 #define TEXT_Y_POSITION         100     /* y position, in document coords. */
 ~~~
 
-##### 4.4.4.1 Handling the Window Messages
+#### 4.4.4.1 Handling the Window Messages
 
 As stated earlier, the winHan global variable contains the window handle of 
 the view's window. To set the variable, Hello World must intercept and 
@@ -1141,7 +1141,7 @@ void HelloDrawText(GStateHandle gstate) {
 }
 ~~~
 
-##### 4.4.4.3 Handling Messages from the Triggers
+#### 4.4.4.3 Handling Messages from the Triggers
 
 When the user clicks on one of the two triggers in the Color dialog box, the 
 pressed trigger sends off a message to the Hello World Process object. The 
@@ -1190,7 +1190,7 @@ This display is part of hello3.goc and follows the previous display directly.
 }
 ~~~
 
-### 4.5 Exercises and Suggestions
+## 4.5 Exercises and Suggestions
 
 After studying the Hello World sample application and reading the System 
 Architecture chapter, you may be ready to try some exercises before 

--- a/TechDocs/Markdown/Concepts/cgraph.md
+++ b/TechDocs/Markdown/Concepts/cgraph.md
@@ -1,4 +1,4 @@
-## 23 Graphics Environment
+# 23 Graphics Environment
 
 The GEOS graphics system provides many powerful tools to enhance your 
 geode's appearance and graphical capabilities.
@@ -17,7 +17,7 @@ see ["Drawing Graphics," Chapter 24](cshapes.md).
 Before reading this chapter, you should be familiar with the basics of the 
 generic UI and messaging. You may also want to review high school geometry.
 
-### 23.1 Graphics Road Map
+## 23.1 Graphics Road Map
 
 Graphics is a big topic. It has many applications and thus many ways to 
 apply it. If you will be writing graphics-intensive programs, you'll probably 
@@ -28,7 +28,7 @@ This section is for those people who would like to skip around the GEOS
 imaging system. It contains an outline of the chapter as well as a list of 
 definitions for terms that will be used throughout.
 
-#### 23.1.1 Chapter Structure
+### 23.1.1 Chapter Structure
 
 This chapter is divided into sections. Which sections you'll want to read 
 depend on what you're interested in.
@@ -91,7 +91,7 @@ does to maintain windows in a Graphical User Interface.
 Included is an in-depth look at clipping, along with some 
 commands by which you can change the way clipping works.
 
-#### 23.1.2 Vocabulary
+### 23.1.2 Vocabulary
 
 Several terms will crop up again and again in your dealings with graphics. 
 Many of these terms will be familiar to programmers experienced with other 
@@ -235,7 +235,7 @@ useful for programs which allow the users to construct some
 sort of graphical document or provide a sort of graphical 
 overlay for a spreadsheet.
 
-### 23.2 Graphics Goals
+## 23.2 Graphics Goals
 
 The graphics system is in charge of displaying everything in GEOS. Thus, it 
 is vital that the GEOS graphics system be both powerful and easy to use. 
@@ -275,7 +275,7 @@ screen and printed images through the same language, the screen can
 display a document just as it will be printed. Except for differences in 
 resolution, what you see is what you get.
 
-### 23.3 Graphics Architecture
+## 23.3 Graphics Architecture
 
 The graphics system involves many pieces of GEOS working together to turn 
 an application's UI and graphics commands into drawings on a display.
@@ -304,7 +304,7 @@ manager. If the requested font isn't already in memory, the font manager
 loads it. The font manager then makes calls to the individual font driver for 
 information about specific characters.
 
-### 23.4 How To Use Graphics
+## 23.4 How To Use Graphics
 
 When looking at the source code of sample applications, it's usually not too 
 hard to pick out the commands that do the actual drawing. Commands with 
@@ -378,7 +378,7 @@ however, be sure that the spaceship will be drawn to the right place if the
 game's window is obscured and then exposed. Don't worry if this sounds 
 confusing now, but keep these words in mind as you read on.
 
-### 23.5 Coordinate Space
+## 23.5 Coordinate Space
 
 The graphics system uses a rectangular coordinate grid to specify the size 
 and position at which drawing commands will be carried out. This is a logical 
@@ -433,7 +433,7 @@ approach closer to a pure mathematical Cartesian plane. Programmers used
 to working with device-based coordinates are especially encouraged to read 
 [section 23.5.4](#2354-device-coordinates) to learn about some of the differences. 
 
-#### 23.5.2 Coordinate Transformations
+### 23.5.2 Coordinate Transformations
 
 GEOS provides routines which "transform" the coordinate space. These 
 commands can shift, magnify, or rotate the coordinate grid, or perform 
@@ -486,7 +486,7 @@ rotated and then translated. The drawing on the right received the same
 transformations but in reverse order. Note that the drawings ended up being 
 drawn to different positions._
 
-##### 23.5.2.1 Simple Transformations
+#### 23.5.2.1 Simple Transformations
 
 GrApplyRotation(), GrApplyScale(), GrApplyTranslation(), 
 GrSetDefaultTransform(), GrSetNullTransform(), 
@@ -539,7 +539,7 @@ There are "push" and "pop" operations for transformations. To keep a record
 of the GState's current transformation, call **GrSaveTransform()**. To restore 
 the saved transformation, call **GrRestoreTransform()**.
 
-##### 23.5.2.2 Complicated Transformations
+#### 23.5.2.2 Complicated Transformations
 
 GrApplyTransform(), GrSetTransform(), GrGetTransform(), 
 GrTransformByMatrix(), GrUntransformByMatrix()
@@ -604,7 +604,7 @@ makes a difference what order you make the transformations and thus
 makes a difference based on what order you multiply the matrices (See 
 Figure 23-6 and Equation 23-2).
 
-#### 23.5.3 Precise Coordinates
+### 23.5.3 Precise Coordinates
 
 As has been previously stated, coordinates are normally given in 
 typographer's points. Most graphics commands accept coordinates accurate 
@@ -627,7 +627,7 @@ commands to draw the components of the outline. To fill an area, use the
 precise drawing commands to describe the path forming the outline of the 
 area, then fill the path.
 
-#### 23.5.4 Device Coordinates
+### 23.5.4 Device Coordinates
 
 Most programmers can work quite well within the document space 
 regardless of how coordinates will correspond to device coordinates. However, 
@@ -636,7 +636,7 @@ The system provides clever algorithms for going from document to device
 space for all programmers, as well as routines to get device coordinate 
 information from the device driver.
 
-##### 23.5.4.1 What the System Draws on the Device
+#### 23.5.4.1 What the System Draws on the Device
 
 Consider a device whose pixels are exactly 1/72nd of an inch, such that no 
 scaling is required to map document units to device units. The relationship 
@@ -709,7 +709,7 @@ the gaps, resulting in a continuous line drawn as on the right._
 Since ellipses and Bèzier curves are drawn as polylines, Bresenham's 
 algorithm will work with them.
 
-##### 23.5.4.2 Converting Between Doc and Device Coordinates
+#### 23.5.4.2 Converting Between Doc and Device Coordinates
 
 GrTransform(), GrUntransform(), GrTransformWWFixed(), 
 GrUntransformWWFixed()
@@ -728,7 +728,7 @@ To transform points through an arbitrary transformation instead of to device
 coordinates, use the **GrTransformByMatrix()** or 
 **GrUntransformByMatrix()** routines, described previously.
 
-#### 23.5.5 Larger Document Spaces
+### 23.5.5 Larger Document Spaces
 
 GrApplyDWordTranslation(), GrTransformDWord(), 
 GrUntransformDWord(), GrTransformDWFixed(), 
@@ -788,7 +788,7 @@ this rectangle, you would have to divide it into two pieces._
 and **GrUntransformWWFixed()**, with two words in the integer part of the 
 number instead of one.
 
-#### 23.5.6 Current Position
+### 23.5.6 Current Position
 
 GrMoveTo(), GrRelMoveTo(), GrGetCurPos(), GrGetCurPosWWFixed()
 
@@ -818,7 +818,7 @@ current position, the current position is used to place the left side of the tex
 When done drawing the text, the current position has moved to the right side 
 of the text.
 
-### 23.6 Graphics State
+## 23.6 Graphics State
 
 The data structure known as the Graphics State, or GState, keeps track of 
 changes your code makes about how it wants to draw things. If your geode 
@@ -829,7 +829,7 @@ wide until the width is set to something else. Many graphics routines ask
 that you pass a GState along as one of the parameters so they know where 
 and how to draw what you've requested.
 
-#### 23.6.1 GState Contents
+### 23.6.1 GState Contents
 
 Sometimes it's convenient to think of the GState as being analogous to the 
 Properties boxes in GeoDraw. The GState keeps track of how the program 
@@ -899,7 +899,7 @@ The function of many of these parts may be fairly intuitive to someone used
 to working with graphics programs. Some of the others may require 
 additional explanation, especially when it comes to how to work with them.
 
-#### 23.6.2 Working with GStates
+### 23.6.2 Working with GStates
 
 GrCreateState(), GrDestroyState(), GrSaveState(), GrRestoreState()
 
@@ -944,7 +944,7 @@ to duplicate the region. **GrSaveTransform()** and **GrRestoreTransform()**
 are optimizations of **GrSaveState()** and **GrRestoreState()**, but they only 
 preserve the GState's transformation.
 
-### 23.7 Working With Bitmaps
+## 23.7 Working With Bitmaps
 
 GrCreateBitmap(), GrDestroyBitmap(), GrEditBitmap() 
 GrGetPoint(), GrSetBitmapMode(), GrGetBitmapMode(), 
@@ -1072,7 +1072,7 @@ bitmaps draw more quickly. Note that the bitmap drawing routines can
 handle compacted and uncompacted bitmaps. These functions are here to aid 
 programmers who wish more immediate control over their memory usage.
 
-### 23.8 Graphics Strings
+## 23.8 Graphics Strings
 
 A GString is a data structure which represents a series of graphics 
 commands. This structure may be stored in a chunk or VM file so that it may 
@@ -1080,7 +1080,7 @@ be played back later. An application may declare a GString statically or may
 create one dynamically using standard kernel drawing commands. They are 
 used for describing application icons and printer jobs, among other things. 
 
-#### 23.8.1 Storage and Loading
+### 23.8.1 Storage and Loading
 
 GrCreateGString(), GrDestroyGString(), GrLoadGString(), 
 GrEditGString(), GrCopyGString(), GrGetGStringHandle(), 
@@ -1181,7 +1181,7 @@ To find the handle of the GString data associated with a GState, call
 **GrGetGStringHandle()**. To update the VM file associated with a GString 
 (perhaps after calling **VMSave()**), use **GrSetVMFile()**.
 
-#### 23.8.2 Special Drawing Commands
+### 23.8.2 Special Drawing Commands
 
 GrEndGString(), GrNewPage(), GrLabel(), GrComment(), 
 GrNullOp(), GrEscape(), GrSetGStringBounds()
@@ -1264,7 +1264,7 @@ bounds of the GString. You should call this routine early on in your GString
 definition so that the system won't have to traverse very much of your 
 GString to discover the special element.
 
-#### 23.8.3 Declaring a GString Statically
+### 23.8.3 Declaring a GString Statically
 
 For most programmers, the first encounter with GStrings (often, in fact, their 
 first encounter with any sort of graphics mechanism) is with a program icon. 
@@ -1407,7 +1407,7 @@ static const byte gstring[] = {
 For more examples of statically declared GStrings, see the Moniker, GSTest, 
 and GSTest2 sample applications.
 
-#### 23.8.4 Creating GStrings Dynamically
+### 23.8.4 Creating GStrings Dynamically
 
 Sometimes it comes in handy to be able to create GStrings "on the fly." To add 
 elements to a GString, issue normal kernel drawing commands, but use a 
@@ -1547,7 +1547,7 @@ Probably the most important piece of advice is to think about how the
 Graphics String will be used. If it will be used only under certain 
 well-controlled circumstances, the above concerns may not affect you.
 
-#### 23.8.5 Drawing and Scanning
+### 23.8.5 Drawing and Scanning
 
 GrDrawGString(), GrDrawGStringAtCP(), GrSetGStringPos(), 
 GrGetGStringBounds(), GrGetGStringBoundsDWord()
@@ -1685,7 +1685,7 @@ returning the coordinates describing the GString's bounding rectangle. If the
 GString may have very large bounds, you should use the 
 **GrGetGStringBoundsDWord()** routine instead.
 
-#### 23.8.6 Editing GStrings Dynamically
+### 23.8.6 Editing GStrings Dynamically
 
 GrEditGString(), GrDeleteGStringElement()
 
@@ -1707,7 +1707,7 @@ of GString elements. The elements deleted will be taken starting at your
 position in the GString. This command only works while editing the GString, 
 and you must pass the GString's editing GState handle to this routine.
 
-#### 23.8.7 Parsing GStrings
+### 23.8.7 Parsing GStrings
 
 GrGetGStringElement(), GrParseGString()
 
@@ -1801,7 +1801,7 @@ all of the GString elements.
 The callback routine is passed a pointer to the GString element and the 
 handle of the GState that was passed to **GrParseGString()**.
 
-### 23.9 Graphics Paths
+## 23.9 Graphics Paths
 
 GrBeginPath(), GrEndPath(), GrCloseSubPath(), 
 GrSetStrokePath(), GrGetPathBounds(), GrTestPointInPath(), 
@@ -1898,13 +1898,13 @@ chapter 24](cshapes.md#24211-paths).
 **GrGetPath()** retrieves the handle of a block containing the path's data. You 
 may pass this handle to **GrSetPath()** and thus copy a path to another GState.
 
-### 23.10 Working With Video Drivers
+## 23.10 Working With Video Drivers
 
 The main benefit of the device independence is that the geode writer can 
 issue graphics commands without worrying about the device. Working with 
 the video driver is left to the graphics system.
 
-#### 23.10.1 Kernel Routines
+### 23.10.1 Kernel Routines
 
 GrInvalRect(), GrInvalRectDWord(), GrGrabExclusive(), 
 GrGetExclusive(), GrReleaseExclusive(), GrBitBlt(), 
@@ -1957,26 +1957,26 @@ find out the color of a pixel.
 At some times, it may prove useful to know what window, if any, is associated 
 with a GState. To find out, call **GrGetWinHandle()**.
 
-#### 23.10.2 Direct Calls to the Driver
+### 23.10.2 Direct Calls to the Driver
 
 Rarely, a geode may wish to make direct calls to the video driver. In most 
 cases, anything your code might want the video driver to do can be handled 
 better by going through the appropriate graphics routine.
 
-### 23.11 Windowing and Clipping
+## 23.11 Windowing and Clipping
 
 Windows are the interface between the graphics commands and the GEOS 
 user interface. In this section we will discuss some of the graphical 
 mechanisms associated with windows in GEOS. 
 
-#### 23.11.1 Palettes
+### 23.11.1 Palettes
 
 Each window has a color palette associated with it. For more information 
 about manipulating palettes, see [section 24.3.1.3 of chapter 24](cshapes.md#24313-color). 
 The system will use the palette of whatever window is active. As a result, if two windows 
 have different palettes, when one window is active, the other's colors will be distorted.
 
-#### 23.11.2 Clipping
+### 23.11.2 Clipping
 
 GrSetClipPath(), GrSetClipRect(), GrGetClipRegion(), 
 GrTestRectInMask(), GrSetWinClipRect(), GrGetMaskBounds(), 
@@ -2032,7 +2032,7 @@ associated with the window; you should never have occasion to use it.
 the window clipping path. To find out whether there is a window clipping 
 path at all, call **GrTestPath()** and pass GPT_WIN_CLIP.
 
-#### 23.11.3 Signalling Updates
+### 23.11.3 Signalling Updates
 
 GrBeginUpdate(), GrEndUpdate()
 

--- a/TechDocs/Markdown/Concepts/chandle.md
+++ b/TechDocs/Markdown/Concepts/chandle.md
@@ -1,4 +1,4 @@
-## 14 Handles
+# 14 Handles
 
 One of the most important data types in GEOS is the handle. There are many 
 different types of handles serving many different purposes. However, they all 
@@ -14,7 +14,7 @@ principles of memory usage and data manipulation. These topics are covered
 in greater detail in other chapters in this book, particularly in the chapters 
 on ["Memory Management," Chapter 15](cmemory.md) and ["Local Memory," Chapter 16](clmem.md).
 
-### 14.1 Design Philosophy
+## 14.1 Design Philosophy
 
 GEOS handles play many different roles. The most fundamental of these is 
 memory access. GEOS moves memory in the global heap and swaps memory 
@@ -78,7 +78,7 @@ Such handles are offsets into handle tables which may be stored in
 memory blocks or VM files. These handles persist as long as the entity 
 containing the handle table does.
 
-### 14.2 The Global Handle Table
+## 14.2 The Global Handle Table
 
 Many handles refer to things which are managed by the kernel. These things 
 include global memory blocks, disk volumes, files, and many other things. 
@@ -99,7 +99,7 @@ will need to synchronize their access to it. They can arrange this by using the
 synchronize access to a global memory block; for this reason, they are 
 documented in [section 15.3.6 of "Memory Management," Chapter 15](cmemory.md#1536-memory-management).
 
-### 14.3 Local Handles
+## 14.3 Local Handles
 
 Many handles are not kept in the global handle table. For example, a block 
 of memory may be declared as a "local-memory (LMem) heap." An LMem 

--- a/TechDocs/Markdown/Concepts/chardw.md
+++ b/TechDocs/Markdown/Concepts/chardw.md
@@ -1,4 +1,4 @@
-## A Machine Architecture
+# A Machine Architecture
 
 The GEOS operating system is state-of-the art technology based on the 
 Intel 80x86 microprocessor. This chapter discusses some of the elements of 
@@ -9,7 +9,7 @@ this overview but also to pick up a book about the Intel chip series. There
 are dozens of good books about the 80x86 chips, and this section provides 
 only a brief review.
 
-### A.1 History of the 80x86
+## A.1 History of the 80x86
 
 The commercial microcomputer essentially began with Intel's introduction 
 of the 8008 chip in 1972. This was an 8-bit machine that eventually led to 
@@ -43,7 +43,7 @@ Both the 8088 and the 8086 can run the same software; they use the same
 instruction set. However, the power of the data processing offered by the 
 8086 eventually won out as systems and software became more complex.
 
-### A.2 8086 Architecture Overview
+## A.2 8086 Architecture Overview
 
 The 8086 uses a 16-bit architecture but can handle 8-bit data as well. It 
 accesses up to one megabyte (1024K) of memory, sixteen times more than 

--- a/TechDocs/Markdown/Concepts/cinput.md
+++ b/TechDocs/Markdown/Concepts/cinput.md
@@ -1,4 +1,4 @@
-## 11 Input
+# 11 Input
 
 Nearly all applications will in some way handle user input. User input can 
 come from a keyboard, a mouse, or a stylus. (Other types of input are 
@@ -20,7 +20,7 @@ passing. It is also suggested that you spend some time programming with
 generic and visible objects and getting used to the rest of the system before 
 handling input events.
 
-### 11.1 Input Flow
+## 11.1 Input Flow
 
 User input must flow in an orderly way from the user's device to the proper 
 GEOS object. In a multithreaded environment, just determining the 
@@ -78,7 +78,7 @@ additional information (e.g. the location of the mouse at the time). Each
 device has its own set of events-for example, keyboard presses induce 
 MSG_META_KBD_CHAR, and mouse moves induce MSG_META_MOUSE_PTR.
 
-#### 11.1.1 Devices and Drivers
+### 11.1.1 Devices and Drivers
 
 GEOS supports a number of input devices through the use of device drivers. 
 The basic GEOS system software supports mouse, keyboard, and stylus 
@@ -98,7 +98,7 @@ it into raw input events that the Input Manager will understand. Your
 objects will never receive these events; they are only sent to the Input 
 Manager for translation into pointer, button, or keyboard events.
 
-#### 11.1.2 Input Manager and GenSystem
+### 11.1.2 Input Manager and GenSystem
 
 The Input Manager is part of the User Interface and primarily assesses input 
 events in the context of the system. It takes a raw input event from the device 
@@ -110,7 +110,7 @@ The GenSystem object determines where the event should be passed.
 Typically, it will send the event on to whichever application is designated as 
 the active application.
 
-#### 11.1.3 Input Events
+### 11.1.3 Input Events
 
 GEOS uses three basic types of input events. These three types make up all 
 the events necessary for mouse, keyboard, and pen input. They are pointer 
@@ -152,7 +152,7 @@ completely separate manner. An object expecting Ink input must be aware
 when Ink events are being passed as opposed to normal mouse events. 
 Special flags are used for this; see [section 11.4](#114-pen-input-and-ink).
 
-#### 11.1.4 Input Hierarchies
+### 11.1.4 Input Hierarchies
 
 Because the entire User Interface of GEOS is implemented as a hierarchy 
 (tree) of objects, input messages naturally flow from the topmost object in the 
@@ -189,7 +189,7 @@ normal target, but it may still need to have similar properties. The Model
 hierarchy can be used to maintain this type of secondary or non-visible 
 selection.
 
-### 11.2 Mouse Input
+## 11.2 Mouse Input
 
 GEOS is built around the user's use of a mouse for most input. Although the 
 system has extensive keyboard navigation capabilities, the mouse is still the 
@@ -223,7 +223,7 @@ with the appropriate bounds) is adequate for most input needs. If you are
 using large documents or visible layers, you will have to subclass the 
 VisContent to handle these special cases.
 
-#### 11.2.1 Mouse Events
+### 11.2.1 Mouse Events
 
 Each time the user moves the mouse or clicks a mouse button, GEOS 
 generates a mouse event and passes it to the proper object. Mouse events are 
@@ -377,7 +377,7 @@ MSG_META_START_SELECT is inherently different from
 MSG_META_START_MOVE_COPY, even though they may pass the exact same 
 values.
 
-###### 11.2.1.1 Structure of Mouse Events
+#### 11.2.1.1 Structure of Mouse Events
 
 Each mouse event passes three items of data and one pointer to a return 
 structure. The three parameters are listed below; the fourth, the return 
@@ -472,7 +472,7 @@ This is the same bit as UIFA_EXTEND and UIFA_COPY, above.
 When UIFA_FEATURES is also set, this flag indicates the 
 "features" button has initiated pan-style scrolling.
 
-##### 11.2.1.2 Return Values for Mouse Events
+#### 11.2.1.2 Return Values for Mouse Events
 
 One of the parameters of every mouse event is a pointer to a 
 **MouseReturnParams** structure. This structure is passed empty; it is up to 
@@ -532,7 +532,7 @@ in the ptrImage field of the return structure. For full information on
 If you are not setting the pointer image, return a NullOptr in ptrImage. You 
 do not have to return anything in the unused field.
 
-#### 11.2.2 Gaining the Mouse Grab
+### 11.2.2 Gaining the Mouse Grab
 
 When no object has the active mouse grab, mouse events are passed to 
 whichever object is directly under the pointer's image. If any object has the 
@@ -604,7 +604,7 @@ MSG_META_POST_PASSIVE_END_FEATURES
 MSG_META_POST_PASSIVE_START_OTHER  
 MSG_META_POST_PASSIVE_END_OTHER  
 
-#### 11.2.3 Large Mouse Events
+### 11.2.3 Large Mouse Events
 
 Applications and visible objects that use large documents (32-bit coordinate 
 spaces) receive special versions of the mouse input messages. These special 
@@ -628,7 +628,7 @@ tree, see ["VisClass," Chapter 23 of the Object Reference Book](../Objects/ovis.
 information also applies to Process objects acting as the contents of 
 GenViews.)
 
-#### 11.2.4 Setting the Pointer Image
+### 11.2.4 Setting the Pointer Image
 
 The GEOS User Interface uses several default settings for the mouse pointer, 
 all defined by the Specific UI. 
@@ -640,7 +640,7 @@ after the move is completed; a graphics application could set the pointer to
 an image of whatever tool is currently in use. Another time an application 
 may change the mouse pointer is when a quick-transfer is in progress.
 
-##### 11.2.4.1 Defining the Pointer Image
+#### 11.2.4.1 Defining the Pointer Image
 
 The pointer is defined as a bitmap 16 pixels on each side. It has a "hot spot" 
 of five pixels that acts as the active point of the image. When the user clicks, 
@@ -704,7 +704,7 @@ _The mask determines how the image mixes with the background. The outline
 of the arrow is XORed with the background; the interior of the arrow is 
 always drawn black._
 
-##### 11.2.4.2 Setting the Pointer Image
+#### 11.2.4.2 Setting the Pointer Image
 
 You can set the pointer's image in three ways. First, you can send a message 
 to the GenView to set the pointer image whenever the pointer is over the 
@@ -735,7 +735,7 @@ This field gives the handle and chunk handle of the **PointerDef**
 structure that defines the pointer image to be set. The structure must be 
 in a sharable block; most likely you will have it set in a geode resource.
 
-### 11.3 Keyboard Input
+## 11.3 Keyboard Input
 
 Keyboard input is scanned by a device driver and passed on to the Input 
 Manager, just as mouse input is. The keyboard driver and Input Manager 
@@ -743,7 +743,7 @@ check the state of the modifier keys (shift, ctrl, alt, num lock, etc.) and pars
 each keypress as much as possible based on its context. Each keypress is 
 called a keyboard event and is passed in MSG_META_KBD_CHAR.
 
-#### 11.3.1 Keyboard Input Flow
+### 11.3.1 Keyboard Input Flow
 
 Each time the user presses a character (with or without modifier keys) on the 
 keyboard, the Input Manager generates a single keyboard event and passes 
@@ -783,7 +783,7 @@ HINT_DEFAULT_FOCUS for that object and all its parents up to the
 GenPrimary containing it. Otherwise, the generic UI does not know which 
 object should gain the default focus.
 
-#### 11.3.2 Keyboard Events
+### 11.3.2 Keyboard Events
 
 Each keyboard event your application and objects receive has gone through 
 preliminary parsing by the keyboard driver. Keyboard drivers are intelligent 
@@ -962,7 +962,7 @@ Code Display 11-1 Sample MSG_META_KBD_CHAR Handler
 }
 ~~~
 
-### 11.4 Pen Input and Ink
+## 11.4 Pen Input and Ink
 
 GEOS supports pen-based systems and applications by means of the Ink data 
 structure formats. Ink is simply a standard way of representing raw pen 
@@ -988,7 +988,7 @@ Because Ink events are not passed on immediately by the UI, the UI actually
 takes care of drawing them directly to the screen. This provides the user 
 direct, immediate feedback.
 
-#### 11.4.1 Ink Data Structures
+### 11.4.1 Ink Data Structures
 
 Ink input is stored in data blocks. The Input Manager stores up Ink events 
 into a data block and then transfers the block to the proper window or 
@@ -1034,7 +1034,7 @@ Actually a label indicating the beginning of the list of points.
 Following this label will be a number of **Point** structures, each 
 one detailing a single Ink point.
 
-#### 11.4.2 Ink Input Flow
+### 11.4.2 Ink Input Flow
 
 When the Input Manager receives a button event, it checks to see if that 
 event should be treated as Ink input. It first holds up input, putting the 
@@ -1043,7 +1043,7 @@ application with MSG_META_QUERY_IF_PRESS_IS_INK. Typically the
 application will pass the message down its object tree to the appropriate 
 visible or generic object that should initially have received the button event.
 
-##### 11.4.2.1 Determining if a Press Is Ink
+#### 11.4.2.1 Determining if a Press Is Ink
 
 It is up to the application or its visible object to determine whether the input 
 should be treated as Ink. If you don't ever handle Ink, you do not need to do 
@@ -1110,7 +1110,7 @@ MSG_META_QUERY_IF_PRESS_IS_INK handler. (Or if all objects running in
 the same GenView want this behavior, you can simply set the GenView's 
 GVIT_INK_WITH_STANDARD_OVERRIDE flag.)
 
-##### 11.4.2.2 Controlling the Ink
+#### 11.4.2.2 Controlling the Ink
 
 When an object requests Ink input by returning IRV_DESIRES_INK or 
 IRV_INK_WITH_STANDARD_OVERRIDE, it must also specify the eventual 
@@ -1169,7 +1169,7 @@ Virtual fptr to a callback routine to determine whether a stroke
 is a gesture or not. This callback routine will be passed to 
 ProcCallFixedOrMovable().
 
-##### 11.4.2.3 How Ink Is Stored and Passed On
+#### 11.4.2.3 How Ink Is Stored and Passed On
 
 When the user presses the pen to the screen and the input is determined to 
 be Ink, the Input Manager generates a mouse button press event and begins 
@@ -1202,7 +1202,7 @@ to the GenSystem object using MSG_META_NOTIFY_WITH_DATA_BLOCK
 with the identifier NT_INK. (For information on this and other notification 
 messages, see ["General Change Notification," Chapter 9](cgcn.md).)
 
-### 11.5 Input Hierarchies
+## 11.5 Input Hierarchies
 
 As previously mentioned in this chapter, the Input Manager channels input 
 events to particular objects. The objects are chosen based on the current 
@@ -1234,7 +1234,7 @@ a fourth, the controller, but it is used only internally by GEOS.) These
 hierarchies all function in the same manner but are used for different 
 purposes.
 
-#### 11.5.1 The Three Hierarchies
+### 11.5.1 The Three Hierarchies
 
 As stated above, GEOS offers three hierarchies you can use for input flow and 
 specification of message destinations. These hierarchies, with their basic 
@@ -1266,7 +1266,7 @@ extends from the GenSystem through the GenApplication and the
 document control objects. The Model hierarchy is described in full in 
 [section 11.5.5](#1155-using-model).
 
-#### 11.5.2 Common Hierarchy Basics
+### 11.5.2 Common Hierarchy Basics
 
 All three of the input hierarchies function in a similar manner. Each relies 
 on the basic tree structure of UI objects to build a path from the topmost 
@@ -1305,7 +1305,7 @@ be given to the leaf node specified without actually changing the object tree
 Note that the other hierarchies operate in a similar manner. The behavior 
 described is not unique to the target hierarchy.
 
-##### 11.5.2.1 Special Terminology
+#### 11.5.2.1 Special Terminology
 
 Before reading the in-depth sections on the individual hierarchies, you 
 should know how several terms are defined and used. These terms are listed 
@@ -1346,7 +1346,7 @@ the topmost node of an inactive path is given the exclusive at
 its level, the entire inactive path will automatically become the 
 active path.
 
-##### 11.5.2.2 Modifying the Active Path
+#### 11.5.2.2 Modifying the Active Path
 
 Each of the three hierarchies has messages understood by **MetaClass** that 
 alter the hierarchy's active path. The Specific UI takes care of most of the 
@@ -1368,7 +1368,7 @@ node will be notified that it has lost the exclusive at its level. See the
 discussions of the individual hierarchies for more detail on the messages 
 used.
 
-##### 11.5.2.3 Sending Classed Messages
+#### 11.5.2.3 Sending Classed Messages
 
 Any object can easily send messages to the object having the active exclusive 
 of a given hierarchy using MSG_META_SEND_CLASSED_EVENT. This 
@@ -1409,7 +1409,7 @@ object, the topmost object in the entire UI object tree. The classed event
 will be passed down the active path, using the GenSystem object as the 
 path's top node.
 
-#### 11.5.3 Using Focus
+### 11.5.3 Using Focus
 
 The specific UI handles most of the manipulation of the focus hierarchy. Most 
 specific UIs interpret keyboard and mouse events and know when to switch 
@@ -1448,7 +1448,7 @@ HINT_DEFAULT_FOCUS in its instance data. If no objects have this hint at a
 particular focus level, then the focus will be granted to the first focusable 
 child.
 
-##### 11.5.3.1 Grabbing and Releasing the Focus
+#### 11.5.3.1 Grabbing and Releasing the Focus
 
 To grab the focus exclusive in its level, a node should send itself 
 MSG_META_GRAB_FOCUS_EXCL. The default handler for this message grabs 
@@ -1470,7 +1470,7 @@ MSG_META_GET_FOCUS_EXCL may be sent to any focusable composite node
 to get the optr of the node's child having the exclusive. This message may be 
 used even on nodes in the inactive path.
 
-##### 11.5.3.2 Gaining and Losing the Focus
+#### 11.5.3.2 Gaining and Losing the Focus
 
 When an object gains the active focus exclusive and is a node in the active 
 path, it receives MSG_META_GAINED_FOCUS_EXCL. This indicates to the 
@@ -1478,7 +1478,7 @@ object that it will receive all keyboard input as the active keyboard object. At
 some point later, when the object has lost the focus exclusive, it will receive 
 MSG_META_LOST_FOCUS_EXCL.
 
-##### 11.5.3.3 Sending Classed Events to the Focus
+#### 11.5.3.3 Sending Classed Events to the Focus
 
 Frequently, you may wish to send messages to objects in the active Focus 
 path. The easiest way to deliver a message to an object in the focus hierarchy 
@@ -1541,7 +1541,7 @@ Code Display 11-2 Delivering Messages to the Focus
 }
 ~~~
 
-#### 11.5.4 Using Target
+### 11.5.4 Using Target
 
 The specific UI handles most of the manipulation of the target hierarchy. 
 Most specific UIs interpret keyboard and mouse events and know when to 
@@ -1589,7 +1589,7 @@ granted to the object with HINT_DEFAULT_TARGET in its instance data. If no
 object has this hint at a particular target level, then the target will be 
 granted to the first targetable object at that level.
 
-##### 11.5.4.1 Grabbing and Releasing the Target
+#### 11.5.4.1 Grabbing and Releasing the Target
 
 To grab the target exclusive in its level, a node should send itself 
 MSG_META_GRAB_TARGET_EXCL. The default handler for this message 
@@ -1611,7 +1611,7 @@ MSG_META_GET_TARGET_EXCL may be sent to any targetable composite
 node to get the optr of the node's child having the exclusive. This message 
 may be used even on nodes in the inactive path.
 
-##### 11.5.4.2 Gaining and Losing the Target
+#### 11.5.4.2 Gaining and Losing the Target
 
 When an object gains the active target exclusive and is a node in the active 
 path, it receives MSG_META_GAINED_TARGET_EXCL. This indicates to the 
@@ -1619,7 +1619,7 @@ object that it will receive all keyboard input as the active keyboard object. At
 some point later, when the object has lost the target exclusive, it will receive 
 MSG_META_LOST_TARGET_EXCL.
 
-##### 11.5.4.3 Sending Classed Events to the Target
+#### 11.5.4.3 Sending Classed Events to the Target
 
 Frequently, you may wish to send messages to objects in the active Target 
 path. The easiest way to deliver a message to an object in the target 
@@ -1684,7 +1684,7 @@ Code Display 11-3 Delivering Messages to the Target
 }
 ~~~
 
-#### 11.5.5 Using Model
+### 11.5.5 Using Model
 
 In some cases, you may need to send or receive information from some object 
 other than the focus or target. The Model hierarchy is provided as an 
@@ -1733,7 +1733,7 @@ This approach is desirable over using MSG_META_GET_MODEL_EXCL to
 return an optr for later use as the system may have corrupted the optr in the 
 meantime.
 
-##### 11.5.5.1 Changing the Model Exclusive
+#### 11.5.5.1 Changing the Model Exclusive
 
 To modify the Model hierarchy, use MSG_META_GRAB_MODEL_EXCL. To 
 remove the model exclusive from an object without setting it to another 
@@ -1752,7 +1752,7 @@ by this method as it may have been changed in the meantime. Use
 MSG_META_SEND_CLASSED_EVENT with the **TravelOption** TO_MODEL 
 instead.
 
-##### 11.5.5.2 Intercepting the Model
+#### 11.5.5.2 Intercepting the Model
 
 Your application may also wish to be notified when an object either gains or 
 loses its model properties. Whenever an object in GEOS gains the model of the 
@@ -1768,7 +1768,7 @@ superclass, however, to perform necessary default functionality. Within your
 message handlers for these messages, you may add whatever additional 
 behavior you require.
 
-#### 11.5.6 Extending the Hierarchies
+### 11.5.6 Extending the Hierarchies
 
 You may also extend or modify the hierarchies to add other objects that are 
 not active nodes by default. If custom objects wish to use the hierarchies, you 

--- a/TechDocs/Markdown/Concepts/cintro.md
+++ b/TechDocs/Markdown/Concepts/cintro.md
@@ -1,4 +1,4 @@
-## 1 Introduction
+# 1 Introduction
 
 Congratulations on taking the first step towards programming for GEOS. 
 This system will most likely be unlike anything you have programmed for 
@@ -6,14 +6,14 @@ before; among the main goals of the system design were to simplify
 development of applications and to incorporate many common application 
 and User Interface features within the system software.
 
-### 1.1 Overview of The Documentation
+## 1.1 Overview of The Documentation
 
 These manuals represent the initial non-Beta release of technical 
 documentation for the GEOS operating system. These manuals should 
 provide you with all the knowledge, both conceptual and reference, to write 
 programs for GEOS.
 
-#### 1.1.1 What You Will Learn
+### 1.1.1 What You Will Learn
 
 This documentation provides everything you need to write a complete GEOS 
 application. It includes in-depth conceptual and reference material about 
@@ -24,7 +24,7 @@ from file management to messaging to object creation and destruction. If you
 read everything in these books, you should be able to create the source code 
 for not only simple applications but even applications of medium complexity.
 
-#### 1.1.2 What You Are Expected To Know
+### 1.1.2 What You Are Expected To Know
 
 This documentation relies heavily on the reader's knowledge of the C 
 programming language and of Object-Oriented Programming (OOP) 
@@ -37,7 +37,7 @@ the features of the system from the user's perspective. In addition, many
 User Interface concepts are illustrated with examples from the retail 
 products.
 
-#### 1.1.3 Roadmap to the Development Kit
+### 1.1.3 Roadmap to the Development Kit
 
 The developer kit documentation is separated into several books. Each of 
 these books has a primary purpose; together, they should give you all the 
@@ -96,7 +96,7 @@ information, but rather all the pass and return and definition
 information for all the object classes in GEOS. It should be used after 
 you've become familiar with the concepts of the system.
 
-#### 1.1.4 Typographical Cues
+### 1.1.4 Typographical Cues
 
 Throughout these manuals, you will see several words in bold or italics, and 
 you will read several code examples. For the most part, there are four types 
@@ -123,12 +123,12 @@ Monospace font is used for all code samples and illustrations of
 commands. It is also used as a subheading for sections that describe 
 particular routines, messages, and data structures.
 
-### 1.2 Chapters in the Books
+## 1.2 Chapters in the Books
 
 This section of this chapter lists all the chapters in each of the main books of 
 this documentation.
 
-#### 1.2.1 The Concepts Book
+### 1.2.1 The Concepts Book
 
 The Concepts Book describes not only the concepts of the GEOS system but 
 also the steps and components of applications. Typically, a reader will read 
@@ -272,7 +272,7 @@ the PC architecture. The second gives an in-depth discussion of threads and
 thread management. The third describes how to create GEOS libraries. The 
 fourth describes the GEOS floating-point math library.
 
-#### 1.2.2 The Object Reference Book
+### 1.2.2 The Object Reference Book
 
 The Object Reference Book is a hybrid of traditional conceptual and 
 traditional reference books. Each chapter gives both in-depth conceptual and 
@@ -425,7 +425,7 @@ directly by application programmers. They are provided here, however, to
 give reference information about the messages that can be sent to them. 
 Included in this chapter are GenSystem, GenScreen, and GenField.
 
-#### 1.2.3 The Tools Reference Manual
+### 1.2.3 The Tools Reference Manual
 
 The Tools Reference manual describes many things about the tools and the 
 development station setup that you will need to know throughout your 
@@ -473,7 +473,7 @@ by GEOS.
 This details all the other tools in the system, including the 
 communications utilities, the make utilities, GOC, Glue, and others.
 
-#### 1.2.4 The Esp Book
+### 1.2.4 The Esp Book
 
 The Esp book describes how to use Esp, the GEOS object-oriented assembly 
 language. You can use this language to recode computation-intensive 
@@ -497,7 +497,7 @@ frames and sending messages.
 This chapter describes UIC, a tool for generating object-blocks for Esp 
 programs.
 
-### 1.3 Suggestions for Study
+## 1.3 Suggestions for Study
 
 If you are unfamiliar with programming, you will most likely not be able to 
 follow this documentation well. You should have working familiarity with the 

--- a/TechDocs/Markdown/Concepts/clibr.md
+++ b/TechDocs/Markdown/Concepts/clibr.md
@@ -1,4 +1,4 @@
-## C Libraries
+# C Libraries
 
 If you write more than one application, you may find yourself repeating a 
 lot of effort. You may end up writing the same routines several times, or 
@@ -14,7 +14,7 @@ GEOS; you should have successfully written a simple GEOS application. You
 should also be very familiar with the material in ["First Steps: Hello World," 
 Chapter 4](cgetsta.md) and ["GEOS Programming," Chapter 5](ccoding.md).
 
-### C.1 Design Philosophy
+## C.1 Design Philosophy
 
 GEOS libraries are designed to make code-sharing simple and efficient. 
 They allow several different applications to make use of the same routines 
@@ -53,7 +53,7 @@ Writing a library is very much like writing an application. There are only
 a few differences, which are covered in this appendix. You should already 
 be familiar with writing applications before you try to write a library.
 
-### C.2 Library Basics
+## C.2 Library Basics
 
 A library is a geode, much like an application geode. However, its behavior 
 is slightly different. In particular, libraries do not have any threads of their 
@@ -101,7 +101,7 @@ object classes, the header file should be a Goc header file with the suffix
 .goh; otherwise it should be a standard C header file with the suffix .h. The 
 header file is described in more detail in [section C.5](#c5-header-files).
 
-### C.3 The Library Entry Point
+## C.3 The Library Entry Point
 
 LibraryEntry(), LibraryCallType
 
@@ -196,7 +196,7 @@ entry point should not change the working directory; instead, it should use
 **FilePushDir()** and **FilePopDir()** to make temporary changes to the 
 working directory.
 
-### C.4 Exported Routines and Classes
+## C.4 Exported Routines and Classes
 
 Writing routines for a library is very much like writing them for an 
 application. Simply export the routine in the .gp file and any geode which 
@@ -229,7 +229,7 @@ Such "hidden" classes need not be exported. However, the classes must be
 fully declared in the header files so the subclasses can be defined accurately 
 and consistently.
 
-### C.5 Header Files
+## C.5 Header Files
 
 Every library should have at least one header file. This file contains 
 declarations and definitions which are needed by each of the geodes which 
@@ -259,7 +259,7 @@ with the libraries they describe. As a rule, a library will include each one
 of those headers; that helps to keep all the files compatible. Nevertheless, 
 you must be careful whenever changing a library.
 
-### C.6 Compiler Directives
+## C.6 Compiler Directives
 
 Libraries have to be compiled slightly differently from applications. Since 
 library routines are run under application threads, they must treat global 

--- a/TechDocs/Markdown/Concepts/clmem.md
+++ b/TechDocs/Markdown/Concepts/clmem.md
@@ -1,4 +1,4 @@
-## 16 Local Memory
+# 16 Local Memory
 
 The GEOS memory manager is well suited to dealing with blocks of memory 
 in the 2K-6K range. However, for small amounts of memory, the manager's 
@@ -17,7 +17,7 @@ Before you read this chapter, you should be familiar with the use of handles in
 GEOS and with the 80x86's segment:offset memory referencing. You should also be 
 familiar with the global memory manager (see ["Memory Management", Chapter 15](cmemory.md)).
 
-### 16.1 Design Philosophy
+## 16.1 Design Philosophy
 
 The GEOS memory manager is designed to deal with blocks of memory which 
 are measured in kilobytes. Every memory block needs an entry in the global 
@@ -49,7 +49,7 @@ complete with a modified Quicksort routine. Similarly, all GEOS objects are
 stored in object blocks, which are a special kind of local-memory heap. This 
 makes it easy to add or delete objects dynamically.
 
-### 16.2 Structure of a Local Memory Heap
+## 16.2 Structure of a Local Memory Heap
 
 A local memory heap looks and acts much like the global heap. However, it is 
 contained entirely within a single memory block. This block is initialized 
@@ -100,7 +100,7 @@ is advisable if the heap is in a fixed block.
 A virtual-memory file block may contain an LMem heap. For details on this, 
 see ["Virtual Memory," Chapter 18](cvm.md).
 
-#### 16.2.2 Chunks and Chunk Handles
+### 16.2.2 Chunks and Chunk Handles
 
 Just as blocks on the local heap are accessed with handles, chunks are 
 accessed via chunk handles. Each chunk handle is an offset into the block 
@@ -139,7 +139,7 @@ this offset indicates an entry in the local memory handle table, where an offset
 to the chunk data is stored. In this case, the block containing the LMem heap 
 begins at address 1000:00. All addresses shown are in hexadecimal._
 
-#### 16.2.3 Types of LMem Heaps
+### 16.2.3 Types of LMem Heaps
 
 LMemType, LMemFlags
 
@@ -279,7 +279,7 @@ This is a constant which combines the LMF_HAS_FLAGS and
 LMF_RELOCATED flags. These flags should be set for all object 
 blocks.
 
-### 16.3 Using Local Memory Heaps
+## 16.3 Using Local Memory Heaps
 
 Local memory heaps are much like the global heap and are accessed in much 
 the same way. Local heaps are simple to create and manage.
@@ -293,7 +293,7 @@ understand how the other mechanisms work.
 Remember that every local memory heap resides in a global memory block. All the 
 rules for using memory blocks apply. (See ["Memory Etiquette"](cmemory.md#1531-memory-etiquette))
 
-#### 16.3.1 Creating a Local Heap
+### 16.3.1 Creating a Local Heap
 
 LMemInitHeap(), MemAllocLMem()
 
@@ -358,7 +358,7 @@ an **LMemType** of LMEM_TYPE_OBJ_BLOCK, **MemAllocLMem()** will pass
 the STD_LMEM_OBJECT_FLAGS flags; otherwise, it will pass a clear 
 **LocalMemoryFlags** record.
 
-#### 16.3.2 Using Chunks
+### 16.3.2 Using Chunks
 
 LMemAlloc(), LMemDeref(), LMemFree(), LMemGetChunkSize(), 
 LMemReAlloc(), LMemInsertAt(), LMemDeleteAt(), 
@@ -445,7 +445,7 @@ specify bytes that are beyond the end of the chunk. If you fail to do this,
 results are undefined. The version which takes handles is named 
 **LMemDeleteAtHandles()**.
 
-#### 16.3.3 Contracting the LMem Heap
+### 16.3.3 Contracting the LMem Heap
 
 LMemContract()
 
@@ -459,7 +459,7 @@ containing the LMem heap. It shuffles all the chunks, thus invalidating
 pointers to chunks; however, it is guaranteed not to move the block on the 
 global heap. 
 
-#### 16.3.4 Example of LMem Usage
+### 16.3.4 Example of LMem Usage
 
 At first, the local memory techniques can seem tricky. This section contains 
 an example of LMem usage in Goc. The example shows the basic principles 
@@ -553,7 +553,7 @@ MemUnlock(thisHeapsHandle);
 MemFree(thisHeapsHandle);
 ~~~
 
-### 16.4 Special LMem Uses
+## 16.4 Special LMem Uses
 
 Local memory heaps are used for many purposes in GEOS. Objects are stored 
 in special LMem heaps, called object blocks; windows, GStrings, and many 
@@ -568,7 +568,7 @@ chunks to store special arrays of data via the Chunk Array routines. The
 chapter will also describe special purpose variants of the Chunk Array: the 
 Element Array and the Name Array.
 
-#### 16.4.1 Chunk Arrays
+### 16.4.1 Chunk Arrays
 
 Very often an application will need to keep track of many different pieces of 
 data and access them by an index. An application can do this in the 
@@ -590,7 +590,7 @@ drops significantly if it is larger than roughly 6K. If you need a larger array,
 you should use a Huge Array (see [section 18.5 of chapter 18](cvm.md#195-huge-arrays)). 
 If you will be using the chunk array routines, you should include chunkarr.h.
 
-##### 16.4.1.1 Structure of the Chunk Array
+#### 16.4.1.1 Structure of the Chunk Array
 
 A chunk array is contained in a single chunk in an LMem heap. It begins 
 with a special header structure which specifies certain characteristics of the 
@@ -644,7 +644,7 @@ constructed by the chunk array routines.
 _A chunk array with variable-size elements is actually two successive arrays; 
 the first array is an array of chunk offsets to the elements of the second array._
 
-##### 16.4.1.2 Creating a Chunk Array
+#### 16.4.1.2 Creating a Chunk Array
 
 ChunkArrayCreate(), ChunkArrayCreateAt(), 
 ChunkArrayCreateAtHandles(), ChunkArrayHeader
@@ -692,7 +692,7 @@ be overwritten (except for whatever data falls in the header area after the
 When you are done with a chunk array, you can free it with **LMemFree()** the 
 way you would any other chunk.
 
-##### 16.4.1.3 Adding, Removing, and Accessing Elements
+#### 16.4.1.3 Adding, Removing, and Accessing Elements
 
 ChunkArrayAppend(), ChunkArrayAppendHandles(), 
 ChunkArrayInsertAt(), ChunkArrayInsertAtHandle(), 
@@ -796,7 +796,7 @@ the element number, and a pointer to a buffer big enough to hold the entire
 element. The routine will copy the element to the specified buffer. The 
 version which takes handles is called **ChunkArrayGetElementHandles()**.
 
-##### 16.4.1.4 Chunk Array Utilities
+#### 16.4.1.4 Chunk Array Utilities
 
 ChunkArrayGetCount(), ChunkArrayGetCountHandles(), 
 ChunkArrayZero(), ChunkArrayZeroHandles(), 
@@ -895,7 +895,7 @@ callback routine. It does not return anything.
 Note that **ChunkArraySort()** is currently implemented only for chunk 
 arrays with fixed-sized elements.
 
-##### 16.4.1.5 Example of Chunk Array Usage
+#### 16.4.1.5 Example of Chunk Array Usage
 
 This section contains an example of how a chunk array might be used. It 
 shows several common chunk array actions, including sorting the array.
@@ -1028,7 +1028,7 @@ ChunkArraySortHandles(blockWithHeap, myChunkArray,
 /* Array is now sorted! */
 ~~~
 
-#### 16.4.2 Element Arrays
+### 16.4.2 Element Arrays
 
 Sometimes an application will create an array with a high duplication rate; 
 that is, the array may contain many identical elements. This can be 
@@ -1072,7 +1072,7 @@ quickly translate an element's token into the offset to that element. Thus, it
 takes no longer to access an element in an element array than it does to 
 access one in a chunk array.
 
-##### 16.4.2.1 Creating an Element Array
+#### 16.4.2.1 Creating an Element Array
 
 ElementArrayCreate(), ElementArrayCreateAt(), 
 ElementArrayCreateAtHandles(), ElementArrayHeader
@@ -1101,7 +1101,7 @@ The routine returns the handle of the newly-created element array. It can
 cause heap compaction or resizing; therefore, all pointers to the heap are 
 invalidated.
 
-##### 16.4.2.2 Adding an Element
+#### 16.4.2.2 Adding an Element
 
 ElementArrayAddElement(), 
 ElementArrayAddElementHandles(), 
@@ -1167,7 +1167,7 @@ Both of these routines have counterparts which are passed handles instead
 of an optr; these counterparts are named 
 **ElementArrayAddElementHandles()** and **ElementArrayAddReferenceHandles()**.
 
-##### 16.4.2.3 Accessing Elements in an Element Array
+#### 16.4.2.3 Accessing Elements in an Element Array
 
 ElementArrayElementChanged(), 
 ElementArrayElementChangedHandles()
@@ -1217,7 +1217,7 @@ to change any references to the old element appropriately. If no match is
 found, the token which was passed will be returned. The version which takes 
 handles is called **ElementArrayElementChangedHandles()**.
 
-##### 16.4.2.4 Removing An Element From An Element Array
+#### 16.4.2.4 Removing An Element From An Element Array
 
 ElementArrayRemoveReference(), 
 ElementArrayRemoveReferenceHandles(), 
@@ -1250,7 +1250,7 @@ Both of these routines have counterparts which take handles; these
 counterparts are named **ElementArrayRemoveReferenceHandles()** and 
 **ElementArrayDeleteHandles()**.
 
-##### 16.4.2.5 The "Used Index" and Other Index Systems
+#### 16.4.2.5 The "Used Index" and Other Index Systems
 
 ElementArrayGetUsedCount(), 
 ElementArrayGetUsedCountHandles(), 
@@ -1309,7 +1309,7 @@ callback routine. Again, passing a null function pointer makes the routine
 count every "in-use" element. The routine which takes handles is called 
 **ElementArrayTokenToUsedIndexHandles()**.
 
-#### 16.4.3 Name Arrays
+### 16.4.3 Name Arrays
 
 Applications can build on chunk arrays and element arrays in many ways. 
 The chunk array library includes one example of an elaboration on these 
@@ -1334,7 +1334,7 @@ through the elements, and thus also takes linear time. Name arrays thus
 become slow if they grow too large. Accessing an element by token, however, 
 still takes constant time.
 
-##### 16.4.3.1 Creating a Name Array
+#### 16.4.3.1 Creating a Name Array
 
 NameArrayCreate(), NameArrayCreateAt(), 
 NameArrayCreateAtHandles(), NameArrayAdd(), 
@@ -1452,7 +1452,7 @@ myNameArray = NameArrayCreate(myLMemHeap, sizeof(MyDataSectionStruct),
                                 sizeof(MyNameArrayHeader));
 ~~~
 
-##### 16.4.3.2 Accessing Elements in a Name Array
+#### 16.4.3.2 Accessing Elements in a Name Array
 
 NameArrayFind(), NameArrayFindHandles(), 
 NameArrayChangeName(), NameArrayChangeNameHandles()

--- a/TechDocs/Markdown/Concepts/clocal.md
+++ b/TechDocs/Markdown/Concepts/clocal.md
@@ -1,4 +1,4 @@
-## 8 Localization
+# 8 Localization
 
 Localization is the means by which GEOS adapts to foreign environments. 
 The kernel automatically accounts for such country-dependent items as 
@@ -9,7 +9,7 @@ look over this chapter whether or not you're planning on distributing your
 software internationally. The chapter includes documentation for some 
 functions which you're likely to use regardless.
 
-### 8.1 Localization Goals
+## 8.1 Localization Goals
 
 The benefit of Geoworks' experience with previous international products 
 was designed into GEOS from the start. The kernel was designed with the 
@@ -61,7 +61,7 @@ _International formats include variations in how numbers, times,
 currencies, etc. are displayed in various countries. These formats may 
 be set in the International section of the Preferences desk tool._
 
-### 8.2 How To Use Localization
+## 8.2 How To Use Localization
 
 Your localization workload will vary depending on whether you plan to 
 release your software in other countries. If you don't plan on exporting your 
@@ -93,7 +93,7 @@ application's resources and checks all objects for strings and bitmaps,
 asking the translator to make any fitting changes. The translator never 
 needs to see the source code and doesn't have to know how to program.
 
-### 8.3 Preparing for ResEdit
+## 8.3 Preparing for ResEdit
 
 **ResEdit** is a GEOS program which speeds geode translations. This section 
 won't tell you how to use the **ResEdit** tool but will explain how to write your 
@@ -194,14 +194,14 @@ problem by constraining the size of some gadgetry, keep in mind that if you
 don't allow it to stretch, your new strings may not fit. See Figure 8-2 for 
 illustrations of these problems.
 
-### 8.4 International Formats
+## 8.4 International Formats
 
 "International Formats" generally refers to formats which differ from 
 country to country. In GEOS, it signifies those formats which the user can set 
 in the International section of the Preferences desk tool. GEOS provides 
 functions to work with International Formats.
 
-#### 8.4.1 Number and Measure
+### 8.4.1 Number and Measure
 
 LocalGetNumericFormat(), LocalSetNumericFormat()
 LocalGetMeasurementType(), LocalSetMeasurementType(), 
@@ -274,7 +274,7 @@ Table 8-1 DistanceUnit types
 
 DU_POINTS_OR_MILLIMETERS and DU_INCHES_OR_CENTIMETERS: special cases
 
-#### 8.4.2 Currency
+### 8.4.2 Currency
 
 LocalGetCurrencyFormat(), LocalSetCurrencyFormat()
 
@@ -293,7 +293,7 @@ changing of the set preferences. Most parts of the currency format are stored
 in a **LocalCurrencyFormat** structure when passed to or returned by these 
 functions.
 
-#### 8.4.3 Quotation Marks
+### 8.4.3 Quotation Marks
 
 LocalGetQuotes(), LocalSetQuotes()
 
@@ -318,7 +318,7 @@ use. If you want to reset the preferences, use the **LocalSetQuotes()** routine.
 These routines work with the **LocalQuotes** structure, which simply holds 
 four characters to use as the four kinds of quotation mark.
 
-#### 8.4.4 Dates and Times
+### 8.4.4 Dates and Times
 
 LocalFormatDateTime(), LocalParseDateTime(),
 LocalGetDateTimeFormat(), LocalSetDateTimeFormat(),
@@ -402,7 +402,7 @@ MAX_MONTH_LENGTH, MAX_DAY_LENGTH, MAX_YEAR_LENGTH,
 MAX_WEEKDAY_LENGTH, MAX_SEPARATOR_LENGTH, and 
 TOKEN_LENGTH.
 
-#### 8.4.5 Filters for Formats
+### 8.4.5 Filters for Formats
 
 LocalIsDateChar(), LocalIsTimeChar(), LocalIsNumChar()
 
@@ -447,7 +447,7 @@ Table 8-3 DateTimeFormat String Tokens
 Examples show what U.S. version could produce. Actual output might not 
 look like samples.
 
-### 8.5 Lexical Functions
+## 8.5 Lexical Functions
 
 Since different languages have different alphabets, GEOS has to allow for 
 characters not in the standard English character set. Thus, many standard 
@@ -456,7 +456,7 @@ lexical value of characters, their place in a lexical, or alphabetic, ordering.
 These lexical values take the place of ASCII standard character values that 
 you may be used to.
 
-#### 8.5.1 Comparing Strings
+### 8.5.1 Comparing Strings
 
 LocalCmpStrings(), LocalCmpStringsNoCase(), 
 LocalCmpStringsNoSpace(), LocalCmpStringsNoSpaceCase(), 
@@ -484,7 +484,7 @@ There are two assembly routines **LocalCmpChars()** and
 **LocalCmpCharsNoCase()** which allow for the quick lexical comparison of 
 two characters.
 
-#### 8.5.2 String Length and Size
+### 8.5.2 String Length and Size
 
 LocalStringLength(), LocalStringSize()
 
@@ -496,7 +496,7 @@ Normally these two values will be the same, but any applications which want
 to support double byte character support will need separate functions to 
 handle those characters that take more than one byte to represent.
 
-#### 8.5.3 Casing
+### 8.5.3 Casing
 
 LocalUpcaseChar(), LocalDowncaseChar(), 
 LocalUpcaseString(), LocalDowncaseString()
@@ -510,7 +510,7 @@ functions by doing arithmetic operations with the lexical or ASCII values of
 characters, but chances are these will not work with other character sets and 
 should be avoided.
 
-#### 8.5.4 Character Categories
+### 8.5.4 Character Categories
 
 LocalIsUpper(), LocalIsLower(), LocalIsAlpha(), 
 LocalIsPunctuation(), LocalIsSpace(), LocalIsSymbol(), 
@@ -535,7 +535,7 @@ space when printed, corresponding to the standard C function **isprint()**.
 **LocalIsGraphic()** checks for displayable characters, in the manner of the 
 standard C function **isgraphic()**.
 
-#### 8.5.5 Lexical Values
+### 8.5.5 Lexical Values
 
 LocalLexicalValue(), LocalLexicalValueNoCase()
 
@@ -547,7 +547,7 @@ character comes first alphabetically. For instance, "a" would have a lower
 lexical value than "z." This ordering will be valid in any language using the 
 same character set. 
 
-#### 8.5.6 DOS Text & Code Pages
+### 8.5.6 DOS Text & Code Pages
 
 LocalDosToGeos(), LocalGeosToDos(), LocalDosToGeosChar(), 
 LocalGeosToDosChar(), LocalCmpStringsDosToGeos(), 

--- a/TechDocs/Markdown/Concepts/cmath.md
+++ b/TechDocs/Markdown/Concepts/cmath.md
@@ -1,4 +1,4 @@
-## D The Math Library
+# D The Math Library
 
 The Math Library allows high precision computations not available 
 through standard integer operations. Floating Point (FP) numbers use 
@@ -25,7 +25,7 @@ Use of math.goh is optional, depending on the purpose of the application.
 A spreadsheet application, for example, might want to allow the user to 
 format FP numbers. Other applications might not want to include this file.
 
-### D.1 Basic Math Functions
+## D.1 Basic Math Functions
 
 The Math Library includes many routines and structures that make the 
 manipulation of FP numbers possible. Most of these are transparent to a C 
@@ -251,7 +251,7 @@ Code Display D-3 Creating a Random Number
 }
 ~~~
 
-### D.2 Conversions to Other Types
+## D.2 Conversions to Other Types
 
 In many cases, FP numbers will need to be converted to different types for 
 use in different parts of an application. For example, floating point 
@@ -612,7 +612,7 @@ return one as the number of digits.
 
 FloatStringGetDateNumber(), FloatStringGetTimeNumber()
 
-### D.3 Float Formats
+## D.3 Float Formats
 
 FP numbers can be displayed in many ways. For example, as we have seen, 
 an FP number may actually represent a date-time. When we display the FP 
@@ -794,7 +794,7 @@ typedef struct {
 } FormatEntry;
 ~~~
 
-### D.4 Direct FP Operations
+## D.4 Direct FP Operations
 
 The Math Library allows your application to use floating point (FP) 
 numbers. C Developers will find little reason to make direct calls to 

--- a/TechDocs/Markdown/Concepts/cmemory.md
+++ b/TechDocs/Markdown/Concepts/cmemory.md
@@ -1,4 +1,4 @@
-## 15 Memory Management
+# 15 Memory Management
 
 Managing memory in a multitasking system is complex because many 
 different entities-the kernel, libraries, and applications-are all trying to 
@@ -11,7 +11,7 @@ also describes the routines applications can use to get raw memory. Before
 you read this chapter, you should be familiar with the use of handles (see 
 ["Handles", Chapter 14](chandle.md)).
 
-### 15.1 Design Philosophy
+## 15.1 Design Philosophy
 
 Some systems make each application maintain and manage its own memory. 
 In a multitasking system, this is not only difficult and time-consuming but 
@@ -52,7 +52,7 @@ Applications can also request memory at run-time, either by requesting raw
 memory from the memory manager, or by creating Virtual Memory files 
 through the VM library (see ["Virtual Memory", Chapter 18](cvm.md)).
 
-### 15.2 The Structure of Memory
+## 15.2 The Structure of Memory
 
 The GEOS memory manager currently uses real mode memory addressing, 
 and is designed to run on PCs with as little as 512K RAM. Typically, between 
@@ -67,7 +67,7 @@ application will need a seemingly contiguous section of memory which is
 larger than 64K; in these situations, it should use the HugeArray routines 
 (see [section 18.4 of chapter 18](cvm.md#184-vm-chains)).
 
-#### 15.2.1 Expanded/Extended Memory
+### 15.2.1 Expanded/Extended Memory
 
 While GEOS is designed to run on a standard system, it makes efficient use 
 of expanded and extended memory, if it is available. GEOS treats extended 
@@ -76,7 +76,7 @@ extended memory rather than out to a slower disk drive. This incurs none of
 the usual overhead of a RAM disk such as a directory because it is treated as 
 normal memory. Expanded memory is used in a similar manner.
 
-#### 15.2.2 Main Memory
+### 15.2.2 Main Memory
 
 Memory available to applications is organized in a data structure called the 
 Global Heap. The size of the global heap may vary from machine to machine 
@@ -98,7 +98,7 @@ when it restores from state. The GEOS kernel attaches object blocks to
 system VM files and takes care of storing them to state and restoring them 
 when GEOS restarts.
 
-##### 15.2.2.1 Blocks and Handles
+#### 15.2.2.1 Blocks and Handles
 
 GEOS segments memory into blocks. A block is simply a number of 
 contiguous bytes on the global heap in which code or data may be stored. Any 
@@ -124,7 +124,7 @@ records the block's attributes, such as whether the block is discardable,
 swapable, or fixed. The memory manager uses all these attributes to 
 manipulate the block.
 
-##### 15.2.2.2 Enabling Block Access
+#### 15.2.2.2 Enabling Block Access
 
 Dynamic memory, while providing significant benefits, poses one major 
 problem: What happens if a block is accessed while being moved, swapped, or 
@@ -144,7 +144,7 @@ memory manager can, depending on the block's category, move the block on
 the heap, swap it to disk or extended/expanded memory, or discard it 
 altogether.
 
-##### 15.2.2.3 Types of Blocks
+#### 15.2.2.3 Types of Blocks
 
 When a geode requests memory, it may specify how that memory is to be 
 treated by the memory manager. The memory request includes a set of 
@@ -213,7 +213,7 @@ remain so until they are freed. However, non-fixed blocks may become or
 cease to be discardable or swapable after they are created. To enable or 
 disable these characteristics, call the routine **MemModifyFlags()**.
 
-##### 15.2.2.4 Maximizing Free Space in Memory
+#### 15.2.2.4 Maximizing Free Space in Memory
 
 Moveable, swapable, and discardable blocks are allocated from the top of the 
 heap using a first-fit method. Fixed blocks are allocated from the bottom of 
@@ -257,7 +257,7 @@ when space can be freed. Applications may also resize blocks at will; if
 necessary, the memory manager will compact the heap to accommodate the 
 request.
 
-##### 15.2.2.5 Block Attributes
+#### 15.2.2.5 Block Attributes
 
 HeapAllocFlags, HeapFlags
 
@@ -350,7 +350,7 @@ HF_SWAPPED
 The block has been swapped to extended or expanded memory 
 or to the hard disk. Only the system can set or clear this flag.
 
-### 15.3 Using Global Memory
+## 15.3 Using Global Memory
 
 When an application needs more raw memory at run-time, it can use the 
 memory manager kernel routines to allocate, use, and free new blocks. An 
@@ -364,7 +364,7 @@ a local memory heap (a special kind of memory block). LMem heaps are also
 useful for storing arrays of information or for storing objects. For more 
 information, see ["Local Memory," Chapter 16](clmem.md).
 
-#### 15.3.1 Memory Etiquette
+### 15.3.1 Memory Etiquette
 
 The GEOS memory manager tries to fulfill every memory request. It does not 
 enforce many rules on how the geodes should use memory. This gives each 
@@ -421,7 +421,7 @@ small data items, you should use the Database library, which automatically
 distributes data items among different memory blocks, keeping each block 
 near the optimum size. (See ["Database Library", Chapter 19](cdb.md)).
 
-#### 15.3.2 Requesting Memory
+### 15.3.2 Requesting Memory
 
 MemAlloc(), MemAllocSetOwner(), MemReAlloc()
 
@@ -466,7 +466,7 @@ error condition. The requestor can prevent error messages by passing the flag
 HAF_NO_ERR; this will result in a system error if the memory cannot be 
 allocated. Passing HAF_NO_ERR is therefore strongly discouraged.
 
-#### 15.3.3 Freeing Memory
+### 15.3.3 Freeing Memory
 
 MemFree()
 
@@ -487,7 +487,7 @@ if several threads will be accessing the same block. For more information, see
 
 When a geode exits, all blocks owned by it are automatically freed.
 
-#### 15.3.4 Accessing Data in a Block
+### 15.3.4 Accessing Data in a Block
 
 MemLock(), MemUnlock()
 
@@ -528,7 +528,7 @@ same time, causing potential synchronization problems. For this reason, if
 threads will be sharing a block, they should use the synchronization routines 
 (see [section 15.3.6](#1536-data-access-synchronization)).
 
-#### 15.3.5 Accessing Data: An Example
+### 15.3.5 Accessing Data: An Example
 
 Code Display 15-1 shows how to allocate a block, lock it, access a word of data 
 in the block, and unlock the block. This example shows the basic principles 
@@ -582,7 +582,7 @@ strcpy(charArray, blockBaseAddress);
 MemFree(myBlockhandle); /* myBlockHandle is now meaningless */
 ~~~
 
-#### 15.3.6 Data-Access Synchronization
+### 15.3.6 Data-Access Synchronization
 
 MemThreadGrab(), MemThreadGrabNB(), MemThreadRelease(), 
 MemLockShared(), MemUnlockShared(), MemLockExcl(), 
@@ -730,7 +730,7 @@ synchronize their access to a file, they can lock and unlock the file handle
 with **HandleP()** and **HandleV()**. However, they are most commonly used 
 with memory blocks.
 
-#### 15.3.7 Retrieving Block Information
+### 15.3.7 Retrieving Block Information
 
 MemDeref(), MemGetInfo(), MemModifyFlags(), 
 HandleModifyOwner(), MemModifyOtherInfo()
@@ -792,7 +792,7 @@ block can change the block's owner.
 handle table entry. It takes two arguments: The handle of the block, and one 
 word of data to store in the HM_otherInfo field. It returns nothing.
 
-#### 15.3.8 The Reference Count
+### 15.3.8 The Reference Count
 
 MemInitRefCount(), MemIncRefCount(), MemDecRefCount()
 
@@ -857,7 +857,7 @@ passed the handle of a global memory block. It decrements the block's
 HM_otherInfo field. If the field reaches zero, **MemDecRefCount()** will 
 immediately free the block. The routine does not return anything.
 
-### 15.4 malloc()
+## 15.4 malloc()
 
 malloc(), calloc(), realloc(), free()
 

--- a/TechDocs/Markdown/Concepts/cmultit.md
+++ b/TechDocs/Markdown/Concepts/cmultit.md
@@ -1,4 +1,4 @@
-## B Threads and Semaphores
+# B Threads and Semaphores
 
 One of the most impressive features of GEOS is its ability to perform 
 several tasks simultaneously, even on the least powerful PCs. Of course, the 
@@ -22,7 +22,7 @@ application, be careful not to send a message with **@call** from an object run
 by a user interface thread to an object run by any other thread of the 
 application.
 
-### B.1 Multitasking Goals
+## B.1 Multitasking Goals
 
 The GEOS multitasking system is one of the most sophisticated available 
 for PCs today. It was designed with the latest available technology and was 
@@ -51,7 +51,7 @@ GEOS (by designing a program to perform more than one task
 concurrently) the system is designed to make this as simple and 
 efficient as possible.
 
-### B.2 Two Models of Multitasking
+## B.2 Two Models of Multitasking
 
 Many operating systems provide the ability to carry out multiple tasks at 
 the same time. While each operating system has its own unique way of 
@@ -138,7 +138,7 @@ programmers need not concern themselves with it.
 This is exactly how GEOS coordinates its resources, as you shall see in the 
 following sections.
 
-### B.3 GEOS Multitasking
+## B.3 GEOS Multitasking
 
 GEOS implements a preemptive multitasking scheme. Application 
 programs are required to follow certain "good citizen" rules and are 
@@ -292,7 +292,7 @@ on each other must keep track of each other's progress in order to avoid
 this; when potential problems are identified, use semaphores to keep the 
 threads in line (see [section B.5](#b5-synchronizing-threads)).
 
-### B.4 Using Multiple Threads
+## B.4 Using Multiple Threads
 
 It is possible for an application to create additional threads for a variety of 
 purposes. For example, a terminal emulation program might have a thread 
@@ -499,7 +499,7 @@ same messages as described above. You may write a special handler for
 MSG_META_DETACH when you subclass **ProcessClass**, but be sure to end 
 the handler with **@callsuper()** so the thread exits properly.
 
-### B.5 Synchronizing Threads
+## B.5 Synchronizing Threads
 
 Because GEOS is a preemptive multitasking environment, it needs a way 
 to prevent two threads from accessing system resources (or other shared 

--- a/TechDocs/Markdown/Concepts/cparse.md
+++ b/TechDocs/Markdown/Concepts/cparse.md
@@ -1,4 +1,4 @@
-## 20 Parse Library
+# 20 Parse Library
 
 The Parse Library was originally created to provide a parser for a 
 spreadsheet language. However, it will also fit the needs of a programmer 
@@ -29,7 +29,7 @@ be familiar with the parsing of context-free grammars. A good book to look at
 is Compilers: Principles, Techniques, and Tools by Aho, Sethi, and Ullman 
 (a.k.a. "The Red Dragon Book").
 
-### 20.1 Parse Library Behavior
+## 20.1 Parse Library Behavior
 
 The Parse Library takes a string of characters and evaluates it. In many 
 ways, it acts like a compiler; it translates a string into tokens, evaluates the 
@@ -110,7 +110,7 @@ section will just describe this in general terms; for example, "the Evaluator
 uses the callback to find out the value of a cell." The advanced section 
 provides a more detailed explanation.
 
-#### 20.1.1 The Scanner
+### 20.1.1 The Scanner
 
 The scanner translates a text string into a sequence of tokens. The tokens 
 can then be processed by the parser. Every token is associated with some data.
@@ -124,7 +124,7 @@ reason, it will not notice if, for example, parentheses are not balanced. It
 returns errors only if it is passed a string which does not scan as a sequence 
 of tokens.
 
-##### 20.1.1.1 Scanner Tokens
+#### 20.1.1.1 Scanner Tokens
 
 The scanner recognizes the tokens listed below. Note that applications will 
 never directly encounter the scanner tokens; the tokens translates them into 
@@ -143,7 +143,7 @@ their names) is given in [section 20.1.2.2](#20112-strings).
 |LIST_SEPARATOR    |This is a comma, i.e. ",". It is used to separate arguments to functions. There is no data section associated with this token.|
 |IDENTIFIER        |This is a sequence of characters, not in quotation marks, which does not match the format for cell references. Identifiers may be functions (built-in or application-defined) or variables; see [section 20.1.1.5](#20115-identifiers). The data section is a string containing the identifier.|
 
-##### 20.1.1.2 Strings
+#### 20.1.1.2 Strings
 
 The string passed to the scanner may, itself, contain strings. These inner 
 strings are not further analyzed; rather, their contents are associated with 
@@ -163,7 +163,7 @@ Backslash-codes include the following:
 |\\   |This code represents a backslash character (i.e. ASCII 0x5C, or "\").         |
 |\nnn |This code is a literal octal value. The backslash must be followed by three digits, making up an octal integer in the range 0-177o (i.e. 0-255). The byte specified is inserted directly into the string. Thus, for example, "\134" is functionally identical to "\\".|
 
-##### 20.1.1.3 Cell References
+#### 20.1.1.3 Cell References
 
 The parse library is often used in conjunction with cell files; for example, the 
 spreadsheet objects use the two libraries together. For this reason, the 
@@ -195,7 +195,7 @@ historically, spreadsheets have had the first row be row number 1. Therefore,
 if the parser encounters a reference to cell A1, it will translate this into a cell 
 reference which specifies row zero, column zero.
 
-##### 20.1.1.4 Operators
+#### 20.1.1.4 Operators
 
 The scanner recognizes a number of built-in operators. Neither the scanner 
 nor the parser does any simplification or evaluation of operator expressions; 
@@ -365,7 +365,7 @@ Note that cell ranges must be rectangular; there is, therefore,
 no "range-union" operator. The data portion of this token is 
 OP_RANGE_INTERSECTION.
 
-##### 20.1.1.5 Identifiers
+#### 20.1.1.5 Identifiers
 
 Any unbroken alphanumeric character sequence which does not appear in 
 quotes, and which is not in the format for a cell reference, is presumed to be 
@@ -380,7 +380,7 @@ routine which will perform this function. If its position indicates that it is a
 identifier, the parser will request the value associated with the identifier; 
 this may be a string, a number, or a cell reference.
 
-#### 20.1.2 The Parser
+### 20.1.2 The Parser
 
 Applications will never call the scanner directly. Instead, if they access the 
 parse library directly (instead of through the spreadsheet objects), they will 
@@ -405,7 +405,7 @@ If the parser is not passed a well-formed expression, or if it is unable to
 successfully parse the string for some other reason, it returns an error code. 
 The error codes are described at length in the advanced section.
 
-##### 20.1.2.1 The Parser's Grammar
+#### 20.1.2.1 The Parser's Grammar
 
 The parser uses a context-free grammar to make sure the string is 
 well-formed. The grammar is listed below. The basic units of the grammar 
@@ -437,7 +437,7 @@ STRING
 CELL_REF  
 IDENTIFIER
 
-##### 20.1.2.2 Parser Tokens
+#### 20.1.2.2 Parser Tokens
 
 The parser does not return scanner tokens; instead, it returns a sequence of 
 parser tokens. The parser tokens are almost directly analogous to the 
@@ -491,7 +491,7 @@ replaces that with an "end-of-argument" token; when it reaches the closing
 parenthesis for the function call, it replaces that with a "close-function" 
 token.
 
-##### 20.1.2.3 An Example of Scanning and Parsing
+#### 20.1.2.3 An Example of Scanning and Parsing
 
 Suppose that you call the parser on the text string 
 "3 + SUM(6.5, 3 ^ (4 - 1), C5...F9)". The parser will evaluate the string, one 
@@ -555,7 +555,7 @@ The application does not need to save the original text string. Instead, it can
 save the buffer containing the parser tokens, and use the formatter to 
 translate the token sequence back into a character string.
 
-#### 20.1.3 Evaluator
+### 20.1.3 Evaluator
 
 The evaluator simplifies a token string returned by the parser. If the input 
 token sequence was well-formed (as are all token sequences generated by the 
@@ -651,7 +651,7 @@ name; act on the value appropriately.
 Evaluate the Operator stack until it is empty; the result will be 
 on the top of the Argument stack.
 
-#### 20.1.4 Formatter
+### 20.1.4 Formatter
 
 In order to display a token sequence, you must call the Formatter. The 
 formatter is very straightforward. It is passed a buffer containing a token 
@@ -662,7 +662,7 @@ local language and the user's Preferences settings.
 If the token sequence consists of an error token, the formatter will generate 
 an appropriate error string.
 
-### 20.2 Parser Functions
+## 20.2 Parser Functions
 
 The Parse library provides many built-in functions. Furthermore, each 
 application can define its own functions. Every function is associated with a 
@@ -694,7 +694,7 @@ function is responsible for popping all the arguments off the stack and
 pushing the result. It can also push an error message on the stack. All of this 
 is discussed at length in the advanced section.
 
-#### 20.2.1 Internal Functions
+### 20.2.1 Internal Functions
 
 The Parse library provides many internal functions, and more are 
 continually being added. Any application which uses the parse library 
@@ -787,7 +787,7 @@ description of each one.
 |UPPER     |Converts all letters in string to uppercase |
 |VALUE     |Converts string to number                   |
 
-#### 20.2.2 External Functions
+### 20.2.2 External Functions
 
 Applications which use the Parse library may write their own functions. 
 Whenever the formatter encounters a function name which it does not 
@@ -797,13 +797,13 @@ arguments and the function ID. The application should return a single value.
 If it cannot produce a value, it should return an error code. The error codes 
 are described in [section 20.3.2](#2032-evaluating-a-token-sequence).
 
-### 20.3 Coding with the Parse Library
+## 20.3 Coding with the Parse Library
 
 This section describes how to use the Parser directly, instead of using 
 intermediaries (like the Spreadsheet library). Most applications will not need 
 to use these routines.
 
-#### 20.3.1 Parsing a String
+### 20.3.1 Parsing a String
 
 ParserParseString()
 
@@ -864,7 +864,7 @@ the callback routine would not provide an ID for it.
 **PSEE_GENERAL**  
 General parser error.
 
-#### 20.3.2 Evaluating a Token Sequence
+### 20.3.2 Evaluating a Token Sequence
 
 ParserEvalExpression()
 
@@ -961,7 +961,7 @@ The application may also define its own error codes, beginning with the
 constant PSEE_FIRST_APPLICATION_ERROR. All internal functions, and all 
 operators, always propagate application-defined errors.
 
-#### 20.3.3 Formatting a Token Sequence
+### 20.3.3 Formatting a Token Sequence
 
 ParserFormatExpression()
 

--- a/TechDocs/Markdown/Concepts/cpccom.md
+++ b/TechDocs/Markdown/Concepts/cpccom.md
@@ -1,4 +1,4 @@
-## 22 PCCom Library
+# 22 PCCom Library
 
 The PCCom library provides a simple way to allow a geode to provide and 
 monitor a PCCom connection. If you are familiar with the SDK, you probably 
@@ -18,7 +18,7 @@ If you're not familiar with the **pccom** tool, you should probably read the
 pccom section of ["Using Tools," Chapter 10 of the Tools Book](../Tools/ttools.md)
 -perhaps not the whole section, but at least enough to understand basic usage.
 
-### 22.1 PCCom Library Abilities
+## 22.1 PCCom Library Abilities
 
 Your geode needn't do much to support PCCom. The PCCom library acts as a 
 passive pccom machine-it will only accept orders from a remote machine. 
@@ -27,7 +27,7 @@ All you need to do to support PCCom is start up a PCCom process, ideally
 freeing it when done. Geodes using the PCCom library have the option of 
 receiving notification when pccom would display text.
 
-### 22.2 What To Do
+## 22.2 What To Do
 
 PCCOMINIT(), PCCOMEXIT(), PCCOMABORT()
 
@@ -47,7 +47,7 @@ You may call the PCCOMABORT() routine at any time; this routine aborts any
 pccom file transfer that may be in progress, but leaves the PCCom connection 
 intact.
 
-### 22.3 Staying Informed
+## 22.3 Staying Informed
 
 The sections above tell you everything you need to let your geode interact 
 with pccom. It is possible to do more: your geode can receive notification 

--- a/TechDocs/Markdown/Concepts/cshapes.md
+++ b/TechDocs/Markdown/Concepts/cshapes.md
@@ -1,4 +1,4 @@
-## 24 Drawing Graphics
+# 24 Drawing Graphics
 
 This chapter describes the commands used to draw things on a display. 
 ["Graphics Environment," Chapter 23](cgraph.md), explains how to set up the display 
@@ -8,7 +8,7 @@ You must have read the previous chapter; in particular, you should be
 familiar with GStates. To use certain commands, you should also be familiar 
 with the GEOS fixed point number formats.
 
-### 24.1 Drawing Goals
+## 24.1 Drawing Goals
 
 The graphics system has a set of graphic commands capable of describing 
 anything that might ever be drawn; at the same time, the command set 
@@ -20,7 +20,7 @@ graphics commands whether you are drawing to a display, describing a
 GString (which can be sent to a printer), drawing to a bitmap, or describing 
 a path. This simplifies graphics programming a great deal.
 
-### 24.2 Shapes
+## 24.2 Shapes
 
 Depending on how much experience you have with the GEOS graphics 
 system, you may have some idea already about what sorts of shapes can be 
@@ -48,7 +48,7 @@ these routines to draw the outline of any conceivable two-dimensional shape.
 To create a precise, filled shape, use these routines to describe a path and 
 then fill the path.
 
-#### 24.2.1 Dots
+### 24.2.1 Dots
 
 GrDrawPoint(), GrDrawPointAtCP()
 
@@ -64,7 +64,7 @@ _A point is defined by its coordinates._
 **GrDrawPoint()** draws a point at the passed coordinate pair.  
 **GrDrawPointAtCP()** draws a point at the current pen position.
 
-#### 24.2.2 Lines
+### 24.2.2 Lines
 
 GrDrawLine(), GrDrawLineTo(), GrDrawRelLineTo(), 
 GrDrawHLine(), GrDrawHLineTo(), GrDrawVLine(), 
@@ -93,7 +93,7 @@ current pen position to a passed y coordinate. The **GrDrawH...()** and
 at the specified x and y offset from the starting position. This routine takes 
 very precise coordinates, and is useful for describing paths.
 
-#### 24.2.3 Rectangles
+### 24.2.3 Rectangles
 
 GrDrawRect(), GrDrawRectTo(), GrFillRect(), GrFillRectTo()
 
@@ -116,7 +116,7 @@ you want a bordered rectangle, call **GrFillRect()** and follow it with
 **GrDrawRect()**. Note that if the order of these operations if reversed, the fill 
 may obscure the draw.
 
-#### 24.2.4 Ellipses
+### 24.2.4 Ellipses
 
 GrDrawEllipse(), GrFillEllipse()
 
@@ -132,7 +132,7 @@ _An ellipse with its bounding rectangle._
 drawing attributes. **GrFillEllipse()** fills the ellipse's area using the current 
 area attributes.
 
-#### 24.2.5 Elliptical Arcs
+### 24.2.5 Elliptical Arcs
 
 GrDrawArc(), GrFillArc()
 
@@ -150,7 +150,7 @@ are two ways to fill an arc: you can fill in the wedge described by the arc, or
 you can fill just the region between the arc and its chord; set the style with 
 an **ArcCloseType** value. 
 
-#### 24.2.6 Three-Point Arcs
+### 24.2.6 Three-Point Arcs
 
 GrDrawArc3Point(), GrDrawArc3PointTo(), GrFillArc3Point(), 
 GrFillArc3PointTo(), GrDrawRelArc3PointTo()
@@ -192,7 +192,7 @@ _The elliptical arc doesn't start quite where the line leaves off, perhaps due t
 a poorly calculated angle. The three-point arc, defined in terms of its 
 endpoints, is certain to have an endpoint in common with the line._
 
-#### 24.2.7 Rounded Rectangles
+### 24.2.7 Rounded Rectangles
 
 GrDrawRoundRect(), GrDrawRoundRectTo(), GrFillRoundRect(), 
 GrFillRoundRectTo()
@@ -218,7 +218,7 @@ rectangle with passed bounding rectangle and corner radius using the
 current area attributes. **GrFillRoundRectTo()** fills a rounded rectangle 
 that has the current position as one corner of the bounding rectangle.
 
-#### 24.2.8 Polylines and Polygons
+### 24.2.8 Polylines and Polygons
 
 GrDrawPolyline(), GrDrawPolygon(), GrFillPolygon(), 
 GrBrushPolyline(), GrTestPointInPolygon()
@@ -267,7 +267,7 @@ where speed is a top priority.
 To find out whether a given point falls within a polygon, call 
 **GrTestPointInPolygon()**.
 
-#### 24.2.9 Bézier Curves and Splines
+### 24.2.9 Bézier Curves and Splines
 
 GrDrawCurve(), GrDrawCurveTo(), GrDrawSpline(), 
 GrDrawSplineTo(), GrDrawRelCurveTo()
@@ -344,7 +344,7 @@ non-smooth derivatives are called "semi smooth", analogous to  continuity.
 ![](Art/figure_24-11.png)  
 **Figure 24-11** Levels of Smoothness
 
-#### 24.2.10 Drawing Bitmaps
+### 24.2.10 Drawing Bitmaps
 
 GrDrawBitmap(), GrDrawBitmapAtCP, GrFillBitmap(), 
 GrFillBitmapAtCP(), GrDrawHugeBitmap(), 
@@ -402,7 +402,7 @@ The image-drawing routines take an **ImageFlags** structure which holds a
 flag to specify whether borders should be drawn between the pixels of the 
 bitmap and a bit size field which specifies the magnification to use.
 
-#### 24.2.11 Paths
+### 24.2.11 Paths
 
 GrDrawPath(), GrFillPath()
 
@@ -434,7 +434,7 @@ _When drawing a path formed by union or intersection, both paths are drawn,
 perhaps not what was expected. The effects of a union or intersection aren't 
 apparent unless the paths are filled (or used to define clip regions)._
 
-#### 24.2.12 Regions
+### 24.2.12 Regions
 
 GrGetPathRegion(), GrDrawRegion(), GrDrawRegionAtCP(), 
 GrMoveReg(), GrGetPtrRegBounds(), GrTestPointInReg(), 
@@ -550,7 +550,7 @@ of a region are set incorrectly, the rows are given out of order, or an incorrec
 Figure 24-17 shows a complicated region which uses parametrized 
 coordinates.
 
-#### 24.2.13 Text
+### 24.2.13 Text
 
 Programs normally display text with UI gadgetry such as GenText, VisText, 
 and GenGlyph objects. For those times when a geode will display text as part 
@@ -568,7 +568,7 @@ parameter. Remember that the coordinate 5000h is not absolute but
 corresponds to the first parameter, and all coordinates between 4000h and 
 5FFFh will be relative to this coordinate._
 
-##### 24.2.13.1 Displaying Text
+#### 24.2.13.1 Displaying Text
 
 GrDrawText(), GrDrawTextAtCP(), GrDrawChar(), 
 GrDrawCharAtCP(), GrDrawTextField()
@@ -586,7 +586,7 @@ draws a text string at the current position. **GrDrawChar()** and
 non-printing character. **GrDrawTextField()** draws a field of text-however, 
 this routine is only available in Assembly language. 
 
-##### 24.2.13.2 Special Text Attributes
+#### 24.2.13.2 Special Text Attributes
 
 GrGetTextStyle(), GrSetTextStyle(), GrGetTextMode(), 
 GrSetTextMode(), GrGetTextSpacePad(), GrSetTextSpacePad(), 
@@ -674,7 +674,7 @@ offset sub- or superscript characters; the low byte is the percentage of font
 size to use for the sub- or superscript character 0x0064 (decimal 100) would 
 be full-sized with no displacement.
 
-##### 24.2.13.3 Accessing Available Fonts
+#### 24.2.13.3 Accessing Available Fonts
 
 GrEnumFonts(), GrCheckFontAvail(), 
 GrFindNearestPointsize(), GrGetDefFontID(), GrGetFontName()
@@ -732,7 +732,7 @@ To find out the ASCII name of a string for which you have the **FontID**, call
 otherwise it will fill a passed buffer with the name of the font. The passed 
 buffer should be FID_NAME_LEN bytes long.
 
-##### 24.2.13.4 Text Metrics
+#### 24.2.13.4 Text Metrics
 
 GrTextWidth(), GrTextWidthWBFixed(), GrCharWidth(), 
 GrFontMetrics(), GrCharMetrics()
@@ -890,7 +890,7 @@ The character's topmost bound. This is the distance the
 character extends above the baseline. It is sometimes called the 
 character's "ascent."
 
-### 24.3 Shape Attributes
+## 24.3 Shape Attributes
 
 GrSetAreaAttr(), GrSetLineAttr(), GrSetTextAttr()
 
@@ -905,7 +905,7 @@ areas at once, call **GrSetAreaAttr()**. Call **GrSetLineAttr()** to set all
 attributes to use when drawing lines. Use **GrSetTextAttr()** to set all 
 text-rendering attributes.
 
-#### 24.3.1 Color
+### 24.3.1 Color
 
 If your geode displays graphics, you can probably make its graphical display 
 more effective by using color. Your geode can have as much control over color 
@@ -979,7 +979,7 @@ typedef ByteEnum    ColorFlag;
  */
 ~~~
 
-##### 24.3.1.1 Using Available Colors
+#### 24.3.1.1 Using Available Colors
 
 GrGetAreaColor(), GrSetAreaColor(), GrGetLineColor(), 
 GrSetLineColor(), GrGetTextColor(), GrSetTextColor()
@@ -1038,7 +1038,7 @@ palette indexes instead of RGB values, it is possible to change the RGB value
 of palette entry 02 so that the C_GREEN constant actually refers to, for 
 example, a shade of magenta.
 
-##### 24.3.1.2 When the Color Isn't in the Palette
+#### 24.3.1.2 When the Color Isn't in the Palette
 
 GrSetLineColorMap(), GrSetAreaColorMap(), 
 GrSetTextColorMap(), GrGetLineColorMap(), 
@@ -1073,7 +1073,7 @@ use the **GrMapColorIndex()** routine to find the RGB value associated with
 an index. The **GrMapColorRGB()** routine returns the index and true RGB 
 color of the palette entry that most closely matches the values passed.
 
-##### 24.3.1.3 Custom Palettes
+#### 24.3.1.3 Custom Palettes
 
 GrCreatePalette(), GrDestroyPalette(), GrSetPaletteEntry(), 
 GrSetPalette(), GrGetPalette()
@@ -1115,7 +1115,7 @@ array with 256 entries (one for each color), each entry consisting of three
 bytes. The first byte of each entry is the color's red component, the second is 
 the color's green component, and the third is the color's blue component.
 
-#### 24.3.2 Patterns and Hatching
+### 24.3.2 Patterns and Hatching
 
 GrSetAreaPattern(), GrSetAreaPatternCustom(), 
 GrSetTextPattern(), GrSetTextPatternCustom(), 
@@ -1289,7 +1289,7 @@ static HatchDash dash3 = {
 To find out the current area or text pattern, call GrGetAreaPattern() or 
 GrGetTextPattern().
 
-#### 24.3.3 Mix Mode
+### 24.3.3 Mix Mode
 
 GrGetMixMode(), GrSetMixMode()
 
@@ -1366,7 +1366,7 @@ overwrite whatever was underneath. When drawing a checkerboard with
 individual black squares, the background would show through no matter 
 what background because there's nothing drawn between the squares.
 
-#### 24.3.4 Masks
+### 24.3.4 Masks
 
 GrSetAreaMaskSys(), GrSetAreaMaskCustom(), GrGetAreaMask(), 
 GrSetLineMaskSys(), GrSetLineMaskCustom(), GrGetLineMask(), 
@@ -1428,7 +1428,7 @@ fill and 25 to a 100% fill. Several SDM_- constants have been set up with the
 more commonly used system draw patterns. For a list of constants, see the 
 Routines manual.
 
-#### 24.3.5 Line-Specific Attributes
+### 24.3.5 Line-Specific Attributes
 
 GrGetLineWidth(), GrSetLineWidth(), GrGetLineJoin(), 
 GrSetLineJoin(), GrGetLineEnd(), GrSetLineEnd(), 

--- a/TechDocs/Markdown/Concepts/csound.md
+++ b/TechDocs/Markdown/Concepts/csound.md
@@ -1,11 +1,11 @@
-## 13 Sound Library
+# 13 Sound Library
 
 GEOS includes a powerful sound library. The library allows users to play 
 individual notes, sequences of notes, and sampled sounds. It also provides 
 support for those sound devices which allow the sampling and playback of 
 digitized sounds.
 
-### 13.1 Goals and Motives
+## 13.1 Goals and Motives
 
 The sound library provides multiple tiers of support for a variety of devices. 
 You may program multiple-voice compositions (musical pieces which require 
@@ -23,7 +23,7 @@ programmer can keep his interface consistent with that of existing programs.
 When the standard system sounds are inappropriate, the programmer can 
 use other routines to completely specify the sound's pitch and duration.
 
-### 13.2 Playing UI Sounds
+## 13.2 Playing UI Sounds
 
 UserStandardSound()
 
@@ -73,7 +73,7 @@ sampled sound. SST_CUSTOM_NOTE signals that you wish to
 play a single note. To learn more about creating custom notes 
 and music buffers, see below. 
 
-### 13.3 Representing Tones
+## 13.3 Representing Tones
 
 Tones are defined by the following characteristics:
 
@@ -195,7 +195,7 @@ instrument, you should probably play notes of that frequency. For example,
 to simulate an "electric snare," you would use IP_ELECTRIC_SNARE to play a 
 note of frequency FR_ELECTRIC_SNARE.
 
-### 13.4 Single Notes
+## 13.4 Single Notes
 
 SoundAllocMusicNote(), SoundPlayMusicNote(), 
 SoundStopMusicNote(), SoundReallocMusicNote(), 
@@ -321,7 +321,7 @@ SoundStopMusicNote(BigBlatt);
 SoundFreeMusicNote(BigBlatt);
 ~~~
 
-### 13.5 Declaring Music Buffers
+## 13.5 Declaring Music Buffers
 
 You may set up a buffer of notes to be played. This buffer may include 
 information for several voices. If you are familiar with constructing MIDI 
@@ -473,7 +473,7 @@ Release a semaphore. There is one word of data:
 
 - **semaphore** The handle of the semaphore to release ("V").
 
-### 13.6 Playing Music Buffers
+## 13.6 Playing Music Buffers
 
 SoundAllocMusic(), SoundInitMusic(), SoundPlayMusic(), 
 SoundStopMusic(), SoundReallocMusic(), SoundFreeMusic()
@@ -542,7 +542,7 @@ SoundStopMusic(theSong);
 SoundFreeMusic(theSong);
 ~~~
 
-### 13.7 Playing Very Large Music Buffers
+## 13.7 Playing Very Large Music Buffers
 
 SoundAllocMusicStream(), SoundPlayToMusicStream(), 
 SoundStopMusicStream(), SoundFreeMusicStream()
@@ -563,7 +563,7 @@ call **SoundStopMusicStream()**. To free up the music stream, call
 through the stream when you free it; be sure to call 
 **SoundStopMusicStream()** if you are not otherwise sure.
 
-### 13.8 Playing Sampled Sounds
+## 13.8 Playing Sampled Sounds
 
 Once you have your sound data structure set up, the basic steps to playing 
 the sound are
@@ -628,7 +628,7 @@ Once the DAC stream has been disabled, you may free up the sound token by
 calling **SoundFreeSampleStream()**. You should call this with all sound 
 tokens before your application exits.
 
-### 13.9 Grabbing the Sound Exclusive
+## 13.9 Grabbing the Sound Exclusive
 
 SoundGetExclusive(), SoundGetExclusiveNB(), 
 SoundReleaseExclusive()
@@ -665,7 +665,7 @@ To release the exclusive, call **SoundReleaseExclusive()**. This will allow
 sounds to enter the queue and will allow another thread which has called 
 **SoundGetExclusive()** to grab the exclusive.
 
-### 13.10 Simulating Musical Instruments
+## 13.10 Simulating Musical Instruments
 
 In addition to the standard instruments provided by the system, you may 
 define instruments of your own. To do so, you must first find out what sort of 
@@ -676,7 +676,7 @@ To find out what sort of data structure the sound driver expects, call
 **SoundSynthDriverInfo()** and note the value returned at the format 
 pointer argument.
 
-#### 13.10.1 Acoustics In Brief
+### 13.10.1 Acoustics In Brief
 
 Sound may be thought of in terms of waves. A pure tone manifests as a sine 
 wave. The higher the frequency of the wave (as measured in Hertz), the 
@@ -695,7 +695,7 @@ A rich instrument such as an organ will make sounds on many frequencies
 other than that of the main note. A violin, with a very pure tone, will generate 
 almost no sound on frequencies other than that of the note being played.
 
-#### 13.10.2 Simple Instrument Description
+### 13.10.2 Simple Instrument Description
 
 The simple instrument description allows you to specify a way for less 
 powerful devices to emulate different musical instruments. You describe 
@@ -747,7 +747,7 @@ CTIEnvelopeFormat NoisyDrum =
     { 0, 0, 0, ((NT_METAL_NOISE << 6) | 63 ) };
 ~~~
 
-#### 13.10.3 Advanced Description
+### 13.10.3 Advanced Description
 
 The advanced instrument description data structures were set up with the 
 SoundBlaster card in mind; for detailed information (i.e. timing numbers) 

--- a/TechDocs/Markdown/Concepts/cstream.md
+++ b/TechDocs/Markdown/Concepts/cstream.md
@@ -1,4 +1,4 @@
-## 21 Using Streams
+# 21 Using Streams
 
 It is often useful for an application to be able to write out data in an orderly 
 manner to be read by another program or sent to a device such as a printer 
@@ -33,7 +33,7 @@ to send data to and receive data from a serial port.
 + A description of the specific routines and conventions for using a stream 
 to send data to a parallel port.
 
-### 21.1 Using Streams: The Basics
+## 21.1 Using Streams: The Basics
 
 A stream is a path along which information flows in one direction. At one end 
 of the stream is a writer, who puts data into the stream. At the opposite end 
@@ -78,7 +78,7 @@ in Object-Assembly can call the driver directly. Goc programs cannot do this;
 instead, they make calls to the Stream Library, which in turn calls the 
 Stream Driver, and passes back any return values.
 
-#### 21.1.1 Initializing a Stream
+### 21.1.1 Initializing a Stream
 
 A stream is essentially a first-in-first-out data buffer, in which the writer is 
 different from the reader. When the writer writes data to the stream, the 
@@ -131,7 +131,7 @@ STREAM_CANNOT_ALLOC (if the memory for the stream's buffer cannot be
 allocated) or STREAM_BUFFER_TOO_LARGE (if the requested stream size 
 was greater than 32767).
 
-##### 21.1.1.2 Assigning Readers and Writers
+#### 21.1.1.2 Assigning Readers and Writers
 
 Once a stream is created, you must make sure that both ends will be 
 managed-a stream that has only a writer or only a reader is not a useful 
@@ -149,7 +149,7 @@ Once both geodes have the stream's token, each can access the stream
 normally. The next several sections explain how to access a stream for 
 writing and reading.
 
-#### 21.1.2 Blocking on Read or Write
+### 21.1.2 Blocking on Read or Write
 
 StreamBlocker, StreamError
 
@@ -184,7 +184,7 @@ If a stream routine returns an error, the error will be a member of the
 **StreamError** enumerated type. The possible error values are described in 
 the section for each routine.
 
-#### 21.1.3 Writing Data to a Stream
+### 21.1.3 Writing Data to a Stream
 
 StreamWrite(), StreamWriteByte()
 
@@ -258,7 +258,7 @@ permitted while this is happening.
 **STREAM_CLOSED**  
 The stream has already been closed.
 
-#### 21.1.4 Reading Data from a Stream
+### 21.1.4 Reading Data from a Stream
 
 StreamRead(), StreamReadByte()
 
@@ -326,7 +326,7 @@ waiting in the stream.
 The stream is in the process of being closed; no reading is 
 permitted while this is happening.
 
-#### 21.1.5 Shutting Down a Stream
+### 21.1.5 Shutting Down a Stream
 
 StreamClose()
 
@@ -357,7 +357,7 @@ until it's read; false (i.e. zero) indicates it should be flushed.
 If you are using the Serial or Parallel drivers (described later in this chapter), 
 you do not have to coordinate the closure of a stream.
 
-#### 21.1.6 Miscellaneous Functions
+### 21.1.6 Miscellaneous Functions
 
 StreamFlush(), StreamQuery()
 
@@ -390,7 +390,7 @@ stream buffer. If you pass STREAM_ROLES_READER, **StreamQuery()**
 returns the number of bytes of data waiting to be read. If the call is 
 unsuccessful, **StreamQuery()** returns a **StreamError**.
 
-### 21.2 Using the Serial Ports
+## 21.2 Using the Serial Ports
 
 The serial driver uses streams to control the flow of data to and from serial 
 ports. The kernel automatically copies data from the serial port into one 
@@ -398,7 +398,7 @@ stream for reading, and sends data from another stream into the serial port.
 An application which wishes to use the serial port simply reads and writes 
 data from those streams. 
 
-#### 21.2.1 Initializing a Serial Port
+### 21.2.1 Initializing a Serial Port
 
 Like the stream driver, the serial driver is not accessed directly from Goc 
 code. Instead, a Goc application makes calls to the Stream Library, which 
@@ -411,7 +411,7 @@ The serial driver uses two streams, one for data going out to the serial port
 program is the writer of the outgoing and the reader of the incoming. (In both 
 cases, the port acts as the opposite user.)
 
-##### 21.2.1.1 Opening a Serial Port
+#### 21.2.1.1 Opening a Serial Port
 
 SerialOpen()
 
@@ -453,7 +453,7 @@ with either STREAM_READ (if reading from the stream) or STREAM_WRITE
 it, you must specify both parameters. The serial driver will understand which 
 stream you are accessing.
 
-##### 21.2.1.2 Configuring a Serial Port
+#### 21.2.1.2 Configuring a Serial Port
 
 SerialSetFormat(), SerialGetFormat(),SerialSetModem(), 
 SerialGetModem(), SerialSetFlowControl()
@@ -608,7 +608,7 @@ hardware flow control is selected). When one of the selected lines is
 de-asserted by the remote system, the serial driver will not transmit any 
 more data until the state changes.
 
-#### 21.2.2 Communicating
+### 21.2.2 Communicating
 
 SerialRead(), SerialReadByte(), SerialWrite(), 
 SerialWriteByte(), SerialQuery(), SerialFlush()
@@ -632,7 +632,7 @@ To find out if you can read or write data to the port, call **SerialQuery()**.
 Again, this routine behaves like its **Stream-()** equivalent. To flush any data 
 from the input or output stream, call **SerialFlush()**.
 
-#### 21.2.3 Closing a Serial Port
+### 21.2.3 Closing a Serial Port
 
 SerialClose(), SerialCloseWithoutReset()
 
@@ -655,7 +655,7 @@ You can also instruct the serial driver to close the stream to a port, without
 actually resetting the port. Do this by calling **SerialCloseWithoutReset()**. 
 This routine is passed the same arguments as **SerialClose()**.
 
-### 21.3 Using the Parallel Ports
+## 21.3 Using the Parallel Ports
 
 Using a parallel port is simpler than using a serial port since data goes in 
 only one direction. GEOS does not currently support reading data from a 
@@ -667,7 +667,7 @@ whose applications will need to send data out through the parallel port
 without using the spooler. Most applications, however, will use the spooler for 
 any and all parallel port use.
 
-#### 21.3.1 Initializing a Parallel Port
+### 21.3.1 Initializing a Parallel Port
 
 ParallelOpen()
 
@@ -714,7 +714,7 @@ driver will understand which stream you are accessing.
 Once the port is selected, the PC will assert the SLCTIN signal, which usually 
 will place the device on-line.
 
-#### 21.3.2 Communicating
+### 21.3.2 Communicating
 
 ParallelWrite(), ParallelWriteByte()
 
@@ -726,7 +726,7 @@ routine is passed the **ParallelUnit** for the appropriate port, instead of bein
 passed a stream token. These routines behave exactly like their **Stream-()** 
 counterparts.
 
-#### 21.3.3 Closing a Parallel Port
+### 21.3.3 Closing a Parallel Port
 
 ParallelClose()
 

--- a/TechDocs/Markdown/Concepts/cuiover.md
+++ b/TechDocs/Markdown/Concepts/cuiover.md
@@ -1,4 +1,4 @@
-## 10 The GEOS User Interface
+# 10 The GEOS User Interface
 
 The GEOS user interface (UI) is an integral part of the system software and 
 does an amazing amount of work for applications. The UI is a sophisticated 
@@ -16,7 +16,7 @@ This chapter will provide an overview of the specifics of the GEOS User
 Interface. For a general overview of the UI and a high-level description of its 
 components, see ["System Architecture", Chapter 3](carch.md).
 
-### 10.1 The GUI
+## 10.1 The GUI
 
 Ever since the first text-based computer application was created, computer 
 users have looked for easier, more intuitive interfaces to their programs. If 
@@ -52,7 +52,7 @@ language. And, since most of the user interface is managed and drawn by
 GEOS, applications written for the system automatically take advantage of 
 this speed.
 
-### 10.2 The GEOS User Interface
+## 10.2 The GEOS User Interface
 
 Most programmers who write applications for GEOS will have worked with 
 other GUI systems. Some will even have worked with object-oriented 
@@ -103,7 +103,7 @@ _All the classes shown have the properties of VisClass and can be used in an
 application's visible object tree. Visible objects are more flexible but require 
 more programming than do generic objects._
 
-### 10.3 Using the Generic Classes
+## 10.3 Using the Generic Classes
 
 Most of your application's UI needs will be satisfied by the use of generic UI 
 objects. Many applications may need only the generic classes. Generic UI 
@@ -162,7 +162,7 @@ look-and-feel specifications; this is desirable to the programmer because he
 only has to code the application once to receive the benefits of several 
 different GUIs.
 
-#### 10.3.1 The Generic Class Tree
+### 10.3.1 The Generic Class Tree
 
 Generic objects have a tremendous amount of built-in functionality. Much of 
 this is built into **GenClass**, the topmost class in the generic class tree. For 
@@ -213,7 +213,7 @@ not encouraged, however, as it can cause a specific UI library to give
 unpredictable results. For a diagram of all the generic classes in their class 
 hierarchy, see Figure 10-1.
 
-##### 10.3.1.1 GenClass
+#### 10.3.1.1 GenClass
 
 **GenClass** provides the functionality basic to all generic objects. **GenClass** 
 is not used directly by any applications and has no visible representation. 
@@ -237,13 +237,13 @@ finish.
 **GenClass** also implements scores of hints that can affect UI geometry, visual 
 representation, data structures, and functions.
 
-##### 10.3.1.2 GenApplicationClass
+#### 10.3.1.2 GenApplicationClass
 
 **GenApplicationClass** provides the basic functionality to open and close 
 applications within GEOS. An object of this class serves as the top object in 
 any application for GEOS.
 
-##### 10.3.1.3 GenPrimaryClass
+#### 10.3.1.3 GenPrimaryClass
 
 **GenPrimaryClass** is a subclass of **GenDisplayClass**. The GenPrimary is 
 the chief UI grouping object of an application, and it usually appears as the 
@@ -252,14 +252,14 @@ all controls and output areas that are invoked when an application is first
 launched. You will usually create a GenPrimary as the sole child of your 
 GenApplication object.
 
-##### 10.3.1.4 GenTriggerClass
+#### 10.3.1.4 GenTriggerClass
 
 A GenTrigger is a simple pushbutton that executes an action when activated 
 by the user. Typically, the trigger will have a moniker displayed within it and 
 will be activated by a mouse click or by a special keystroke sequence. 
 GenTriggers are very common in applications.
 
-##### 10.3.1.5 GenInteractionClass
+#### 10.3.1.5 GenInteractionClass
 
 GenInteraction objects are essentially grouping mechanisms. 
 GenInteractions are the key objects for creating both menus and dialog 
@@ -268,7 +268,7 @@ Typically, a GenInteraction will have a number of children, each of which will
 appear within the interaction on the screen. The Interaction itself may or 
 may not have a visible representation.
 
-##### 10.3.1.6 GenViewClass
+#### 10.3.1.6 GenViewClass
 
 The GenView object provides a scrollable window in which the application 
 has complete drawing control. Most applications will use a GenView, and 
@@ -278,7 +278,7 @@ automatically. A View can even be splittable or linked to other views. The
 GenView can display either normal graphic documents or hierarchies of 
 visible objects. 
 
-##### 10.3.1.7 List Classes
+#### 10.3.1.7 List Classes
 
 Together, GenBoolean, GenBooleanGroup, GenItem, **GenItemGroup**, and 
 GenDynamicList provide many different types of lists. List objects may be 
@@ -286,14 +286,14 @@ used to create lists that are dynamic or static; scrollable or not; exclusive,
 non-exclusive, or otherwise. List objects may appear within menus or dialog 
 boxes as well as within an application's primary window.
 
-##### 10.3.1.8 GenValueClass
+#### 10.3.1.8 GenValueClass
 
 The GenValue object allows the user to set a value within a particular range. 
 This may be implemented as a slider, a spinner, or a pair of up/down buttons 
 next to the value. Ranges may use scalar or distance values and can have 
 their maximum and minimum values set by the application.
 
-##### 10.3.1.9 GenTextClass
+#### 10.3.1.9 GenTextClass
 
 **GenTextClass** is tremendously versatile and can be used for text displays or 
 text-edit fields. The GenText is used by nearly every application that either 
@@ -307,7 +307,7 @@ manual leading, and character kerning, as well as several other features. The
 text library also provides several controllers that work with the GenText to 
 allow the user to set all these features.
 
-##### 10.3.1.10 Document and Document Control Classes
+#### 10.3.1.10 Document and Document Control Classes
 
 Together, **GenDocumentClass**, **GenDocumentGroupClass**, and 
 **GenDocumentControlClass** provide all the functions necessary to create, 
@@ -321,7 +321,7 @@ GenDocument objects are created and managed automatically by the
 GenDocumentGroup. Each document object represents a single file which 
 has been opened or newly created by the user.
 
-##### 10.3.1.11 Display and Display Control Classes
+#### 10.3.1.11 Display and Display Control Classes
 
 Together, the GenDisplay, GenDisplayGroup, and GenDisplayControl 
 provide display windows and the UI gadgetry to manage them. Typically, 
@@ -334,7 +334,7 @@ Window menu to allow the user to operate on the individual displays. If your
 application will have multiple documents or multiple displays open, you will 
 want to use these objects.
 
-##### 10.3.1.12 GenControlClass and UI Controllers
+#### 10.3.1.12 GenControlClass and UI Controllers
 
 **GenControlClass** is used to create UI controller objects. Applications will 
 most likely not use **GenControlClass** directly, though some object libraries 
@@ -351,7 +351,7 @@ and displays UI gadgetry to set color information; and
 **GenViewControlClass**, which creates and maintains a View menu 
 allowing the user to set scaling and scrolling behavior.
 
-##### 10.3.1.13 GenToolControlClass
+#### 10.3.1.13 GenToolControlClass
 
 **GenToolControlClass** lets the user select which of an application's tools 
 are available and where they should be placed (in a toolbox, in a menu, etc.). 
@@ -360,19 +360,19 @@ controllers will provide several tool areas and a GenToolControl; the
 GenToolControl will automatically create all the UI gadgetry to let the user 
 select which tools are active and where they will appear.
 
-##### 10.3.1.14 GenFileSelectorClass
+#### 10.3.1.14 GenFileSelectorClass
 
 The GenFileSelector provides user interface to allow the user to navigate 
 through his or her file system. It is used most often by the document control 
 objects and is used directly by only some applications.
 
-##### 10.3.1.15 GenGlyphClass
+#### 10.3.1.15 GenGlyphClass
 
 GenGlyph displays simple text or graphics strings. Text displayed by a Glyph 
 object is not selectable or editable; these objects are typically used for 
 labeling areas or items on the screen.
 
-##### 10.3.1.16 GenContentClass
+#### 10.3.1.16 GenContentClass
 
 **GenContentClass** is used with a GenView to display other generic UI 
 objects within a scrollable window. The GenContent is rarely used because 
@@ -380,7 +380,7 @@ having some of an application's UI objects not visible can confuse some users.
 More often, a GenDocument is used as the view's content; 
 GenDocumentClass is subclassed from the GenContent.
 
-#### 10.3.2 Creating a Generic Object Tree
+### 10.3.2 Creating a Generic Object Tree
 
 You don't have to understand all the generic object classes to create a 
 complete generic object tree for your application. For insight into and an 
@@ -388,14 +388,14 @@ example of creating a generic tree (including the primary window, a menu, a
 dialog box, and a scrolling view window), see ["First Steps: Hello World", 
 Chapter 4](cgetsta.md).
 
-### 10.4 Using the Visible Classes
+## 10.4 Using the Visible Classes
 
 The visible classes in GEOS provide custom objects that can be used for any 
 number of purposes. There are many visible object classes and they are so 
 versatile that everything from spreadsheets to drawing programs to 
 interactive games can be created from them.
 
-#### 10.4.1 Visible Objects and the GenView
+### 10.4.1 Visible Objects and the GenView
 
 Visible objects are designed for flexibility and for interacting with the user. 
 Typically, visible objects will reside in an object tree, the root of which is a 
@@ -420,7 +420,7 @@ events are expected or required, and the view will notify the VisContent
 whenever the window has been invalidated and the document needs 
 redrawing.
 
-#### 10.4.2 The Visible Object Document
+### 10.4.2 The Visible Object Document
 
 Visible objects exist in an object tree and draw themselves in the GEOS 
 graphic space. Every visible object knows where in the graphic coordinate 
@@ -454,7 +454,7 @@ within its bounds).
 For examples of visible objects that know their bounds and that handle 
 MSG_VIS_DRAW, see ["A UI Example"](#105-a-ui-example).
 
-#### 10.4.3 Visible Object Abilities
+### 10.4.3 Visible Object Abilities
 
 Visible objects can be used in innumerable situations; with a little work from 
 the application developer, they provide dozens of useful features including
@@ -504,7 +504,7 @@ about clipping or scrolling or even determining what type of input event is
 taking place. All this is somewhat automatic and can, for the most part, be 
 ignored.
 
-#### 10.4.4 The Vis Class Tree
+### 10.4.4 The Vis Class Tree
 
 There are four base visible classes on which the other object libraries are 
 founded. **VisClass** is the most basic and at the root of the visible class tree. 
@@ -537,7 +537,7 @@ the VisContent interacts with the GenView to handle input and drawing.
 The content can interact with the view to determine sizing behavior as 
 well as input behavior.
 
-#### 10.4.5 Creating a Visible Object Tree
+### 10.4.5 Creating a Visible Object Tree
 
 You can create a visible object tree either in your Goc source code or at 
 run-time. As stated earlier, the visible tree is linked to the generic UI object 
@@ -564,7 +564,7 @@ object is ever to be shown on the screen: Since visible objects can have any
 application-defined visible representation, you must write the 
 MSG_VIS_DRAW handler yourself; this can be done only in a subclass.
 
-#### 10.4.6 Working with Visible Object Trees
+### 10.4.6 Working with Visible Object Trees
 
 Working with visible object trees is quite easy and provides immense 
 flexibility to your applications. Entire groups of objects can be added to, 
@@ -601,12 +601,12 @@ object of the proper class, where they will be handled.
 information about the visible tree. They also have messages for altering the 
 visible tree's structure.
 
-### 10.5 A UI Example
+## 10.5 A UI Example
 
 This section uses the sample application TicTac, a simple Tic Tac Toe board 
 and pieces that can be moved around the board.
 
-#### 10.5.1 What TicTac Illustrates
+### 10.5.1 What TicTac Illustrates
 
 The TicTac sample application can teach you several things about how the 
 visible world works and about how to manage visible objects in an 
@@ -644,7 +644,7 @@ content.
 A simple, two-layer visible tree is used in the TicTac application: The 
 VisContent is the root of the tree, and each of the pieces is a leaf.
 
-#### 10.5.2 What TicTac Does
+### 10.5.2 What TicTac Does
 
 The TicTac sample application is extremely simple. It draws a Tic Tac Toe 
 board and its outline, and it has ten pieces which the user can move. Five of 
@@ -658,7 +658,7 @@ kind are enforced. Recognition of winning sequences and rules involving turn
 sequencing or playing against the computer are left as exercises for the 
 reader.
 
-#### 10.5.3 The Structure of TicTac
+### 10.5.3 The Structure of TicTac
 
 The TicTac sample application is coded in two files: The first, tictac.gp, is the 
 geode parameters file. The other, tictac.goc, contains all the code for objects 
@@ -824,7 +824,7 @@ Code Display 10-3 The TicTacView Object
 @end Interface                  /* End of the Interface resource block */
 ~~~
 
-##### 10.5.3.2 TicTac's Visible Tree
+#### 10.5.3.2 TicTac's Visible Tree
 
 The visible tree contains eleven objects. One acts as TicTacView's content and 
 is of TicTacBoardClass, a subclass of **VisContentClass**. The other ten are 
@@ -963,7 +963,7 @@ typedef ByteEnum TicTacPieceTypes;
 @classdecl TicTacPieceClass;
 ~~~
 
-#### 10.5.4 TicTacBoard Specifics
+### 10.5.4 TicTacBoard Specifics
 
 The TicTacBoard object, being of a subclass of **VisContentClass**, handles 
 many messages specific to content objects. However, only three messages are 
@@ -1113,7 +1113,7 @@ Code Display 10-5 Methods of TicTacBoardClass
 }
 ~~~
 
-#### 10.5.5 TicTacPiece Specifics
+### 10.5.5 TicTacPiece Specifics
 
 TicTacPieceClass contains most of the game's functionality. Since the user 
 interacts directly with each game piece, the piece must know not only how to 

--- a/TechDocs/Markdown/Concepts/cvm.md
+++ b/TechDocs/Markdown/Concepts/cvm.md
@@ -1,4 +1,4 @@
-## 18 Virtual Memory
+# 18 Virtual Memory
 
 Most disk-operating systems provide minimal file functionality. A file is 
 simply treated as a sequence of bytes; applications can copy data from files to 
@@ -18,7 +18,7 @@ and ["Memory Management," Chapter 15](cmemory.md). You should also be familiar w
 the GEOS file system; you should have at least skimmed ["File System," 
 Chapter 17](cfile.md), although you need not have read it in depth.
 
-### 18.1 Design Philosophy
+## 18.1 Design Philosophy
 
 The GEOS Virtual Memory file management system is designed to provide 
 features not easily available with standard file systems. Designed primarily 
@@ -60,7 +60,7 @@ can take care of opening, closing, and saving all data files which are
 based on VM files. Furthermore, data structures can be designed which 
 can be added at will into any VM file.
 
-### 18.2 VM Structure
+## 18.2 VM Structure
 
 Virtual memory can be thought of as a heap stored in a disk file. Like the 
 global heap, it is divided into blocks which are 64K or smaller; each block is 
@@ -91,7 +91,7 @@ block's location in the file. Usually, the Block Table contains entries for bloc
 that haven't been created yet; when all of these handles have been used, the 
 VM Manager expands the block table. For details, see [section 18.2.3](#1822-vm-handles).
 
-#### 18.2.1 The VM Manager
+### 18.2.1 The VM Manager
 
 The VM manager can be thought of as a memory manager for a disk-based 
 heap, providing all the services a memory manager would and more. The VM 
@@ -153,7 +153,7 @@ data. These libraries are based on the LMem library. Each item of data
 has its own DB handle as well as a VM Block handle. Database items are 
 discussed in depth in ["Database Library," Chapter 19](cdb.md).
 
-#### 18.2.3 Virtual Memory Blocks
+### 18.2.3 Virtual Memory Blocks
 
 Most file systems treat files as a string of bytes. A user can read a file 
 sequentially or can start reading at a specified distance into the file. This 
@@ -167,7 +167,7 @@ a sequence of bytes, and other operating systems can copy the file normally.
 However, GEOS geodes can access the file much more conveniently by 
 specifying the blocks they wish to access.
 
-##### 18.2.3.1 The Nature of VM Blocks
+#### 18.2.3.1 The Nature of VM Blocks
 
 A VM block is a sequence of bytes in a VM file. It must be small enough to fit 
 in a global memory block (i.e. 64K or less, preferably 2K-6K). It may move 
@@ -195,7 +195,7 @@ changed at will with the routine **VMModifyUserID()**. Note that all user IDs
 from 0xff00 to 0xffff are reserved for system use. You can find a block with a 
 specific user ID by calling **VMFind()**.
 
-##### 18.2.3.2 Creating and Using VM Blocks
+#### 18.2.3.2 Creating and Using VM Blocks
 
 There are two ways you can create a VM block. The first is to request a VM 
 block: You specify the size of the block, the block is created, and you are 
@@ -224,7 +224,7 @@ memory block, and saving it back to the disk.
 These techniques are described in detail in ["Creating and Freeing Blocks"]
 (#1834-creating-and-freeing-blocks) and ["Attaching Memory Blocks"](#1835-attaching-memory-blocks).
 
-##### 18.2.3.3 File Compaction
+#### 18.2.3.3 File Compaction
 
 When a VM block is freed, the VM manager will note that there is empty 
 space in the file. It will use that space when new blocks are allocated. 
@@ -263,7 +263,7 @@ Note that if a file is in "backup mode," the file will be compacted only on call
 to **VMSave()**, **VMSaveAs()**, or **VMRevert()**. If the file is not in backup 
 mode, it can be compacted on any call to **VMUpdate()**. 
 
-##### 18.2.3.4 File Updating and Backup
+#### 18.2.3.4 File Updating and Backup
 
 When a block is locked into memory, the VM manager copies the data from 
 the disk block to the global memory block. When the block is unlocked, the 
@@ -304,7 +304,7 @@ create a new file, which does not contain the backup blocks; that is, it
 contains the file as it currently exists. It will then revert the original file to 
 its last-saved version and close it.
 
-#### 18.2.4 VM File Attributes
+### 18.2.4 VM File Attributes
 
 VMAttributes
 
@@ -363,7 +363,7 @@ VMA_NO_DISCARD_IF_IN_USE, and
 VMA_SINGLE_THREAD_ACCESS. All of these attributes must 
 be set if the file contains object blocks. 
 
-### 18.3 Using Virtual Memory
+## 18.3 Using Virtual Memory
 
 The most common way applications will use Virtual Memory is for their data 
 files. However, there are other uses; for example, VM provides a convenient 
@@ -404,7 +404,7 @@ try to update blocks whenever they are unlocked.)
 Use **VMClose()** when you are done with the file. It will update the file 
 and close it.
 
-#### 18.3.2 Opening or Creating a VM File
+### 18.3.2 Opening or Creating a VM File
 
 VMOpen(), VMOpenTypes, VMAccessFlags
 
@@ -549,7 +549,7 @@ VM_WRITE_PROTECTED
 **VMOpen()** was passed VMAF_FORCE_READ_WRITE, but the 
 file or disk was write-protected.
 
-#### 18.3.3 Changing VM File Attributes
+### 18.3.3 Changing VM File Attributes
 
 VMGetAttributes(), VMSetAttributes()
 
@@ -563,7 +563,7 @@ takes three arguments: the file handle (which may be overridden), a set of
 bits which should be turned on, and a set of bits which should be turned off. 
 It returns the new **VMAttributes** flags.
 
-#### 18.3.4 Creating and Freeing Blocks
+### 18.3.4 Creating and Freeing Blocks
 
 VMAlloc(), VMAllocLMem(), VMFree()
 
@@ -623,7 +623,7 @@ freed, even if it is locked. Any associated memory will also be freed. If you
 want to keep the memory, detach the global memory block from the file (with 
 **VMDetach()**) before you free the block.
 
-#### 18.3.5 Attaching Memory Blocks
+### 18.3.5 Attaching Memory Blocks
 
 VMAttach(), VMDetach()
 
@@ -667,7 +667,7 @@ return the memory block's handle. If the VM block was dirty, the block will be
 updated to the file before it is detached. The next time the VM block is locked, 
 a new global memory block will be allocated for it.
 
-#### 18.3.6 Accessing and Altering VM Blocks
+### 18.3.6 Accessing and Altering VM Blocks
 
 VMLock(), VMUnlock(), VMDirty(), VMFind(), 
 VMModifyUserID(), VMPreserveBlocksHandle()
@@ -735,7 +735,7 @@ the VM file handle and the VM block handle. It sees to it that the specified VM
 block will remain attached to the same global block until the VM block is 
 specifically detached (or reattached).
 
-#### 18.3.7 VM Block Information
+### 18.3.7 VM Block Information
 
 VMVMBlockToMemBlock(), VMMemBlockToVMBlock(), VMInfo()
 
@@ -781,7 +781,7 @@ typedef struct {
 } VMInfoStruct;
 ~~~
 
-#### 18.3.8 Updating and Saving Files
+### 18.3.8 Updating and Saving Files
 
 VMUpdate(), VMSave(), VMSaveAs(), VMRevert(), 
 VMGetDirtyState() VMSave()
@@ -870,7 +870,7 @@ have backup-capability, both bytes will always be equal. Note that
 **VMUpdate()** even if the file might be clean, rather than checking the 
 dirty-state with **VMGetDirtyState()**. 
 
-#### 18.3.9 Closing Files
+### 18.3.9 Closing Files
 
 VMClose()
 
@@ -898,7 +898,7 @@ is next opened. That means, for example, that the next time you open the file,
 you can continue working on it normally, or you can immediately revert it to 
 its condition as of the last time it was saved (in the earlier GEOS session).
 
-#### 18.3.10 The VM File's Map Block
+### 18.3.10 The VM File's Map Block
 
 VMGetMapBlock(), VMSetMapBlock()
 
@@ -925,7 +925,7 @@ In addition to setting a map block, you can set a map database item with the
 command **DBSetMap()**. For details, see [section 19.2.5 of chapter 19]
 (cdb.md#1925-the-db-map-item).
 
-#### 18.3.11 File-Access Synchronization
+### 18.3.11 File-Access Synchronization
 
 VMGrabExclusive(), VMReleaseExclusive()
 
@@ -1041,7 +1041,7 @@ When a thread is done accessing a file, it should release its exclusive access
 by calling **VMReleaseExclusive()**. The routine takes one argument, 
 namely the file handle. It does not return anything.
 
-#### 18.3.12 Other VM Utilities
+### 18.3.12 Other VM Utilities
 
 VMCopyVMBlock(), VMSetReloc()
 
@@ -1087,7 +1087,7 @@ unrelocating object, not by the VM manager.
 Using the routine **VMSetReloc()**, you can instruct the VM manager to call 
 your relocation routine whenever appropriate.
 
-### 18.4 VM Chains
+## 18.4 VM Chains
 
 A VM file is just a collection of blocks. These blocks are not kept in any 
 particular order. If the application wants to keep the blocks in some kind of 
@@ -1104,7 +1104,7 @@ special "tree blocks," which may have links to any number of child blocks. By
 using these blocks, an application can set up VM trees of unlimited 
 complexity.
 
-#### 18.4.1 Structure of a VM Chain
+### 18.4.1 Structure of a VM Chain
 
 A VM chain is composed of two kinds of blocks: chain blocks (which are linked 
 to at most one other block), and tree blocks (which may be linked to any 
@@ -1167,7 +1167,7 @@ changing VMCT_count.
 _This is a sample VM tree block. It contains links to four other link (or chain) 
 blocks, and enough extra space for 0x100 bytes of data._
 
-#### 18.4.2 VM Chain Utilities
+### 18.4.2 VM Chain Utilities
 
 VMChainHandle, VMFreeVMChain(), VMCompareVMChains(), 
 VMCopyVMChain(), VMCHAIN_IS_DBITEM(), 
@@ -1230,7 +1230,7 @@ identifies a VM chain. It returns the VM handle (i.e. the more significant word
 of the structure). Finally, the macro VMCHAIN_MAKE_FROM_VM_BLOCK() 
 takes a **VMBlockHandle** value and casts it to type **VMChain**.
 
-### 18.5 Huge Arrays
+## 18.5 Huge Arrays
 
 Sometimes a geode needs to work with an array that can get very large. 
 Chunk arrays are very convenient, but they are limited to the size of an 
@@ -1265,7 +1265,7 @@ Huge arrays may have fixed-size or variable-sized elements. If elements are
 variable-sized, there is a slight increase in memory overhead, but no 
 significant slowdown in data-access time.
 
-#### 18.5.1 Structure of a Huge Array
+### 18.5.1 Structure of a Huge Array
 
 The huge array has two different type of blocks: a single directory block, and 
 zero or more data blocks. The blocks are linked together in a simple (i.e., 
@@ -1346,7 +1346,7 @@ means you cannot use a VM chain utility when any block in the chain is
 locked or while any thread might be accessing the array. If more than one 
 thread might be using the array, you should not use the chain utilities.
 
-#### 18.5.2 Basic Huge Array Routines
+### 18.5.2 Basic Huge Array Routines
 
 HugeArrayCreate(), HugeArrayDestroy(), HugeArrayLock(), 
 HugeArrayUnlock(), HugeArrayDirty(), HugeArrayAppend(), 
@@ -1519,7 +1519,7 @@ handle and the handle of the Huge Array. The routine returns the number of
 elements in the array. Since array indices begin at zero, if 
 **HugeArrayGetCount()** returns, the last element in the array has index [x-1].
 
-#### 18.5.3 Huge Array Utilities
+### 18.5.3 Huge Array Utilities
 
 HugeArrayNext(), HugeArrayPrev(), HugeArrayExpand(), 
 HugeArrayContract(), HugeArrayEnum(), 

--- a/TechDocs/Markdown/Ddk/ddkbasics.md
+++ b/TechDocs/Markdown/Ddk/ddkbasics.md
@@ -1,4 +1,4 @@
-## 1 Driver Development
+# 1 Driver Development
 
 There are three kinds of geode: applications, libraries, and drivers. Most
 programmers will only write applications. A few will write libraries, either
@@ -18,7 +18,7 @@ examining them, you should be able to see how a driver is put together, and
 how to rewrite one of those drivers for a new device. These examples are
 located in the \OMNIGO\DRIVER\DDK directory.
 
-### 1.1 Driver Basics
+## 1.1 Driver Basics
 
 One of the advantages of the GEOS operating system is that it insulates
 application developers from many of the low-level hardware chores. GEOS
@@ -50,7 +50,7 @@ printer driver, for example, all printer drivers should look and act more or
 less the same. Thus, a driver will have close constraints on its interface with
 other parts of GEOS.
 
-#### 1.1.1 Driver Behavior
+### 1.1.1 Driver Behavior
 
 In some ways, drivers behave differently from other geodes. One major
 difference is that for some drivers, running speed is a much higher priority
@@ -73,7 +73,7 @@ Drivers tend to use fixed memory more often than other geodes do. A driver’s
 strategy routine (described below) and interrupt handlers must all be in fixed
 memory; any other timing-critical routines may also be in fixed resources.
 
-#### 1.1.2 Driver Structure
+### 1.1.2 Driver Structure
 
 A driver usually provides two communication structures. One is the interface
 it provides to the GEOS system, either through a library or a GEOS
@@ -90,7 +90,7 @@ driving. Most often, a driver will receive and handle interrupts from its
 device. It does this by registering an interrupt handler with the GEOS kernel.
 The interrupt handler must also be in a fixed code resource.
 
-#### 1.1.3 Extended Drivers
+### 1.1.3 Extended Drivers
 
 Some drivers can handle a number of similar, but distinct, devices. These
 drivers are known as extended drivers. An extended driver must provide
@@ -100,7 +100,7 @@ provide certain extra functionality to the kernel.
 When an extended driver is loaded, it is told which of its various devices it is
 intended to drive.
 
-### 1.2 Defining a Basic Driver
+## 1.2 Defining a Basic Driver
 
 Every driver, of whatever type, has a few components in common. The driver
 stores information about itself in a certain, rigidly defined way; that way, the
@@ -112,7 +112,7 @@ type; these are listed in this section. Others are specific for a type of driver
 these will be listed in the chapter pertaining to that type of driver.
 Driver Development
 
-#### 1.2.1 The Driver’s .GP File
+### 1.2.1 The Driver’s .GP File
 
 A driver is a geode. As such, it will be compiled as any other geode, and
 contains a geode parameters file. The geode parameters file looks somewhat
@@ -147,7 +147,7 @@ if available, and check the device’s driver include file in
 \OMNIGO\INCLUDE\INTERNAL. All device include file names end with
 dr.def; for example, all mouse drivers must include the file mousedr.def.
 
-#### 1.2.2 Information about the Driver
+### 1.2.2 Information about the Driver
 
 DriverTable, DriverInfoStruct, DriverAttrs, DriverType
 
@@ -272,7 +272,7 @@ udata segment
 udata ends
 ~~~
 
-#### 1.2.3 Extended Drivers
+### 1.2.3 Extended Drivers
 
 If the driver is an extended driver (i.e., if the DA_HAS_EXTENDED_INFO bit
 in the DIS _driverAttributes field is set), the device must use a slightly
@@ -395,7 +395,7 @@ DriverInfoStruct. For example, if you are writing a mouse driver, you must
 begin its driver table segment with a MouseDriverInfoStruct, the first
 field of which is a DriverExtendedInfoStruct.
 
-#### 1.2.4 The Strategy Routine
+### 1.2.4 The Strategy Routine
 
 Every driver must have a strategy routine. This routine is called by the GEOS
 kernel and by libraries. The strategy routine is passed a code telling it what
@@ -404,7 +404,7 @@ routine contains a jump table; it calls a different routine, using the passed
 code as an offset into the jump table. (All the passed codes are even numbers,
 to facilitate jumping through a table of near-pointers.)
 
-##### 1.2.4.1 What Functions Must Be Handled?
+#### 1.2.4.1 What Functions Must Be Handled?
 
 ''DriverFunction, DriverExtendedFunction''
 
@@ -442,7 +442,7 @@ to those drivers.
 Different drivers will react to this in different ways. Some drivers will not
 have to handle escape codes at all.
 
-##### 1.2.4.2 The DriverFunction Type
+#### 1.2.4.2 The DriverFunction Type
 
 DR_INIT, DR_EXIT, DR_SUSPEND, DR_UNSUSPEND
 
@@ -526,7 +526,7 @@ __Destroyed:__
 __Include:__
 driver.def
 
-##### 1.2.4.3 Writing the Strategy Routine
+#### 1.2.4.3 Writing the Strategy Routine
 
 As noted, the strategy routine is the single entry point upon which a driver
 executes code. That routine determines what the driver needs to do, and calls
@@ -605,7 +605,7 @@ MyExit       endp
 Init         ends
 ~~~
 
-##### 1.2.4.4 The DriverExtendedFunction Type
+#### 1.2.4.4 The DriverExtendedFunction Type
 
 ``DRE_TEST_DEVICE, DRE_SET_DEVICE, DevicePresent, EnumerateDevice``  
 All extended drivers must be able to handle the two functions specified by the
@@ -697,7 +697,7 @@ __Warning:__
 containing the driver’s extended information and return the block’s segment
 address in es. Be sure to unlock this block when you’re done with it.
 
-#### 1.2.5 Escape Codes
+### 1.2.5 Escape Codes
 
 ``DriverEscCode``  
 Some kinds of drivers may be passed escape codes. An escape code is passed

--- a/TechDocs/Markdown/Ddk/ddkfont.md
+++ b/TechDocs/Markdown/Ddk/ddkfont.md
@@ -1,11 +1,11 @@
-## 4 Font Driver
+# 4 Font Driver
 
 AUTHOR:	Gene Anderson (01/21/91)
 
 This document describes the interface and interactions of font drivers in
 PC/GEOS.
 
-### 4.1 Overview
+## 4.1 Overview
 
 In PC/GEOS, outline font drivers play a vital role in the
 WYSIWYG rendering engine.  They are called to generate the metrics for
@@ -74,7 +74,7 @@ which the font driver may choose to support or not, as is appropriate.
 These include functions such as adding or deleting a font from the
 system.
 
-### 4.2 Initialization Routines
+## 4.2 Initialization Routines
 
 *DR_INIT*
 
@@ -133,7 +133,7 @@ include pointsize, as that is irrelevant for outline fonts).  If there
 are no outlines for the FontIDs value in question, FI_outlineTab is
 zero (0) and there are no OutlineDataEntry structures.
 
-### 4.3 Data Routines
+## 4.3 Data Routines
 
 *DR_FONT_GEN_WIDTHS*
 
@@ -325,7 +325,7 @@ scheme, the characters may not be in any particular order.
                 [...]
         Region/CharData #c
 
-### 4.4 Metrics Routines
+## 4.4 Metrics Routines
 
 *DR_FONT_CHAR_METRICS*
 
@@ -418,7 +418,7 @@ be the only routine called to add data to the RegionPath, so the
 integrity of RegionPath data must be ensured.
 
 
-### 4.5 Debugging Tips
+## 4.5 Debugging Tips
 
 To assist in debugging font drivers and their interaction with
 the Font Manager, there are a number of useful TCL commands available:

--- a/TechDocs/Markdown/Ddk/ddkmouse.md
+++ b/TechDocs/Markdown/Ddk/ddkmouse.md
@@ -1,11 +1,11 @@
-## 2 Mouse Driver
+# 2 Mouse Driver
 
 Most GEOS platforms will use some kind of pointing device. On desktop
 machines, this is most commonly a mouse; in any event, these pointing
 devices share many similarities with mice. Accordingly, all these devices are
 driven by drivers known collectively as mouse drivers.
 
-### 2.1 Mouse Driver Basics
+## 2.1 Mouse Driver Basics
 Most mouse drivers behave in very similar ways. For this reason, most GEOS
 mouse drivers share a lot of code. This code is provided in the SDK in the files
 \OMNIGO\DRIVER\DDK\MOUSE\MOUSECOM.ASM and
@@ -14,7 +14,7 @@ mouse drivers; these demonstrate how the drivers actually use the common
 code to perform such tasks as send mouse movements to the system, handle
 strategy-routine requests, etc.
 
-#### 2.1.1 Data Structures
+### 2.1.1 Data Structures
 All mouse drivers must be extended drivers, even if they support only one
 kind of mouse. A mouse driver’s dgroup segment must begin with the
 MouseDriverInfoStruct structure. This structure is based on the
@@ -73,7 +73,7 @@ This field should contain the factory-set default value.
 ``MEI_CALIBRATE``  
 Set if this mouse can be calibrated within GEOS.
 
-#### 2.1.2 Functions
+### 2.1.2 Functions
 
 Mouse drivers must be able to handle all four functions defined by
 DriverFunction, and both functions defined by

--- a/TechDocs/Markdown/Ddk/ddkpcmcia.md
+++ b/TechDocs/Markdown/Ddk/ddkpcmcia.md
@@ -1,5 +1,5 @@
 
-## 3 PCMCIA Drivers
+# 3 PCMCIA Drivers
 
 This chapter explains the fundamentals associated with writing a PCMCIA
 driver for GEOS . Life for a PCMCIA driver— as with a human being— begins
@@ -30,7 +30,7 @@ A PCMCIA sample driver that you may use as a template is available in
 \OMNIGO\DRIVER\DDK\PCMCIA\SAMPLE . Other (functioning) drivers are
 located within \OMNIGO\DRIVER\DDK\PCMCIA.
 
-### 3.1 PCMCIA Drivers Basics
+## 3.1 PCMCIA Drivers Basics
 Writing a GEOS device driver for PCMCIA cards is somewhat different than
 writing a driver for other devices. The driver acts not only with the device,
 but with the PCMCIA library (a GEOS library) and CardServices.
@@ -45,7 +45,7 @@ callback routine handling the specific CardServicesEventCode types. It
 will also need to send function calls to CardServices using the
 CardServicesFunction type.
 
-#### 3.1.1 State Information
+### 3.1.1 State Information
 A PCMCIA driver needs to maintain information about the card(s) and
 socket(s) that it is driving. The “socket” refers to the physical slot of the
 PCMCIA hardware interface. (This should not be confused with the GEOS
@@ -62,7 +62,7 @@ of information that may be necessary:
 + How the card was configured. This depends on the requirements of the
 device.
 
-#### 3.1.2 Handling Basic Functions
+### 3.1.2 Handling Basic Functions
 ``DR_INIT, DR_EXIT``  
 Your PCMCIA driver will need to handle the basic DR_INIT and DR_EXIT
 routines defined in driver.def. (There usually is not any need to handle
@@ -70,7 +70,7 @@ DR_SUSPEND and DR_UNSUSPEND .) Because PCMCIA drivers are not
 extended, there is no need to handle DRE_TEST_DEVICE and
 DRE_SET_DEVICE.
 
-##### 3.1.2.1 Insertion
+#### 3.1.2.1 Insertion
 As noted, the insertion or removal of a PCMCIA card are the two most
 important events in the driver’s life. When a driver is first loaded, it registers
 with CardServices. Among other things, this registration allows the driver to
@@ -86,7 +86,7 @@ the card. If the card is compatible, the driver configures the card according to
 its own specifications and makes its devices and/or memory available to
 GEOS.
 
-##### 3.1.2.2 Removal
+#### 3.1.2.2 Removal
 The removal of a PCMCIA card is a difficult event for a PCMCIA driver. The
 driver may be writing a file to the card; it may be communicating something
 over the serial line. No one wants to “go” when confronted with the tasks still
@@ -236,7 +236,7 @@ SampleExit     proc    far
 SampleExit     endp
 ~~~
 
-#### 3.1.3 PCMCIA Driver Functions
+### 3.1.3 PCMCIA Driver Functions
 ``DR_PCMCIA_CHECK_SOCKET, DR_PCMCIA_OBJECTION_RESOLVED,
 DR_PCMCIA_CLOSE_SOCKET, DR_PCMCIA_DEVICE_ON, DR_PCMCIA_DEVICE_OFF``
 
@@ -521,7 +521,7 @@ __Destroyed:__
 __Include:__
 pcmciaDr.def
 
-### 3.2 PCMCIA Library Functions
+## 3.2 PCMCIA Library Functions
 As noted, a PCMCIA driver will interact with both a PCMCIA library and,
 through that library, CardServices. The PCMCIA library provides a number
 of routines to aid in communicating with CardServices.
@@ -585,7 +585,7 @@ __Destroyed:__
 __Include:__
 pcmcia.def
 
-### 3.3 CardServices Functions
+## 3.3 CardServices Functions
 A driver must contact CardServices through use of CardServicesFunction
 types defined in pcmcia.def. Consult that file for a complete list of all
 possible function calls, as well as pass and return information for those calls.  
@@ -731,7 +731,7 @@ procedure), DONT_LOCK_BIOS must be passed as an option. At all other
 times you must not pass DONT_LOCK_BIOS (unless you call SysLockBIOS
 yourself) as CardServices is not re-entrant.
 
-### 3.4 CardServices Events
+## 3.4 CardServices Events
 The interface between CardServices and your driver occurs not only through
 use of the PCMCIA library; your driver must also handle events sent by
 CardServices as well. This is performed through use of a callback routine.

--- a/TechDocs/Markdown/Devices/Nokia9000/ngrabbag.md
+++ b/TechDocs/Markdown/Devices/Nokia9000/ngrabbag.md
@@ -1,8 +1,8 @@
-## Nokia 9000/9000i/9110 Communicator Fact Sheet
+# Nokia 9000/9000i/9110 Communicator Fact Sheet
 
 ![](Art/p_9000.gif)
 
-### Hardware
+## Hardware
 
 **The device dimensions are:**
 
@@ -76,7 +76,7 @@ The keyboard is a standard QWERTY keyboard. English, French German and Scandinav
 
 The Nokia 9110 Communicator uses a 1100 mAh Li-ion Battery that provides 3-6 hours of talk/data/fax, 60-200 hours of standby, up to 400 hours of standby when the phone is off, and takes 2 hours to charge.
 
-### Text
+## Text
 
 The following is a list of all the available fonts, their sizes, styles, and comments.
 
@@ -97,7 +97,7 @@ The following is a list of all the available fonts, their sizes, styles, and com
 | FID\_DTC\_URW\_ROMAN   | Any Size            | --                               | Outline font.                                                                                                                             |
 | FID\_BISON             | --                  | --                               | This font has only one character, '\*'. This is used for passwords.                                                                       |
 
-### Icons
+## Icons
 
 There are two types of icons: Status Pane Icons and File List Icons.
 
@@ -119,7 +119,7 @@ When creating a file list icon using the Icon Editor, use the following settings
 - Format Type: Icon
 - Display Size: Tiny
 
-### Communicator Grays
+## Communicator Grays
 
 Nokia 9000i Communicators support 4 levels of gray and the newer Nokia 9110 Communicators support 4-bit color, even though the display is grayscale (16 shades of gray). There are two different grayscale schemes used, one for visMonikers and icons, and the other for normal GEOS drawing routines.
 
@@ -147,7 +147,7 @@ Other graphics can make use of the 16 GEOS enumerated color types to choose the 
 | **C\_YELLOW, C\_BROWN**         | **White**            | **Light-light gray**  |
 | **C\_WHITE, C\_LIGHT\_GRAY**    |                      | **White**             |
 
-### Disk Space Warnings
+## Disk Space Warnings
 
 Often, it is useful to get a qualitative measure of the available free disk space to check whether the disk is dangerously full. The disk warning levels are:
 
@@ -155,7 +155,7 @@ The **Warning Level** is less than 50K.
 
 The **Critical Level** is less than 25K
 
-### UI Conventions: Triggers
+## UI Conventions: Triggers
 
 **Trigger Usage**
 
@@ -203,7 +203,7 @@ To create a menu trigger, follow the same steps for creating a normal trigger bu
 
 Ctrl-F2 corresponds to the menu button on the emulator.
 
-### Zoom Levels
+## Zoom Levels
 
 On versions 4.8.8 or later of the 9000i Communicator, the user can press an off-screen "Zoom" button to toggle between three text size settings -- "Zoom" levels -- and adjust the text size for comfortable reading.
 
@@ -222,7 +222,7 @@ Use `HINT_MAXIMUM_ZOOM_LEVEL` to determine the maximum size that a UI component 
 
 The higher the zoom level, the larger the font size, and the fewer the number of characters that will fit into a fixed pixel length field. Thus, if you use a `CreateVisMoniker...()` routine, you should use the routines `FoomZoomGetLevel()` and `FoamConvertToZoomedSize()` to take the zoom level into consideration and create a VisMoniker of appropriate size. (Refer to [Zoom Level UI](../../Nokia9000/UI/9000UI_zoom.htm) for more details.)
 
-### Nokia 9000i Emulator Keyboard Mapping
+## Nokia 9000i Emulator Keyboard Mapping
 
 **This only applies to US QWERTY keyboards**
 
@@ -270,21 +270,21 @@ Ctrl F3 - Detach application
 
 Ctrl F4 - Close application
 
-### Sound
+## Sound
 
 Communicator applications may play `StandardSoundType` sounds through the PDA-side speaker. If you write applications that use sounds, you will have to debug sounds on the actual device since the emulator does not provide sound support.
 
-### The Installer
+## The Installer
 
 The Nokia 9000i Communicator SDK comes with an installer application called **NServer.exe**. It uses an installation script that describes your application's name, version, and related files that will need to be transferred.
 
-### To Clear all RAM
+## To Clear all RAM
 
 To reset the Nokia 9000i Communicator and effectively erase every bit of data on the phone (except, of course, the factory settings and data) you must pull out the main battery, put it back in, then hold down the keys Shift-Esc-f. You will be prompted to format the RAM of the device and you can cancel here if you don't really want to erase the data.
 
 Once the phone has been reset you must re-enter all of the user data again, including your home country, name, and address.
 
-### Version Information
+## Version Information
 
 You can get version information from the INI file on the Nokia 9000i Communicator. The information is stored as a string in `[UI]swSerialNumber`. The string is 27 characters long. This same string can be seen on the last line of About this product. The whole string looks like this:
 
@@ -327,13 +327,13 @@ MemUnlock( OptrToHandle( @UICategory ) );
 }
 ```
 
-### Lid-closing Event
+## Lid-closing Event
 
 After the Nokia 9000i Communicator's lid is closed, the Communicator waits for 30 seconds and then turns off the CPU. Of course, the CPU will not turn off until all applications are idle.
 
 To receive notification that the lid is closed, an application should register on the GCN list `GCNSLT_RESPONDER_NOTIFICATIONS`. It should watch for `MSG_META_NOTIFY` with `notificationType == GWNT_RESPONDER_NOTIFICATION`, `manufID == MANUFACTURER_ID_GEOWORKS` and `data == RNT_LID_CLOSED`. (`ResponderNotificationType` is defined in N9000v20\\CInclude\\Internal\\respondr.goh)
 
-### Debugging an actual Nokia 9000i Communicator
+## Debugging an actual Nokia 9000i Communicator
 
 To debug on an actual Nokia 9000i Communicator, you need to attach your host PC to the device's 6-pin serial port. Then run the GEOS Setup program and change the "Communication Mode" to Remote and set the "Comm Speed" to 38400. Which "COMM Port" you use depends on which port on your PC you have used to connect to the phone. Remove the battery so the phone shuts down. Then replace the battery and press:
 

--- a/TechDocs/Markdown/Devices/zoomer1.md
+++ b/TechDocs/Markdown/Devices/zoomer1.md
@@ -1,4 +1,4 @@
-## Zoomer Programmer's Guide
+# Zoomer Programmer's Guide
 
 This booklet is a storehouse of advice for Zoomer 
 programmers. We assume you know a reasonable 

--- a/TechDocs/Markdown/Esp/ebasics.md
+++ b/TechDocs/Markdown/Esp/ebasics.md
@@ -1,4 +1,4 @@
-## 2 Esp Basics
+# 2 Esp Basics
 
 Esp is an assembly language for 80x86 microprocessors. It is designed for 
 creating applications, libraries, and drivers that will run under GEOS. As 
@@ -15,7 +15,7 @@ MASM.
 This book assumes that you already know how to program in 80x86 assembly 
 language.
 
-### 2.1 The Purpose of Esp
+## 2.1 The Purpose of Esp
 
 Esp is mainly a superset of MASM. With the exception of a few special cases 
 (which are noted in this chapter), MASM code can be ported intact to Esp 
@@ -26,7 +26,7 @@ Esp is, however, philosophically different from other assembly languages. It
 is designed for an object-oriented, multitasking environment. This means 
 that it works with different assumptions from other assembly languages. 
 
-### 2.2 Esp Ground Rules
+## 2.2 Esp Ground Rules
 
 There are certain rules you must follow when programming in Esp. These 
 rules are imposed by the nature of GEOS.
@@ -35,7 +35,7 @@ If you violate these rules, the results are unpredictable. Error-checking code
 may find violations of these rules; however, this is not guaranteed. Therefore, 
 you must be sure to follow the rules under all circumstances.
 
-#### 2.2.1 GEOS is a Multitasking Environment
+### 2.2.1 GEOS is a Multitasking Environment
 
 GEOS uses preemptive multitasking. It uses interrupts to halt each thread's 
 execution when its allotted time slice ends. This has two major consequences 
@@ -84,7 +84,7 @@ It bears repeating: Whenever you perform an unusual operation on the stack,
 ask yourself what would happen if a context switch occurred immediately 
 before or immediately after the instruction.
 
-#### 2.2.2 Upward and Downward Compatibility
+### 2.2.2 Upward and Downward Compatibility
 
 GEOS is intended to run on a wide range of platforms, from 8088-based 
 machines up through powerful desktop computers (80486s and beyond). 
@@ -128,7 +128,7 @@ There is currently no way for geodes to use a floating-point coprocessor
 directly. However, all GEOS floating-point routines will automatically use a 
 floating-point coprocessor if one is present.
 
-#### 2.2.3 Flags
+### 2.2.3 Flags
 
 GEOS makes certain assumptions about the flags.Your application must 
 follow these if it is to work with GEOS properly.
@@ -168,7 +168,7 @@ is the case unless the routine reference says so.
 
 You should never change TF; this is used by the debugger.
 
-### 2.3 Differences from MASM
+## 2.3 Differences from MASM
 
 Esp has a number of differences with other 80x86 assemblers. Some of these 
 are entirely transparent to the programmer; these differences will not be 
@@ -182,13 +182,13 @@ both synonymous with IF.
 In all cases where an algorithmic break is not involved, you can force Esp to 
 use the MASM syntax and directives by passing the flag "-m".
 
-#### 2.3.1 Data Types
+### 2.3.1 Data Types
 
 Esp makes it easy to declare and define structures, records, enumerated 
 types, and similar constructs. Its conventions are, however, slightly different 
 from those of MASM; you should be aware of these differences.
 
-##### 2.3.1.1 Constants
+#### 2.3.1.1 Constants
 
 Esp's rules for constants are almost the same as MASM's. Esp is slightly more 
 versatile. For example, hexadecimal constants may be specified with either 
@@ -213,7 +213,7 @@ Table 2-2. Since "\" is the escape character, you have to use a
 doubled backslash to put a backslash in the character string; that is, "\\" 
 specifies the single character 5Ch.
 
-##### 2.3.1.2 Simple Types
+#### 2.3.1.2 Simple Types
 
 Esp defines many standard data types beyond those provided by MASM. 
 These types can be used alone, or they can serve as building blocks for 
@@ -247,7 +247,7 @@ integers (i.e. "70, 111, 111, 33"); and if they are declared as an array of
 Similarly, Swat can use the information about a pointer's type to display its 
 referent appropriately.
 
-##### 2.3.1.3 Enumerated Types
+#### 2.3.1.3 Enumerated Types
 
 Sometimes you will have a variable that indicates one of a number of 
 conditions by holding an arbitrarily-chosen integer. For example, you may 
@@ -340,7 +340,7 @@ the step-value of two. If a routine expected to be passed a member of the
 MyColor enumerated type, it could check this by comparing the value to the 
 value of MyColor.
 
-##### 2.3.1.4 Structures
+#### 2.3.1.4 Structures
 
 Esp lets you define structures. Structure declarations have the following 
 format:
@@ -448,7 +448,7 @@ mov     ax, es:[di].3
 
 You can use the dot operator this way in any effective-address instruction.
 
-##### 2.3.1.5 Unions
+#### 2.3.1.5 Unions
 
 Esp supports unions as well as structures. A union is a variable that might, 
 at different times, have values of different sizes or types.
@@ -511,7 +511,7 @@ value after the field name, like so:
 aVariable               MyUnion         <MU_sbyte 12>
 ~~~
 
-##### 2.3.1.6 Records
+#### 2.3.1.6 Records
 
 Sometimes you will need to store several pieces of information, each of which 
 can be represented in less than a byte. One common situation is when you 
@@ -647,7 +647,7 @@ assembles equivalently to
 move    ax, 0x03E7
 ~~~
 
-##### 2.3.1.7 Creating New Types
+#### 2.3.1.7 Creating New Types
 
 Esp overloads the TYPE operator as a type-creation directive. It is useful if 
 you will be creating many arrays of exactly the same size. This is the format:
@@ -729,7 +729,7 @@ AStructure              MyStructure             <-123, <"Foo!", 0>,
 idata   ends
 ~~~
 
-#### 2.3.2 Symbols and Labels
+### 2.3.2 Symbols and Labels
 
 Esp improves on MASM's rules for symbols and labels.
 
@@ -746,7 +746,7 @@ label outside of the procedure, you should declare it thus:
 <myLabel> label near
 ~~~
 
-#### 2.3.3 Segments and dgroup
+### 2.3.3 Segments and dgroup
 
 Geodes are divided into segments. Each segment is loaded into memory all at 
 once, and accessed with a given segment address (hence the name). 
@@ -773,7 +773,7 @@ Every resource has a resource ID. This resource ID is determined at
 link-time; this means that a resource in a multi-launchable application will 
 have the same ID in each copy of the application running.
 
-##### 2.3.3.1 The dgroup Segment
+#### 2.3.3.1 The dgroup Segment
 
 Every geode is assigned a fixed memory resource for its global variables (and, 
 if the geode has a process object, for the process thread's stack). This resource 
@@ -826,7 +826,7 @@ udata   segment
 udata   ends
 ~~~
 
-##### 2.3.3.2 Accessing Segments
+#### 2.3.3.2 Accessing Segments
 
 GetResourceHandleNS, GetResourceSegmentNS, handle, segment, 
 GeodeGetResourceHandle, vSegment
@@ -947,7 +947,7 @@ handle.
 **Destroyed:**   
 Nothing.
 
-##### 2.3.3.3 Declaring Static Variables
+#### 2.3.3.3 Declaring Static Variables
 
 Esp has slightly different conventions for declaring variables than MASM 
 does. In Esp, you do not need to use the "db", dw", or "dd" reserved words 
@@ -1012,7 +1012,7 @@ myByteArray                     word    1, 2, 3, 4
 Note that if the variable is in the [udata](#2331-the-dgroup-segment) pseudo-segment, any specified 
 initializers will generate a link-time error.
 
-##### 2.3.3.4 Strings
+#### 2.3.3.4 Strings
 
 Esp provides a special format for declaring arrays of byte-sized values 
 (strings). A sequence of characters surrounded by single or double quotes is 
@@ -1081,7 +1081,7 @@ Certain character sequences (called escape sequences) are used to specify
 special characters. Esp supports the full range of C escape sequences; these 
 are shown in Table 2-2.
 
-#### 2.3.4 Miscellaneous Enhancements
+### 2.3.4 Miscellaneous Enhancements
 
 Many of Esp's features are general enhancements of MASM. Our engineers 
 simply felt that a given behavior was useful or preferable to the ordinary 
@@ -1106,7 +1106,7 @@ passing the "-m" flag to Esp.
 
 **Table 2-2** Esp Escape Sequences
 
-##### 2.3.4.1 Pseudo-Ops and Directives
+#### 2.3.4.1 Pseudo-Ops and Directives
 
 Esp provides a wide range of pseudo-ops and directives. Some of these will be 
 described in later chapters; a few of the most useful will be described here. 
@@ -1273,7 +1273,7 @@ Esp lets you use the EQ and NE directives to compare strings or segments, as
 well as immediate values. Of course, the operands must be defined at 
 assemble-time.
 
-##### 2.3.4.2 Miscellaneous Macros
+#### 2.3.4.2 Miscellaneous Macros
 
 Esp comes with a tremendous number of predefined macros. Some of these 
 perform common tasks in a roundabout, but more efficient, way. Others are 
@@ -1416,7 +1416,7 @@ _expr_ An expression whose value is known at assemble-time.
 **Include:**  
 geos.def
 
-##### 2.3.4.3 Useful Miscellaneous Macros
+#### 2.3.4.3 Useful Miscellaneous Macros
 
 clr, tst, BitSet, BitClr, segmov, segxchg, CmpStrings, 
 XchgTopStack
@@ -1671,7 +1671,7 @@ _fieldName_ The name of the field to clear. All bits in this field will be clear
 **Destroyed:**  
 Flags are destroyed.
 
-##### 2.3.4.4 dword Macros
+#### 2.3.4.4 dword Macros
 
 cmpdw, jgedw, jgdw, jledw, jldw, tstdw, pushdw, popdw, 
 notdw, negdw, incdw, decdw, movdw, adddw, adcdw, subdw, 
@@ -1689,7 +1689,7 @@ flags slightly differently from the corresponding instructions. The reference
 entries detail any such differences. Remember, when in doubt, you can 
 always look at the macro's source code.
 
-### 2.4 Defining Classes
+## 2.4 Defining Classes
 
 Every application defines at least one new class, its own process class. Most 
 applications define several more classes in addition to the process class.
@@ -1705,7 +1705,7 @@ of your class (in the .ui file) which matches the Esp one. The "Espire"
 language and the User-Interface compiler are discussed in ["The UI 
 Compiler", Chapter 4](euic.md).
 
-#### 2.4.1 Defining a Class
+### 2.4.1 Defining a Class
 
 Every class needs to be defined. The class's definition must be included once, 
 and only once, in the compilation, before the class name is ever actually used 
@@ -1732,7 +1732,7 @@ This is the name of the class's immediate superclass.
 
 For an example of a class definition, see Code Display 2-4.
 
-##### 2.4.1.1 Defining a Class's Messages
+#### 2.4.1.1 Defining a Class's Messages
 
 In Esp, you specify very little when you define a class's messages. You simply 
 specify the message name, without arguments or other information, like this:
@@ -1775,7 +1775,7 @@ exported by your class's superclass, define the message like this:
 This is the name of the message range exported by your class's 
 superclass.
 
-##### 2.4.1.2 Defining a Class's Instance Data Fields
+#### 2.4.1.2 Defining a Class's Instance Data Fields
 
 To define a class's instance data fields, put lines with this format in your class 
 definition:
@@ -1795,7 +1795,7 @@ standard or application-defined data type.
 This is the default value of the field when an object of this class 
 in instantiated.
 
-##### 2.4.1.3 Defining a Class's Vardata
+#### 2.4.1.3 Defining a Class's Vardata
 
 To define a hint or vardata field for a class, put lines with this format in your 
 class definition:
@@ -1812,7 +1812,7 @@ This field is optional; it is the type of data associated with the
 vardata field. It may be any standard or application-defined 
 data type.
 
-#### 2.4.2 Creating a Class's Class Structure
+### 2.4.2 Creating a Class's Class Structure
 
 Once you have defined a class, you must create its class structure. The class 
 structure must be in fixed memory; therefore, it is generally placed in the 
@@ -1871,7 +1871,7 @@ MyTriggerClass
 idata   ends
 ~~~
 
-#### 2.4.3 Defining your Process Class
+### 2.4.3 Defining your Process Class
 
 Every application with a process thread needs to define a new process class 
 for its process object. This is much like defining any other class. There are a 
@@ -1884,7 +1884,7 @@ process object (as described in [section 2.4.1](#241-defining-a-class)), you do 
 define the process object (with class... endc) unless you are defining 
 messages for your process class.
 
-### 2.5 Error-Checking Code
+## 2.5 Error-Checking Code
 
 ERROR_CHECK, ERROR, ERROR_C, ERROR_NC, ERROR_Z, ERROR_NZ...
 

--- a/TechDocs/Markdown/Esp/eintro.md
+++ b/TechDocs/Markdown/Esp/eintro.md
@@ -1,4 +1,4 @@
-## 1 Introduction to Esp
+# 1 Introduction to Esp
 
 This software development kit is geared towards C programmers. The SDK is 
 based around the GEOS-specific language Goc, which is based on C. Very few 
@@ -11,7 +11,7 @@ assembly. Furthermore, the SDK is not intended to teach assembly language;
 you should be familiar with 80x86 assembly before you attempt to program 
 in Esp.
 
-### 1.1 What is Esp?
+## 1.1 What is Esp?
 
 Esp is an 80x86 assembly language specially designed for GEOS 
 programming. In many ways, it is very similar to other common 80x86 
@@ -43,7 +43,7 @@ in Goc and Esp. In particular, they will let you compare Esp and Goc
 techniques for creating structures and classes, and compare Goc and Espire 
 techniques for creating objects and classes.
 
-### 1.2 Should I Use Esp?
+## 1.2 Should I Use Esp?
 
 Not everyone will want to use Esp. For many programmers, assembly 
 language is much harder to use than high-level languages like Goc. You may 
@@ -70,7 +70,7 @@ new object classes, you can write the message handlers in Esp; any
 application that uses those objects will be able to take advantage of the added 
 efficiency of Esp, even if the application is written in Goc.
 
-### 1.3 Roadmap to the Esp Book
+## 1.3 Roadmap to the Esp Book
 
 The Esp book is fairly short. This is because its main role is to help you 
 integrate knowledge you already have. You should already know how to 

--- a/TechDocs/Markdown/Esp/emixing.md
+++ b/TechDocs/Markdown/Esp/emixing.md
@@ -1,4 +1,4 @@
-## E Mixing C and Assembly
+# E Mixing C and Assembly
 
 You may sometimes wish to combine Goc and Esp code in a single application. 
 There are two main times when you may want to do this. You may be writing 
@@ -21,7 +21,7 @@ that class of object. You can write all the method code in assembly, while
 providing a Goc interface; this lets every application that uses the class take 
 advantage of assembly's efficiency.
 
-### E.1 Adding Esp Code to a Goc Geode
+## E.1 Adding Esp Code to a Goc Geode
 
 Most people will find it easiest to write applications in Goc. For most 
 purposes, Goc is efficient enough; after all, whenever an application is 
@@ -87,7 +87,7 @@ arguments are passed in the opposite order they are declared. This is useful
 if the routine has a variable number of arguments, but in other situations, 
 it's just a nuisance.
 
-### E.2 Writing an Esp Library
+## E.2 Writing an Esp Library
 
 You may wish to write a library in Esp whose routines can be called by either 
 Goc or Esp code. This is very much like writing a library in Goc. Simply write 

--- a/TechDocs/Markdown/Esp/erout.md
+++ b/TechDocs/Markdown/Esp/erout.md
@@ -1,4 +1,4 @@
-## 3 Routine Writing
+# 3 Routine Writing
 
 This chapter deals with some of Esp's special features, and describes how to 
 write routines (and message-handlers) in Esp. 
@@ -14,7 +14,7 @@ describes conventions for writing both Esp routines and message-handlers,
 as well as special Esp conventions and techniques which differ significantly 
 from their Goc counterparts.
 
-### 3.1 GEOS Conventions
+## 3.1 GEOS Conventions
 
 GEOS has certain presumptions about how routines behaves. If you write 
 your code to follow these conventions, Esp and Swat can work together to 
@@ -73,7 +73,7 @@ just enough space for the local variables. (It will, if necessary, add a padding
 byte, so the total amount of space used by local variables remains 
 word-aligned.)
 
-#### 3.1.1 Parameters and Local Variables
+### 3.1.1 Parameters and Local Variables
 
 Esp makes it easy to use local variables and parameters. You need simply 
 declare them in the beginning of a procedure; Esp will automatically set up 
@@ -144,7 +144,7 @@ the stack frame, as well as the aliases for the variable names. .leave
 destroys the stack frame, restoring sp and bp to their values at the time 
 .enter was used.
 
-##### 3.1.1.1 Initializing Local Variables
+#### 3.1.1.1 Initializing Local Variables
 
 If you wish, you can specify that local variables be initialized. When Esp 
 builds the stack frame (i.e. at the .enter instruction). The initialization is 
@@ -210,7 +210,7 @@ if you need to return a value in bp. If you want a local variable to contain the
 passed bp, but you do not want to change bp on return, you should 
 push-initialize the variable with ss:[bp], as described above.
 
-#### 3.1.2 The "uses" Directive
+### 3.1.2 The "uses" Directive
 
 Many routines will need to preserve the state of some or all of their registers. 
 Esp provides for this with the uses directive. This directive is used to specify 
@@ -225,7 +225,7 @@ uses must be used in conjunction with .enter and .leave. The registers
 will be pushed at the point where .enter is used; they will be popped where 
 .leave is used.
 
-#### 3.1.3 .enter and .leave
+### 3.1.3 .enter and .leave
 
 Esp provides several conveniences for writing routines. It can automatically 
 save registers, set up stack frames, and set up local arguments. You can 
@@ -352,7 +352,7 @@ HelloProc endp
 HelloProc               endp
 ~~~
 
-#### 3.1.4 Inheriting a Stack Frame
+### 3.1.4 Inheriting a Stack Frame
 
 You may write a routine which is called only by a single other routine. For 
 example, if you were writing a sort routine, you might write several 
@@ -420,7 +420,7 @@ accesses it, Esp will generate a warning at assembly time. If you declare a
 variable that is used only by other routines which inherit the stack frame, 
 you can disable the warning by using the [ForceRef](ebasics.md#forceref) macro.
 
-### 3.2 LMem Heaps and Chunks
+## 3.2 LMem Heaps and Chunks
 
 It is worth paying special attention to Local Memory heaps as they are used 
 in Esp. The heaps themselves are always the same, whether they are created 
@@ -520,7 +520,7 @@ Object Blocks are also LMem heaps. Whenever a message is sent to an object,
 that object may be resized; this can shuffle the block, or cause the object block 
 to move on the global heap.
 
-### 3.3 Objects and Classes
+## 3.3 Objects and Classes
 
 One big difference between Esp and other assemblers is Esp's support for 
 object-oriented programming. OOP is at the heart of GEOS, and Esp is 
@@ -532,7 +532,7 @@ categories: Declaring objects; creating new classes; and handling messages.
 Each issue will be treated in its own section. This section also contains a 
 review of the structure of GEOS objects, and how objects are handled in Esp.
 
-#### 3.3.1 Object Structure
+### 3.3.1 Object Structure
 
 This section is a review of how GEOS works with objects. Before you read this, 
 you should be familiar with ["GEOS Programming," Chapter 5 of the 
@@ -641,7 +641,7 @@ mov     ax, ds:[si].G_aDatum
 If any class in GoodbyeClass's class hierarchy becomes a master class, 
 Goodbye_offset will become defined, and this code will generate an error.
 
-#### 3.3.2 Messages
+### 3.3.2 Messages
 
 Writing code for objects is much like any other coding. Indeed, almost all 
 GEOS code is run by one object or another; either it is a message handler (or 
@@ -649,7 +649,7 @@ method), or it is a routine which is run by a method, directly or indirectly.
 There are a few conventions which apply specifically to methods; other than 
 that, methods can be treated just like other routines.
 
-##### 3.3.2.1 Handling Messages
+#### 3.3.2.1 Handling Messages
 
 Writing methods (also known as "message handlers") is little different from 
 writing other Esp procedures. This section describes GEOS's conventions for 
@@ -835,7 +835,7 @@ parameter.
 
 The other registers have the usual values.
 
-##### 3.3.2.2 Sending Messages
+#### 3.3.2.2 Sending Messages
 
 By now you should be very familiar with sending messages to objects. 
 However, there are enough differences between Esp and Goc in how they 
@@ -862,7 +862,7 @@ message is sent within the thread, or because it is sent as a
 "call-and-return"-there is a danger that the recipient object block might be 
 shuffled or moved while the sender is blocked.
 
-##### 3.3.2.3 ObjMessage
+#### 3.3.2.3 ObjMessage
 
 ObjMessage, MessageFlags
 
@@ -1207,7 +1207,7 @@ exists. (Note that if MF_CHECK_DUPLICATE and
 MF_DISCARD_IF_NO_MATCH is passed but MF_REPLACE is not, the message 
 will always be discarded.)
 
-##### 3.3.2.4 Other Ways of Sending Messages
+#### 3.3.2.4 Other Ways of Sending Messages
 
 ObjCallInstanceNoLock, ObjcallInstanceNoLockES, 
 ObjCallSuperNoLock

--- a/TechDocs/Markdown/Esp/euic.md
+++ b/TechDocs/Markdown/Esp/euic.md
@@ -1,4 +1,4 @@
-## 4 The UI Compiler
+# 4 The UI Compiler
 
 Assembly language is, by nature, very low-level. It does not ordinarily 
 provide support for object-oriented programming. GEOS has had to add 
@@ -27,7 +27,7 @@ kept in an object-block (e.g. Vis monikers).
 For assembly reference information about the various GEOS classes, see the 
 PCGEOS\INCLUDE\*.DEF and *.UIH files.
 
-### 4.1 UIC Overview
+## 4.1 UIC Overview
 
 Essentially, UIC reads files written in Espire, a special object-specification 
 language, and writes special GEOS object-assembly files. These files (which 
@@ -73,7 +73,7 @@ example, in assembly, a field might be called MET_AN_ENUM_VALUE; if the
 type were declared in a .uih file, the member would be called 
 "anEnumValue".
 
-### 4.2 Declaring Classes
+## 4.2 Declaring Classes
 
 You can create new classes by specifying them in your .ui file. You do this by 
 writing special Espire directives; these tell Esp how to create objects of that 
@@ -120,7 +120,7 @@ After the top line, you specify all the instance data fields for the class. You
 may also change default values for fields inherited from the class's 
 superclass. 
 
-#### 4.2.1 Declaring Fields
+### 4.2.1 Declaring Fields
 
 You must list all the instance data fields that are added with that subclass. 
 The basic format for specifying a field is:
@@ -270,7 +270,7 @@ two bits wide, and currentTask, which is four bits wide. By default, mode is
 set to sharedSingle (i.e. 1), and currentTask is set to new (i.e. 1); the flags 
 vmFile and supportsSaveAsRevert are set; and all other flags are cleared.
 
-#### 4.2.2 Changing a Default Value
+### 4.2.2 Changing a Default Value
 
 When you create a class, you may wish to change the default values of 
 instance fields inherited from a superclass. The format for doing this is:
@@ -348,7 +348,7 @@ MyTriggerClass class GenTriggerClass
 MyTriggerClass endc
 ~~~
 
-### 4.3 Creating Objects and Chunks
+## 4.3 Creating Objects and Chunks
 
 The whole point of the UIC is that it lets you create objects in your geode's 
 source code, instead of having to instantiate them at run-time. You can 
@@ -361,7 +361,7 @@ object block; that way, a resource editor can modify the text (if e.g. you are
 translating the application for another country). You may also set up data 
 resources, i.e. LMem heaps that contain chunks, but no objects.
 
-#### 4.3.1 Setting Up a Resource
+### 4.3.1 Setting Up a Resource
 
 start, end
 
@@ -395,7 +395,7 @@ A single resource may "start" and "end" many times in a .ui file. Thus, you
 can group your object declarations in whichever order is clear or convenient, 
 instead of being forced to group them by resource.
 
-#### 4.3.2 Creating Objects
+### 4.3.2 Creating Objects
 
 Creating objects in Espire is simple. You just specify the name of the object, 
 and the initial settings for any fields which do not have the default settings. 
@@ -474,7 +474,7 @@ aRecord = default +aFlag, -anotherFlag;
 specifies that the field aRecord should have its default settings, except that 
 the field aFlag should be set, and anotherFlag should be cleared.
 
-##### 4.3.2.1 Setting Up Parent-Child Links
+#### 4.3.2.1 Setting Up Parent-Child Links
 
 Gen and Vis objects are arranged in a hierarchy of children. GEOS 
 implements this with special linkings to the first child and the next sibling. 
@@ -493,7 +493,7 @@ These are the names of the children, in order, separated by commas.
 UIC automatically sets up the parent's and children's links to each other in 
 the proper way.
 
-##### 4.3.2.2 Hints and Vardata
+#### 4.3.2.2 Hints and Vardata
 
 You may specify an object's hints and other vardata in the .ui file. You can do 
 this by putting the "hints" directive in the instance-data section. This 
@@ -516,7 +516,7 @@ This field is optional. If the vardata field takes a value, you may
 specify it here. Everything between the curly braces is written 
 to the .rdf file, i.e. it is not interpreted by the UIC.
 
-#### 4.3.3 Creating Chunks
+### 4.3.3 Creating Chunks
 
 Chunks are very much like objects. They may be placed in an object block, 
 and referenced by name. They may also be placed in LMem data blocks.
@@ -611,7 +611,7 @@ The only difference is that in the second example, the name MyChunk
 evaluates to an optr to the chunk. (This allows you to examine the chunk by 
 name in Swat.)
 
-#### 4.3.4 Creating VisMonikers
+### 4.3.4 Creating VisMonikers
 
 **VisMoniker**s are created much the way they are in Goc. As in Goc, a 
 **VisMoniker** may be a single moniker, or a list of monikers; if it is, the system 

--- a/TechDocs/Markdown/Objects/ogen.md
+++ b/TechDocs/Markdown/Objects/ogen.md
@@ -5617,7 +5617,7 @@ values into one word.
 **Interception:** Generally not intercepted.
 
 ----------
-####MSG_GEN_SET_WIN_CONSTRAIN
+#### MSG_GEN_SET_WIN_CONSTRAIN
 
     void    MSG_GEN_SET_WIN_CONSTRAIN(
             VisUpdateMode       updateMode,

--- a/TechDocs/Markdown/Objects/ogenctl.md
+++ b/TechDocs/Markdown/Objects/ogenctl.md
@@ -2574,7 +2574,7 @@ This message sets the draw mask stored in *CSI_drawMask*.
 
 ----------
 
-####MSG_COLOR_SELECTOR_GET_PATTERN
+#### MSG_COLOR_SELECTOR_GET_PATTERN
     GraphicPattern MSG_COLOR_SELECTOR_GET_PATTERN();
 
 This message returns the pattern set in *CSI_pattern*.

--- a/TechDocs/Markdown/Objects/ogendoc.md
+++ b/TechDocs/Markdown/Objects/ogendoc.md
@@ -2770,7 +2770,7 @@ MSG_GEN_DOCUMENT_PHYSICAL_REVERT) if they wish to implement
 save-as/revert functionality. 
 
 ----------
-####MSG_GEN_DOCUMENT_PHYSICAL_REVERT
+#### MSG_GEN_DOCUMENT_PHYSICAL_REVERT
     Boolean MSG_GEN_DOCUMENT_PHYSICAL_REVERT(
             word *          error,
             FileHandle      file);

--- a/TechDocs/Markdown/Objects/ogenint.md
+++ b/TechDocs/Markdown/Objects/ogenint.md
@@ -456,7 +456,7 @@ made GS_USABLE.
 
 **Warnings:** Make sure that the object sent this message is not GS_USABLE.
 
-#### 7.2.2 Standard Interactions (Menus)
+### 7.2.2 Standard Interactions (Menus)
     ATTR_GEN_INTERACTION_GROUP_TYPE, GenInteractionGroupType
 
 Often you will set up standard menus such as the File menu, the Window 

--- a/TechDocs/Markdown/Objects/ogenvew.md
+++ b/TechDocs/Markdown/Objects/ogenvew.md
@@ -393,7 +393,7 @@ the Screen" in "VisClass," Chapter 23.
     }
 
 ----------
-### 9.3 Basic View Attributes
+## 9.3 Basic View Attributes
 
 The GenView has several instance data fields that it uses to maintain its 
 current status. It also has other attribute fields that determine its scrolling, 
@@ -945,7 +945,7 @@ This macro extracts the green component byte from the given dword.
 
 This macro extracts the blue component byte from the given dword.
 
-#### 9.3.4  The GVI_increment Attribute
+### 9.3.4  The GVI_increment Attribute
 GVI_increment, MSG_GEN_VIEW_GET_INCREMENT, 
 MSG_GEN_VIEW_SET_INCREMENT
 

--- a/TechDocs/Markdown/Objects/osyscla.md
+++ b/TechDocs/Markdown/Objects/osyscla.md
@@ -3019,7 +3019,7 @@ See description for this and other gained/lost exclusive messages below.
 
 ----------
 
-####MSG_META_GAINED_SYS_TARGET_EXCL
+#### MSG_META_GAINED_SYS_TARGET_EXCL
 
     @importMessage MetaUIMessages, void MSG_META_GAINED_SYS_TARGET_EXCL();
 
@@ -5202,7 +5202,7 @@ application exits, for custom mode cases. Superclass must be called.
 
 ----------
 
-####MSG_GEN_PROCESS_ATTACH_TO_PASSED_STATE_FILE
+#### MSG_GEN_PROCESS_ATTACH_TO_PASSED_STATE_FILE
 
     MemHandle   MSG_GEN_PROCESS_ATTACH_TO_STATE_FILE(
                 AppAttachFlags      attachFlags,

--- a/TechDocs/Markdown/Objects/otext.md
+++ b/TechDocs/Markdown/Objects/otext.md
@@ -3202,7 +3202,7 @@ This message retrieves the text object's **VisTextFeatures** (*VTI_features*).
 
 **Interception:** Generally not intercepted.
 
-#### 10.5.2 VisText States
+### 10.5.2 VisText States
     VTI_state, VisTextStates, MSG_VIS_TEXT_GET_STATE, 
     MSG_VIS_TEXT_GET_USER_MODIFIED_STATE, 
     MSG_VIS_TEXT_SET_NOT_USER_MODIFIED, 
@@ -3719,7 +3719,7 @@ in an upcoming release.
 
 **Interception:** Generally not intercepted.
 
-#### 10.5.6 Setting Text Confines
+### 10.5.6 Setting Text Confines
     MSG_VIS_TEXT_GET_MAX_LENGTH, MSG_VIS_TEXT_SET_MAX_LENGTH, 
     MSG_VIS_TEXT_GET_LR_MARGIN, MSG_VIS_TEXT_SET_LR_MARGIN, 
     MSG_VIS_TEXT_GET_TB_MARGIN, MSG_VIS_TEXT_SET_TB_MARGIN
@@ -3995,7 +3995,7 @@ This message is sent when the text object gains the focus of the application.
 **Interception:** Intercept to receive notification of when the text object gains the focus.
 
 ----------
-#### ###MSG_META_TEXT_LOST_TARGET
+#### SG_META_TEXT_LOST_TARGET
     @importMessage MetaTextMessages, void MSG_META_TEXT_LOST_TARGET(
                 optr        obj);
 
@@ -4654,7 +4654,7 @@ affect the stored text.
 **Interception:** Generally not intercepted.
 
 ----------
-####MSG_GEN_TEXT_SET_MODIFIED_STATE
+#### MSG_GEN_TEXT_SET_MODIFIED_STATE
     void    MSG_GEN_TEXT_SET_MODIFIED_STATE(
             Boolean modifiedState);
 
@@ -4692,7 +4692,7 @@ indeterminate, *false* otherwise).
 **Interception:** Generally not intercepted.
 
 ----------
-####MSG_GEN_TEXT_IS_MODIFIED
+#### MSG_GEN_TEXT_IS_MODIFIED
     Boolean MSG_GEN_TEXT_IS_MODIFIED();
 
 This message checks whether a GenText object has been modified.
@@ -5632,7 +5632,7 @@ controllers and were described earlier.) These messages common to both
 controllers are listed and described here.
 
 ----------
-####MSG_REPLACE_CURRENT
+#### MSG_REPLACE_CURRENT
     @importMessage MetaSearchSpellMessages, void MSG_REPLACE_CURRENT(
                 MemHandle       replaceInfo);
 

--- a/TechDocs/Markdown/Objects/ovis.md
+++ b/TechDocs/Markdown/Objects/ovis.md
@@ -3878,7 +3878,7 @@ VUM_MANUAL is not allowed.
 
 **Interception:** Generally not intercepted.
 
-#### 23.5.3 Getting Visible Tree Information
+### 23.5.3 Getting Visible Tree Information
     MSG_VIS_FIND_CHILD, MSG_VIS_FIND_CHILD_AT_POSITION, 
     MSG_VIS_COUNT_CHILDREN, MSG_VIS_FIND_PARENT
 
@@ -4755,7 +4755,7 @@ object and then drag-scroll too far. To prevent this from happening, the
 visible object must call MSG_VIS_VUP_SET_MOUSE_INTERACTION_BOUNDS 
 to set a temporary boundary on drag scrolling.
 
-### 23.7 VisClass Error Checking
+## 23.7 VisClass Error Checking
     MSG_VIS_VUP_EC_ENSURE_WINDOW_NOT_REFERENCED, 
     MSG_VIS_VUP_EC_ENSURE_OBJ_BLOCK_NOT_REFERENCED, 
     MSG_VIS_VUP_EC_ENSURE_OD_NOT_REFERENCED

--- a/TechDocs/Markdown/Routines/rgoc.md
+++ b/TechDocs/Markdown/Routines/rgoc.md
@@ -1,7 +1,7 @@
 # 1 Goc Keywords
 
 ----------
-#### @alias
+### @alias
     @alias(<protoMsg>) <messageDef>;
 
 The @alias keyword is used for messages which take conditional parameters in 
@@ -21,7 +21,7 @@ definition as would follow the @message keyword.
 **See Also:** @message
 
 ----------
-#### @call
+### @call
     <ret> = @call [,<flags>] [{<cast_ret>}] \
     <obj>::[{<cast_par>}]<msg>(<param>*);
 
@@ -122,7 +122,7 @@ keyword rather than @call.
 **See Also:** @send, @callsuper, @message, @method, @object
 
 ----------
-#### @callsuper
+### @callsuper
     <ret> = @callsuper [{<cast_ret>}] \
     <obj>::<class>::[{<cast_par>}]<msg>(<param>*) [<flags>]+;
 
@@ -158,7 +158,7 @@ superclass.
 **See Also:** @call, @send, @message, @method
 
 ----------
-#### @chunk
+### @chunk
     @chunk  <type> <name> [= <init>];
 
 The @chunk keyword declares a resource chunk containing data of some kind. 
@@ -192,7 +192,7 @@ declare it in the other file with @extern. Objects are declared with @object.
 **See Also:** @start, @end, @object, @extern
 
 ----------
-#### @chunkArray
+### @chunkArray
     @chunkArray     <stype> <aname> [= {<init>}];
 
 The @chunkArray keyword declares a Chunk Array, a special kind of chunk. Only 
@@ -217,7 +217,7 @@ no elements.
 **See Also:** @chunk, @elementArray
 
 ----------
-#### @class
+### @class
     @class  <cname>, <super> [, master [, variant]];
 
 The @class keyword begins a class definition. All instance data and messages 
@@ -241,7 +241,7 @@ are listed below:
 **See Also:** @endc, @classdecl
 
 ----------
-#### @classdecl
+### @classdecl
     @classdecl <cname> [, neverSaved];
 
 The @classdecl keyword defines a given class structure in memory. Every new 
@@ -259,7 +259,7 @@ saved along with state information.
 **See Also:** @class
 
 ----------
-#### @composite
+### @composite
     @instance @composite <iname> = <linkFieldName>;
 
 The @composite keyword appears as a subcommand of @instance. It is a type 
@@ -279,7 +279,7 @@ of its children. The arguments of the @composite keyword are given below:
 **See Also:** @instance, @link
 
 ----------
-#### @default
+### @default
     <fname> = @default [<op> [~]<attr>]*; /* to use default value of
                                             instance data field */
 
@@ -339,7 +339,7 @@ the following arguments:
 **See Also:** @object, @instance, @class
 
 ----------
-#### @define
+### @define
     @define <mname>[(<pdef>)] <macro>
 
 The @define directive defines a Goc macro. You can define C macros with the 
@@ -368,7 +368,7 @@ the macro.
     @chunk char[] Text2 = "newText";
 
 ----------
-#### @deflib
+### @deflib
     @deflib <libName>
 
 Most Goc libraries will have a **.goh** header file. This file should begin with a 
@@ -385,7 +385,7 @@ stripped off. For example, if the library's header file is
 **See Also:** @endlib
 
 ----------
-#### @dispatch
+### @dispatch
     @dispatch [noFree] [{<cast>}] <nObj>::<nMsg>::<event>;
 
 The @dispatch keyword sends a previously-encapsulated message to the 
@@ -415,7 +415,7 @@ value. If no override is desired, specify this as null.
 **See Also:** @record, @send, @dispatchcall
 
 ----------
-#### @dispatchcall
+### @dispatchcall
     <ret> = @dispatchcall [noFree] [{<cast>}] <nObj>::<nMsg>::<event>;
 
 The @dispatchcall keyword sends a previously-encapsulated message to the 
@@ -447,7 +447,7 @@ value. If no override is desired, specify this as null.
 **See Also:** @record, @send, @dispatchcall
 
 ----------
-#### @elementArray
+### @elementArray
     @elementArray   <stype> <aname> [= {<init>}];
 
 The @elementArray keyword declares an Element Array, a special kind of Chunk Array. 
@@ -465,7 +465,7 @@ no elements.
 **See Also:** @chunk, @chunkArray
 
 ----------
-#### @end
+### @end
     @end    <segname>
 
 The @end keyword denotes the end of a resource block definition that had been 
@@ -477,7 +477,7 @@ started with @start. Its one argument is the name of the resource segment.
 **See Also:** @start, @header, @object, @chunk
 
 ----------
-#### @endc
+### @endc
     @endc
 
 The @endc keyword denotes the end of a class definition begun with @class. It 
@@ -486,7 +486,7 @@ has no arguments.
 **See Also:** @class
 
 ----------
-#### @endif
+### @endif
     @endif
 
 The @endif directive denotes the end of a block of conditionally-compiled code. 
@@ -495,7 +495,7 @@ It is used with @if, @ifdef, and @ifndef.
 **See Also:** @if, @ifdef, @ifndef
 
 ----------
-#### @endlib
+### @endlib
     @endlib
 
 Most Goc libraries will have a .goh header file. This file should end with an 
@@ -505,7 +505,7 @@ than once in a given compilation. The file must begin with an @deflib directive.
 **See Also:** @deflib
 
 ----------
-#### @exportMessages
+### @exportMessages
     @exportMessages <expname>, <num>;
 
 The @exportMessages keyword sets aside a number of message spots so the 
@@ -524,7 +524,7 @@ messages are declared with the @importMessage keyword. The arguments of
 **See Also:** - @importMessage, @reserveMessages, @message
 
 ----------
-#### @extern
+### @extern
     @extern <type> <name>;
     @extern method <cname>, <manme>+
 
@@ -603,7 +603,7 @@ possible if you will be using @**call**, passing arguments, or what have you):
 **See Also:** @chunk, @object, @visMoniker
 
 ----------
-#### gcnList
+### gcnList
     gcnList(<manufID>,<lname>) = <oname> [, <oname>]*;
 
 The gcnList keyword, which does not have the keyword marker @ preceeding 
@@ -628,7 +628,7 @@ Separate objects with commas.
 **See Also:** @object
 
 ----------
-#### @genChildren
+### @genChildren
     @send @genChildren::<msg>(<params>);
 
 Any composite object in a generic object tree (therefore a subclass of 
@@ -638,7 +638,7 @@ must be dispatched with the @**send** keyword and therefore can have no return
 value and can not pass pointers in its parameters.
 
 ----------
-#### @genParent
+### @genParent
     [@send | @call]@genParent::<msg>(<params>);
 
 Any composite object in a generic object tree (therefore a subclass of 
@@ -646,7 +646,7 @@ GenClass) can use the @genParent address to send a message to its **generic**
 parent. This can be used with either @send or @call.
 
 ----------
-#### @gstring
+### @gstring
     @gstring <gsname> = {[<command> [, <command>]+]}
 
 The @gstring keyword lets you declare a GString in Goc source code.
@@ -656,7 +656,7 @@ The @gstring keyword lets you declare a GString in Goc source code.
 *command* - This may be any command which could be put in a GString.
 
 ----------
-#### @header
+### @header
     @header <type> [= <init>];
 
 The @header keyword sets the header of an object or data resource segment to 
@@ -679,7 +679,7 @@ ObjLMemBlockHeader. The arguments of @header are given below:
 **See Also:** @start, @end, @object, @chunk
 
 ----------
-#### @if
+### @if
     @if (<cond>)
 
 The @if directive denotes the beginning of a conditionally-compiled block of 
@@ -707,7 +707,7 @@ macros, and Boolean operators (|| and &&).
 **See Also:** @ifdef, @ifndef, @endif
 
 ----------
-#### @ifdef
+### @ifdef
     @ifdef <item>
 
 The @ifdef directive is similar to the @if directive in use, except the condition 
@@ -717,7 +717,7 @@ defined, the following code is compiled).
 **See Also:** @if, @ifndef, @endif
 
 ----------
-#### @ifndef
+### @ifndef
     @ifndef <item>
 
 The @ifndef directive is similar to the @ifdef directive in use, except the 
@@ -727,7 +727,7 @@ not defined, the following code is compiled).
 **See Also:** @if, @ifdef, @endif
 
 ----------
-#### @importMessage
+### @importMessage
     @importMessage <expname>, <messageDef>;
 
 The @importMessage keyword declares a message with a reserved message 
@@ -745,7 +745,7 @@ the @message keyword for message declaration.
 **See Also:** @exportMessages, @reserveMessages, @message
 
 ----------
-#### @include
+### @include
     @include <fname>
 
 The @include directive is used to include Goc files into a code file. It is similar 
@@ -759,7 +759,7 @@ will look first in the standard include directories.
     @include "Art/mkrGenDoc"
 
 ----------
-#### @instance
+### @instance
     @instance <insType> <iname> = <default>;
 
 The @instance keyword declares an instance data field for a class. This 
@@ -817,7 +817,7 @@ should use the @vardata keyword rather than @instance.
 **See Also:** @vardata, @visMoniker, @link, @composite, @kbdAccelerator
 
 ----------
-#### @kbdAccelerator
+### @kbdAccelerator
     @instance @kbdAccelerator <iname>;
 
 The @kbdAccelerator keyword follows @instance to create an instance data 
@@ -829,7 +829,7 @@ of the instance data field.
 **See Also:** @instance
 
 ----------
-#### @link
+### @link
     @instance @link <iname>;
 
 The @link keyword follows @instance to define a link instance data field 
@@ -843,7 +843,7 @@ field must be set as the default value of the corresponding @composite field.
 **See Also:** @instance, @composite
 
 ----------
-#### @message
+### @message
     @message    <retType> <mname>([@stack] <param>*);
 
 The @message keyword defines a message and its parameters and return 
@@ -878,7 +878,7 @@ the parameter of that type.
 **See Also:** @method, @reserveMessages, @exportMessages, @importMessage, @record
 
 ----------
-#### @method
+### @method
     @method [<hname>,] <cname>, <mname>+ [{<code>}];
 
 The @method keyword begins definition of a method (message handler). Its 
@@ -911,7 +911,7 @@ should be used as the method.
 **See Also:** - @message
 
 ----------
-#### @noreloc
+### @noreloc
     @noreloc <iname>;
 
 The @noreloc keyword specifies that an instance data field (defined in the 
@@ -921,7 +921,7 @@ when shutting down and coming back from a shutdown; by means of the
 @noreloc, this automatic behavior can be turned off for a given field.
 
 ----------
-#### @object
+### @object
     @object <class> <name> <flags>* = {
         [<fieldName> = <init>;]*
         [<varName> [= <init>];]*
@@ -978,7 +978,7 @@ field will be set to its default value as defined by the class.
 **See Also:** @start, @end, @extern, @class, @instance, @vardata
 
 ----------
-#### @optimize
+### @optimize
     @optimize
 
 This directive may be placed at the top of a **.goh** file. The directive instructs 
@@ -988,7 +988,7 @@ automatically regenerated if the corresponding **.goh** file has been changed
 since the last compilation.
 
 ----------
-#### @protominor
+### @protominor
     @protominor <prototypeName>
 
 When creating a new version of an existing library, use the @**protominor** 
@@ -1017,7 +1017,7 @@ To do the equivalent version control with routines, use the **incminor** .gp fil
 directive.
 
 ----------
-#### @prototype
+### @prototype
     @prototype <messageDef>;
 
 The @prototype keyword allows multiple messages to have the same pass and 
@@ -1035,7 +1035,7 @@ message definition.
 **See Also:** @alias, @message
 
 ----------
-#### @record
+### @record
     <event> = @record <obj>::<msg>(<param>*);
 
 The @record keyword encapsulates an event for later use with @dispatch or 
@@ -1060,7 +1060,7 @@ when it is dispatched.
 **See Also:** @dispatch, @dispatchcall, @call, @send
 
 ----------
-#### @reloc
+### @reloc
     @reloc  <iname>, [(<count>, <struct>)] <ptrType>;
     @reloc  <iname>, <fn>, [(<count>, <struct>)] <ptrType>;
 
@@ -1098,7 +1098,7 @@ field, then put a zero (0) rather than a field name.
 **See Also:** @instance, @vardata
 
 ----------
-#### _reloc
+### _reloc
     @method [<hname>,] <cname>, _reloc { <code>};
 
 The _reloc keyword is used to write relocation handlers for classes, if you need 
@@ -1111,7 +1111,7 @@ state, in which case instance data may need to be relocated or
 unrelocated by hand.    
 
 ----------
-#### @reserveMessages
+### @reserveMessages
     @reserveMessages <number>;
 
 The @reserveMessages keyword reserves the given number of message spots. 
@@ -1125,7 +1125,7 @@ versions obsolete. The single argument is the number of message spots to skip.
 **See Also:** @exportMessages, @importMessage, @message
 
 ----------
-#### @send
+### @send
     @send   [<flags>+] [(<cast_ret>)] <obj>::[{<cast_par>}]<msg>(<param>*);
 
 The @send keyword sends a given message to the specified object. The message 
@@ -1200,7 +1200,7 @@ immediately.
 **See Also:** @call, @callsuper, @message, @method
 
 ----------
-#### @specificUI
+### @specificUI
     <fname> = [@specificUI] <mod>* <key>;
 
 The @specificUI keyword is used when setting a keyboard accelerator instance 
@@ -1223,7 +1223,7 @@ keyboard key or a letter enclosed in single quotation marks.
 **See Also:** GenClass, @kbdAccelerator, @instance
 
 ----------
-#### @stack
+### @stack
     @message    <retType> <mname>([@stack] <param>*);
 
 This keyword may be used if the message might be sent from assembly 
@@ -1234,7 +1234,7 @@ they are listed in the declaration.
 **See Also:** @message
 
 ----------
-#### @start
+### @start
     @start  <segname> [, <flags>];
 
 The @start keyword indicates the beginning of a resource block. The end of the 
@@ -1257,7 +1257,7 @@ to a state file.
 **See Also:** @end, @header, @object, @chunk
 
 ----------
-#### @uses
+### @uses
     @uses <class>;
 
 If you know that a variant class will always be resolved to be a subclass of some 
@@ -1274,7 +1274,7 @@ such that the used class is one of its ancestor classes.
 **See Also:** @class
 
 ----------
-#### @vardata
+### @vardata
     @vardata    <type> <vname>;
 
 The @vardata keyword creates a vardata data type for a class. Each type 
@@ -1300,7 +1300,7 @@ place of a type.
 **See Also:** @vardataAlias, @instance
 
 ----------
-#### @vardataAlias
+### @vardataAlias
     @vardataAlias (<origName>) <newType> <newName>;
 
 The @vardataAlias keyword allows you to set up variable data fields with 
@@ -1331,7 +1331,7 @@ the word void instead of a type.
 **See Also:** @vardata, @instance
 
 ----------
-#### @visChildren
+### @visChildren
     @send @visChildren::<msg>(<params>);
 
 Any composite object in a visible object tree (therefore a subclass of 
@@ -1341,7 +1341,7 @@ must be dispatched with the @**send** keyword and therefore can have no return
 value.
 
 ----------
-#### @visParent
+### @visParent
     @send @visParent::<msg>(<params>);
 
 Any object in a visible tree can use @**visParent** as the destination of an @call 
@@ -1349,7 +1349,7 @@ command. The message will be sent to the object's parent in the visible object
 tree. The remainder of the command is the same as a normal @**call**.
 
 ----------
-#### @visMoniker
+### @visMoniker
     @instance @visMoniker <iname>;
 
 The @visMoniker keyword follows @instance to create an instance data field 

--- a/TechDocs/Markdown/Routines/rgp.md
+++ b/TechDocs/Markdown/Routines/rgp.md
@@ -1,7 +1,7 @@
 # 2 Parameters File Keywords
 
 ----------
-#### appobj
+### appobj
     appobj  <name>
 
 The **appobj** field indicates the name of the application object. All geodes with 
@@ -10,7 +10,7 @@ argument should be the name of the object of **GenApplicationClass** specified
 in the application's **.goc** file.
 
 ----------
-#### class
+### class
     class   <name>
 
 The **class** field specifies the name of the object class to be bound to the geode's 
@@ -21,7 +21,7 @@ of this connection). Note that this class binding will only be for the geode's f
 (primary) thread.
 
 ----------
-#### driver
+### driver
     driver  <name> [noload]
 
 This field specifies another driver that is used by this geode. The *noload* flag 
@@ -32,7 +32,7 @@ that access serial and parallel ports - those geodes will include the serial or
 parallel driver.)
 
 ----------
-#### entry
+### entry
     entry   <name>
 
 This field is used by library geodes. The *name* argument is the name of the 
@@ -40,7 +40,7 @@ library routine to be called by the kernel when the library is loaded or unloade
 and when a program using the library is loaded or unloaded.
 
 ----------
-#### exempt
+### exempt
     exempt  <library-name>
 
 If you wish to exempt a certain library from Glue's platform checking, call it 
@@ -49,7 +49,7 @@ the library not normally available with platforms named in your **platform**
 statement.
 
 ----------
-#### export
+### export
     export  <name> [as <name2>]
 
 This field identifies routines usable by geodes other than the one being 
@@ -64,7 +64,7 @@ This field is also used to export classes defined in a **.goc** or **.goh** file
 World for an example of this usage.
 
 ----------
-#### incminor
+### incminor
     incminor [<name>]
 
 The **incminor** directive is used at the end of a library's **.gp** file before new 
@@ -84,7 +84,7 @@ the protominor label should be associated with the revision represented by the
 **incminor** directive.
 
 ----------
-#### library
+### library
     library <name> [noload]
 
 This field specifies another library that is used by this geode. The *noload* flag 
@@ -101,7 +101,7 @@ included in the **.gp** file. Most will also have the following line:
 Any number of used libraries may be specified.
 
 ----------
-#### load
+### load
     load    <name> ["<class>"] as [<name2>] [<align>] [<combine>]\ ["<class2>"]
 
 The **load** field is used when you want to alter the way a segment is linked for 
@@ -159,7 +159,7 @@ Examples:
     load _NAME_ "CODE" as DATASEG para common "DATA"
 
 ----------
-#### longname
+### longname
     longname "<string>"
 
 The **longname** field designates a 32-character name for the geode. This name 
@@ -167,7 +167,7 @@ will be displayed with the geode's icon by GeoManager; all geodes should be
 given a long name.
 
 ----------
-#### name
+### name
     name    <pname>.<ext>
 
 The **name** field in the parameters file gives the geode a permanent name which 
@@ -180,7 +180,7 @@ When Glue is linking an error-checking geode, it drops the fourth character of
 *ext* and adds "ec" to the end of *pname*.
 
 ----------
-#### nosort
+### nosort
     nosort
 
 This keyword should appear before the list of resources. Normally glue will sort 
@@ -191,7 +191,7 @@ geode order their resources in the same way. If you won't generate .GYM files,
 you probably don't want to use this option.
 
 ----------
-#### platform
+### platform
     platform <name>
 
 The platform directive specifies that the Geode is compatible with the named 
@@ -216,7 +216,7 @@ If the new routine happens to be a "published" routine, glue will copy it into t
 geode in an effort to avoid the error.
 
 ----------
-#### publish
+### publish
     publish <name>
 
 Normally, If a geode is required to run (via platform specifications) with a 
@@ -251,7 +251,7 @@ output by glue:
     APPRESOURCE                         416     1
 
 ----------
-#### resource
+### resource
     resource <name> (read-only|preload|discardable|fixed|conforming|shared|\
              code|data|lmem|discard-only|swap-only|ui-object|object|\
              no-swap|no-discard)+
@@ -337,7 +337,7 @@ listed below:
     resource <name> code
 
 ----------
-#### stack
+### stack
     stack   <number>
 
 The **stack** field designates the size of the application's stack in bytes. The 
@@ -347,7 +347,7 @@ smaller stack size for example only). The **stack** field is valid only for geod
 with a process aspect.
 
 ----------
-#### tokenchars
+### tokenchars
     tokenchars "<string>"
 
 This is one of two fields that identifies a unique token in GeoManager's token 
@@ -356,7 +356,7 @@ four characters that identifies the geode's token. Note that these characters
 also appear in the geode file's extended attributes.
 
 ----------
-#### tokenid
+### tokenid
     tokenid <number>
 
 This is the other of two fields that identifies a unique token in GeoManager's 
@@ -365,7 +365,7 @@ corresponding to the programmer's manufacturer ID number. Note that this
 number also appears in the geode file's extended attributes.
 
 ----------
-#### type
+### type
     type    (process|driver|appl|library)+ [single] [system] [uses-coproc]\
             [needs-coproc] [has-gcm] [c-api]
 
@@ -410,7 +410,7 @@ to locate all GCM applications.
 so the kernel must call them with C calling conventions.
 
 ----------
-#### usernotes
+### usernotes
     usernotes "<string>"
 
 This field specifies text to be put in the **.geo** file's usernotes field. The text must 

--- a/TechDocs/Markdown/Routines/rrouta_d.md
+++ b/TechDocs/Markdown/Routines/rrouta_d.md
@@ -8,7 +8,7 @@ following chapter.
 ## 3.1 Routines A-D
 
 ----------
-#### ArrayQuickSort()
+### ArrayQuickSort()
     void    ArrayQuickSort(
             void    *array,     /* Pointer to start of array */
             word    count,      /* Number of elements in array */
@@ -68,14 +68,14 @@ chunks or allocate other chunks in the same LMem heap.
 **See Also:** QuickSortParameters, ChunkArraySort()
 
 ----------
-#### BlockFromTransferBlockID
+### BlockFromTransferBlockID
     VMBlockHandle BlockFromTransferBlockID(id);
             TransferBlockID     id;
 
 This macro extracts the VMBlockHandle from a **TransferBlockID**.
 
 ----------
-#### BlockIDFromFileAndBlock
+### BlockIDFromFileAndBlock
     TransferBlockID BlockIDFromFileAndBlock(file, block);
             VMFileHandle    file;
             VMBlockHandle   block;
@@ -84,7 +84,7 @@ This macro creates the dword type **TransferBlockID** from a VMFileHandle
 and a VMBlockHandle.
 
 ----------
-#### bsearch()
+### bsearch()
     extern void *_pascal bsearch(
             const void      *key, 
             const void      *array,
@@ -96,7 +96,7 @@ This is a standard binary search routine. The callback routine must be
 declared _pascal.
 
 ----------
-#### calloc()
+### calloc()
     void *  calloc(
             word        n,          /* number of structures to allocate */
             size_t      size);      /* size of each structure in bytes */
@@ -129,7 +129,7 @@ smaller than 64K.
 **See Also:** malloc(), free(), GeoMalloc(), realloc()
 
 ----------
-#### CCB()
+### CCB()
     #define CCB(return_type, pointer_name, args) \
             return_type _cdecl (*pointer_name) args
 
@@ -146,7 +146,7 @@ which would be expanded to
 **See Also:** PCB()
 
 ----------
-#### CellDeref()
+### CellDeref()
     void *  CellDeref(
             optr    CellRef);
 
@@ -154,7 +154,7 @@ This routine translates an optr to a cell into the cell's address. The routine i
 simply a synonym for **LMemDeref()**.
 
 ----------
-#### CellDirty()  
+### CellDirty()  
     void    CellDirty(
             void *      ptr);   /* pointer to anywhere in locked cell */
 
@@ -171,7 +171,7 @@ in the cell. This is useful if you have incremented the pointer to the cell.
 **See Also:** Section 19.4.2.2 of the Concepts book
 
 ----------
-#### CellGetDBItem()
+### CellGetDBItem()
     DBGroupAndItem  CellGetDBItem(
             CellFunctionParameters *    cfp,
             word    row,        /* Get handles of cell in this row */
@@ -190,7 +190,7 @@ change it in any way.
 **See Also:** DBGroupAndItem, Section 19.4.2.2 of the Concepts book
 
 ----------
-#### CellGetExtent()
+### CellGetExtent()
     void    CellGetExtent(
             CellFunctionParameters *    cfp, 
             RangeEnumParams *   rep); /* write boundaries in REP_bounds field */
@@ -210,7 +210,7 @@ to -1.
 **See Also:** Section 19.4.2.2 of the Concepts book
 
 ----------
-#### CellLock()
+### CellLock()
     void *  CellLock(
             CellFunctionParameters*     cfp,
             word        row,        /* Lock cell in this row... */
@@ -225,7 +225,7 @@ pointer to it.
 **See Also:** CellLockGetRef(), Section 19.4.2.2 of the Concepts book
 
 ----------
-#### CellLockGetRef()
+### CellLockGetRef()
     void *  CellLockGetRef(
             CellFunctionParameters*     cfp,
             word        row,        /* Lock cell in this row... */
@@ -245,7 +245,7 @@ translate the optr structure into a pointer by passing it to **CellDeref()**.
 **See Also:** CellGetDBItem(). CellLock(), Section 19.4.2.2 of the Concepts book
 
 ----------
-#### CellReplace()
+### CellReplace()
     void    CellReplace{
             CellFunctionParameters *    cfp,
             word            row,        /* Insert/replace cell at this row... */
@@ -273,7 +273,7 @@ item block will not have its lock count decremented, which will prevent the
 block from being unlocked.
 
 ----------
-#### CellUnlock()
+### CellUnlock()
     void    CellUnlock(
             void *  ptr); /* pointer to anywhere in locked cell */
 
@@ -292,7 +292,7 @@ it. This is useful if you have incremented the pointer to the cell.
 **Be Sure To:** If you change the cell, dirty it (with CellDirty()) *before* you unlock it.
 
 ----------
-#### CFatalError()
+### CFatalError()
     void    CFatalError(
             word    code)
 
@@ -300,7 +300,7 @@ This routine generates a fatal error. It stores an error code passed for use by
 the debugger.
 
 ----------
-#### ChunkArrayAppend()
+### ChunkArrayAppend()
     void *  ChunkArrayAppend(
             optr    array,          /* optr to chunk array */
             word    elementSize)    /* Size of new element (ignored if 
@@ -325,7 +325,7 @@ invalidated.
 **See Also:** ChunkArrayInsertAt(), ChunkArrayDelete(), ChunkArrayResize()
 
 ----------
-#### ChunkArrayAppendHandles()
+### ChunkArrayAppendHandles()
     void *  ChunkArrayAppendHandles(
             MemHandle       mh,     /* Handle of LMem heap's block */
             ChunkHandle     ch,     /* Handle of chunk array */
@@ -346,7 +346,7 @@ invalidated.
 **See Also:** ChunkArrayInsertAt(), ChunkArrayDelete(), ChunkArrayResize()
 
 ----------
-#### ChunkArrayCreate()
+### ChunkArrayCreate()
     ChunkHandle  ChunkArrayCreate(
             MemHandle   mh,     /* Handle of LMem heap's block */
             word    elementSize,/* Size of each element (or zero if elements are
@@ -388,7 +388,7 @@ chunk, it can cause heap compaction or resizing; all pointers to within the
 block are invalidated.
 
 ----------
-#### ChunkArrayCreateAt()
+### ChunkArrayCreateAt()
     ChunkHandle     ChunkArrayCreateAt(
         optr    array,          /* Create chunk array in this chunk */
         word    elementSize,    /* Size of each element (or zero if elements are
@@ -407,7 +407,7 @@ heap.
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayCreateAtHandles()
+### ChunkArrayCreateAtHandles()
     ChunkHandle     ChunkArrayCreateAtHandles(
             MemHandle       mh,
             ChunkHandle     ch,
@@ -426,7 +426,7 @@ LMem heap.
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayDelete()
+### ChunkArrayDelete()
     void    ChunkArrayDelete(
             optr    array,      /* optr to chunk array */
             void *  element);   /* Address of element to delete */
@@ -452,7 +452,7 @@ address of an element in the array, results are undefined.
 ChunkArrayZero()
 
 ----------
-#### ChunkArrayDeleteHandle()
+### ChunkArrayDeleteHandle()
     void    ChunkArrayDeleteHandle(
             ChunkHandle     ch,     /* Handle of chunk array */
             void *          el);    /* Address of element to delete */
@@ -467,7 +467,7 @@ to the element.
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayDeleteRange()
+### ChunkArrayDeleteRange()
     void    ChunkArrayDeleteRange(
             optr    array,          /* optr to chunk array */
             word    firstElement,   /* index of first element to delete */
@@ -481,7 +481,7 @@ to cause heap compaction or resizing; thus, pointers to other elements in the
 array will remain valid.
 
 ----------
-#### ChunkArrayElementResize()
+### ChunkArrayElementResize()
     void    ChunkArrayElementResize(
             optr    array,      /* optr to chunk array */
             word    element,    /* Index of element to resize */
@@ -505,7 +505,7 @@ within the LMem heap will be invalidated.
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayElementResizeHandles()
+### ChunkArrayElementResizeHandles()
     void    ChunkArrayElementResizeHandles(
             Memhandle       mh,     /* Global handle of LMem heap */
             ChunkHandle     ch,     /* Chunk handle of chunk array */
@@ -525,7 +525,7 @@ thus, all pointers to within the LMem heap will be invalidated.
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayElementToPtr()
+### ChunkArrayElementToPtr()
     void *  ChunkArrayElementToPtr(
             optr        array,          /* optr to chunk array */
             word        elementNumber,  /* Element to get address of */
@@ -553,7 +553,7 @@ argument.
 CA_NULL_ELEMENT (i.e. 0xffff, or -1).
 
 ----------
-#### ChunkArrayElementToPtrHandles()
+### ChunkArrayElementToPtrHandles()
     void *  ChunkArrayElementToPtrHandles(
             Memhandle   mh,             /* Handle of LMem heap's block */
             ChunkHandle chunk,          /* Handle of chunk array */
@@ -577,7 +577,7 @@ fourth argument.
 CA_NULL_ELEMENT (i.e. 0xffff, or -1).
 
 ----------
-#### ChunkArrayEnum()
+### ChunkArrayEnum()
     Boolean ChunkArrayEnum(
             optr        array,      /* optr to chunk array */
             void*       enumData,   /* This is passed to callback routine */
@@ -606,7 +606,7 @@ declared _pascal.
 **Be Sure To:** Lock the LMem heap's block on the global heap (unless it is fixed).
 
 ----------
-#### ChunkArrayEnumHandles()
+### ChunkArrayEnumHandles()
     Boolean ChunkArrayEnumHandles(
             MemHandle       mh,         /* Handle of LMem heap's block */
             ChunkHandle     ch,         /* Handle of chunk array */
@@ -620,7 +620,7 @@ array is specified by its global and chunk handles (instead of with an optr).
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayEnumRange()
+### ChunkArrayEnumRange()
     Boolean     ChunkArrayEnumRange(
             optr    array,          /* optr to chunk array */
             word    startElement,   /* Start enumeration with this element */
@@ -646,7 +646,7 @@ passing a *count* of CA_LAST_ELEMENT.
 **See Also:** ChunkArrayEnum()
 
 ----------
-#### ChunkArrayEnumRangeHandles()
+### ChunkArrayEnumRangeHandles()
     Boolean     ChunkArrayEnumRangeHandles(
             MemHandle   mh,         /* Handle of LMem heap's block */
             ChunkHandle ch,         /* Handle of chunk array */
@@ -661,7 +661,7 @@ chunk array is specified by its global and chunk handles (instead of with an
 optr).
 
 ----------
-#### ChunkArrayGetCount()
+### ChunkArrayGetCount()
     word    ChunkArrayGetCount(
             optr    array);             /* optr of chunk array */
 
@@ -679,7 +679,7 @@ of elements in the chunk array.
 **See Also:** ChunkArrayHeader
 
 ----------
-#### ChunkArrayGetCountHandles()
+### ChunkArrayGetCountHandles()
     word    ChunkArrayGetCountHandles(
             MemHandle       mh,     /* Handle of LMem heap's block */
             ChunkHandle     ch);    /* Handle of chunk array */
@@ -690,7 +690,7 @@ array is specified by its global and local handles (instead of with an optr).
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayGetElement()
+### ChunkArrayGetElement()
     void    ChunkArrayGetElement(
             optr    array,          /* optr to chunk array */
             word    elementNumber,  /* Index of element to copy */
@@ -708,7 +708,7 @@ the buffer is large enough to hold the element.
 **See Also:** ChunkArrayPtrToElement(), ChunkArrayElementToPtr()
 
 ----------
-#### ChunkArrayGetElementHandles()
+### ChunkArrayGetElementHandles()
     void    ChunkArrayGetElementHandles(
             Memhandle       mh,             /* Handle of LMem heap's block */
             ChunkHandle     array,          /* Handle of chunk array */
@@ -726,7 +726,7 @@ the buffer is large enough to hold the element.
 **See Also:** ChunkArrayPtrToElement(), ChunkArrayElementToPtr()
 
 ----------
-#### ChunkArrayInsertAt()
+### ChunkArrayInsertAt()
     void *  ChunkArrayInsertAt(
             optr    array,          /* Handle of chunk array */
             void *  insertPointer,  /* Address at which to insert
@@ -757,7 +757,7 @@ resizing; all pointers within the block are invalidated.
 **See Also:** ChunkArrayAppend(), ChunkArrayDelete(), ChunkArrayResize()
 
 ----------
-#### ChunkArrayInsertAtHandle()
+### ChunkArrayInsertAtHandle()
     void *  ChunkArrayInsertAtHandle(
             ChunkHandle chunk,          /* Handle of chunk array */
             void *      insertPointer,  /* Address at which to insert
@@ -772,7 +772,7 @@ pointer passed.)
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayPtrToElement()
+### ChunkArrayPtrToElement()
     word    ChunkArrayPtrToElement(
             optr    array,      /* Handle of chunk array */
             void *  element);   /* Address of element */
@@ -793,7 +793,7 @@ results are unpredictable.
 **See Also:** ChunkArrayElementToPtr()
 
 ----------
-#### ChunkArrayPtrToElementHandle()
+### ChunkArrayPtrToElementHandle()
     word    ChunkArrayPtrToElementHandle(
             ChunkHandle     array,      /* chunk handle of chunk array */
             void *          element);   /* Pointer to element to delete */
@@ -803,7 +803,7 @@ chunk array is indicated by its chunk handle. (The global block is implicit in
 the pointer passed.)
 
 ----------
-#### ChunkArraySort()
+### ChunkArraySort()
     void    ChunkArraySort(
             optr        array,              /* optr to chunk array */
             word        valueForCallback,   /* Passed to callback routine */
@@ -848,7 +848,7 @@ pointers to the array (such as allocate a new chunk or element).
 **See Also:** ArrayQuickSort()
 
 ----------
-#### ChunkArraySortHandles()
+### ChunkArraySortHandles()
     void    ChunkArraySortHandles(
             MemHandle       memHandle,          /* Handle of LMem heap's block */
             ChunkHandle     chunkHandle,        /* Handle chunk array */
@@ -862,7 +862,7 @@ array is specified by its global and chunk handles (instead of by an optr).
 **Include:** chunkarr.h
 
 ----------
-#### ChunkArrayZero()
+### ChunkArrayZero()
     void    ChunkArrayZero(
             optr    array);     /* optr to chunk array */
 
@@ -878,7 +878,7 @@ chunks remain valid.
 **See Also:** ChunkArrayDelete()
 
 ----------
-#### ChunkArrayZeroHandles()
+### ChunkArrayZeroHandles()
     void    ChunkArrayZeroHandles(
             MemHandle       mh      /* Global handle of LMem heap */
             ChunkHandle     ch);    /* Chunk handle of chunk array */
@@ -890,7 +890,7 @@ optr).
 **Include:** chunkarr.h
 
 ----------
-#### ClipboardAbortQuickTransfer()
+### ClipboardAbortQuickTransfer()
     void    ClipboardAbortQuickTransfer(void);
 
 This routine cancels a quick-transfer operation in progress. It is typically 
@@ -901,7 +901,7 @@ object or Process which initiated the quick-transfer.
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardAddToNotificationList()
+### ClipboardAddToNotificationList()
     void    ClipboardAddToNotificationList(
             optr    notificationOD);
 
@@ -916,7 +916,7 @@ object or the geode handle if the Process object should be registered.
 **See Also:** ClipboardRemoveFromNotificationList()
 
 ----------
-#### ClipboardClearQuickTransferNotification()
+### ClipboardClearQuickTransferNotification()
     void    ClipboardClearQuickTransferNotification(
             optr    notificationOD);
 
@@ -934,7 +934,7 @@ when detaching and possibly abort it if there is one.
 **See Also:** **clipbrd.goh**
 
 ----------
-#### ClipboardDoneWithItem()
+### ClipboardDoneWithItem()
     void    ClipboardDoneWithItem(
             TransferBlockID header);
 
@@ -945,7 +945,7 @@ had previously called **ClipboardQueryItem()**.
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardEndQuickTransfer()
+### ClipboardEndQuickTransfer()
     void    ClipboardEndQuickTransfer(
             ClipboardQuickNotifyFlags       flags);
 
@@ -967,7 +967,7 @@ the originator can then respond if necessary.
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardEnumItemFormats()
+### ClipboardEnumItemFormats()
     word    ClipboardEnumItemFormats(
             TransferBlockID         header,
             word                    maxNumFormats,
@@ -1002,7 +1002,7 @@ routine will also return the passed buffer filled with that number of
 **See Also:** ClipboardTestItemFormat()
 
 ----------
-#### ClipboardGetClipboardFile()
+### ClipboardGetClipboardFile()
     VMFileHandle ClipboardGetClipboardFile(void);
 
 This routine returns the VM file handle of the current default transfer VM 
@@ -1011,7 +1011,7 @@ file.
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardGetItemInfo()
+### ClipboardGetItemInfo()
     optr    ClipboardGetItemInfo(
             TransferBlockID header);
 
@@ -1022,7 +1022,7 @@ transfer item. Pass the transfer item's header returned by
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardGetNormalItemInfo()
+### ClipboardGetNormalItemInfo()
     TransferBlockID ClipboardGetNormalItemInfo(void);
 
 This routine returns information about the normal transfer item. It returns 
@@ -1036,7 +1036,7 @@ To extract the file handle from the return value, use the macro
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardGetQuickItemInfo()
+### ClipboardGetQuickItemInfo()
     TransferBlockID ClipboardGetQuickItemInfo(void);
 
 This routine returns information about the quick-transfer transfer item. It 
@@ -1050,7 +1050,7 @@ To extract the file handle from the return value, use the macro
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardGetQuickTransferStatus()
+### ClipboardGetQuickTransferStatus()
     Boolean ClipboardGetQuickTransferStatus(void);
 
 This routine returns true if a quick-transfer operation is in progress, false 
@@ -1060,7 +1060,7 @@ order to abort any quick-transfers originated by the caller.
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardGetUndoItemInfo()
+### ClipboardGetUndoItemInfo()
     TransferBlockID ClipboardGetUndoItemInfo(void);
 
 This routine returns information about the undo transfer item. It returns a 
@@ -1074,7 +1074,7 @@ To extract the file handle from the return value, use the macro
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardQueryItem()
+### ClipboardQueryItem()
     void    ClipboardQueryItem(
             ClipboardItemFlags      flags,
             ClipboardQueryArgs *    retValues);
@@ -1119,7 +1119,7 @@ VM file.
 **See Also:** ClipboardRequestItemFormat(), ClipboardDoneWithItem()
 
 ----------
-#### ClipboardRegisterItem()
+### ClipboardRegisterItem()
     Boolean ClipboardRegisterItem(
             TransferBlockID     header,
             ClipboardItemFlags  flags);
@@ -1147,7 +1147,7 @@ TIF_NORMAL) indicates the item is a normal clipboard item.
 **See Also:** ClipboardRequestItemFormat()
 
 ----------
-#### ClipboardRemoveFromNotificationList()
+### ClipboardRemoveFromNotificationList()
     Boolean ClipboardRemoveFromNotificationList(
             optr    notificationOD);
 
@@ -1165,7 +1165,7 @@ from the list.
 **See Also:** ClipboardAddToNotificationList()
 
 ----------
-#### ClipboardRequestItemFormat()
+### ClipboardRequestItemFormat()
     void    ClipboardRequestItemFormat(
             ClipboardItemFormatID       format,
             TransferBlockID             header,
@@ -1209,7 +1209,7 @@ zero.
 **See Also:** ClipboardRegisterItem(), ClipboardQueryItem()
 
 ----------
-#### ClipboardSetQuickTransferFeedback()
+### ClipboardSetQuickTransferFeedback()
     void    ClipboardSetQuickTransferFeedback(
             ClipboardQuickTransferFeedback      cursor,
             UIFunctionsActive                   buttonFlags);
@@ -1241,7 +1241,7 @@ operation" cursor.
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardStartQuickTransfer()
+### ClipboardStartQuickTransfer()
     Boolean ClipboardStartQuickTransfer(
             ClipboardQuickTransferFlags         flags,
             ClipboardQuickTransferFeedback      initialCursor,
@@ -1323,7 +1323,7 @@ flag will be *false*.
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardTestItemFormat()
+### ClipboardTestItemFormat()
     Boolean ClipboardTestItemFormat(
             TransferBlockID     header,
             ClipboardFormatID   format);
@@ -1348,7 +1348,7 @@ this parameter from its individual parts using the macro
 **Include:** clipbrd.goh
 
 ----------
-#### ClipboardUnregisterItem()
+### ClipboardUnregisterItem()
     void    ClipboardUnregisterItem(
             optr    owner);
 
@@ -1364,7 +1364,7 @@ previous state.
 **Include:** clipbrd.goh
 
 ----------
-#### ConstructOptr()
+### ConstructOptr()
     optr    ConstructOptr(
             Handle      han,
             ChunkHandle         ch);
@@ -1375,7 +1375,7 @@ MemHandle) and chunk handle.
 **See Also:** HandleToOptr(), OptrToHandle(), OptrToChunk()
 
 ----------
-#### DBAlloc()
+### DBAlloc()
     DBItem  DBAlloc(
             VMFileHandle    file,
             DBGroup         group,
@@ -1392,7 +1392,7 @@ new item's item-handle.
 **See Also:** DBAllocUngrouped()
 
 ----------
-#### DBAllocUngrouped()
+### DBAllocUngrouped()
     DBGroupAndItem  DBAllocUngrouped(
             VMFileHandle    file,           
             word            size);
@@ -1408,7 +1408,7 @@ handle of the file which will contain the new item. It returns the item's
 **See Also:** DBAlloc()
 
 ----------
-#### DBCombineGroupAndItem()
+### DBCombineGroupAndItem()
     DBGroupAndItem  DBCombineGroupAndItem(
             DBGroup     group,
             DBItem      item);
@@ -1421,7 +1421,7 @@ This macro combines group and item handles into a dword-sized
 **See Also:** DBGroupFromGroupAndItem(), DBItemFromGroupAndItem()
 
 ----------
-#### DBCopyDBItem()
+### DBCopyDBItem()
     DBItem  DBCopyDBItem(
             VMFileHandle    srcFile,
             DBGroup         srcGroup,
@@ -1441,7 +1441,7 @@ a copy of the DB item and returns its **DBItem** handle.
 **See Also:** VMCopyVMChain()
 
 ----------
-#### DBCopyDBItemUngrouped()
+### DBCopyDBItemUngrouped()
     DBGroupAndItem  DBCopyDBItemUngrouped(
             VMFileHandle        srcFile, 
             DBGroupAndItem      srcID,      /* source item */
@@ -1462,7 +1462,7 @@ handles into a **DBGroupAndItem** value by calling the macro
 **See Also:** VMCopyVMChain()
 
 ----------
-#### DBDeleteAt()
+### DBDeleteAt()
     void    DBDeleteAt(
             VMFileHandle    file,
             DBGroup         group,
@@ -1479,7 +1479,7 @@ within the item, starting with the byte at the specified offset.
 **Include:** dbase.h
 
 ----------
-#### DBDeleteAtUngrouped()
+### DBDeleteAtUngrouped()
     void    DBDeleteAtUngrouped(
             VMFileHandle        file,
             DBGroupAndItem      id,
@@ -1493,7 +1493,7 @@ does not invalidate pointers to other items.
 **Include:** dbase.h
 
 ----------
-#### DBDeref()
+### DBDeref()
     void *  DBDeref(
             optr        *ref);
 
@@ -1505,7 +1505,7 @@ address of the item.
 **Include:** dbase.h
 
 ----------
-#### DBDirty()
+### DBDirty()
     void    DBUnlock(
             const void *        ptr);
 
@@ -1521,7 +1521,7 @@ in the item. This is useful if you have incremented the pointer to the item.
 **Include:** dbase.h
 
 ----------
-#### DBFree()
+### DBFree()
     void    DBFree(
             VMFileHandle    file,
             DBGroup         group,
@@ -1540,7 +1540,7 @@ properly unlocked.
 **See Also:** DBFreeUngrouped()
 
 ----------
-#### DBFreeUngrouped()
+### DBFreeUngrouped()
     void    DBFreeUngrouped(
             VMFileHandle        file,
             DBGroupAndItem      id);
@@ -1558,7 +1558,7 @@ block from ever being properly unlocked.
 **See Also:** DBFree()
 
 ----------
-#### DBGetMap()
+### DBGetMap()
     DBGroupAndItem  DBGetmap(
             VMFileHandle        file);
 
@@ -1570,7 +1570,7 @@ map item. If there is no map item, it returns a null handle.
 **See Also:** DBSetMap(), DBLockMap()
 
 ----------
-#### DBGroupAlloc()
+### DBGroupAlloc()
     DBGroup DBGroupAlloc(
             VMFileHandle        file);
 
@@ -1581,7 +1581,7 @@ handle.
 **Include:** dbase.h
 
 ----------
-#### DBGroupFree()
+### DBGroupFree()
     void    DBGroupFree(
             VMFileHandle        file,
             DBGroup     group);
@@ -1594,7 +1594,7 @@ those locked items will also be freed.
 **Include:** dbase.h
 
 ----------
-#### DBGroupFromGroupAndItem()
+### DBGroupFromGroupAndItem()
     DBGroup DBGroupFromGroupAndItem(
             DBGroupAndItem      id);
 
@@ -1603,7 +1603,7 @@ This macro returns the **DBGroup** portion of a **DBGroupAndItem** value.
 **Include:** dbase.h
 
 ----------
-#### DBInsertAt()
+### DBInsertAt()
     void    DBInsertAt(
             VMFileHandle    file,
             DBGroup         group,
@@ -1623,7 +1623,7 @@ inserted bytes.
 **Include:** dbase.h
 
 ----------
-#### DBInsertAtUngrouped()
+### DBInsertAtUngrouped()
     void    DBInsertAtUngrouped(
             VMFileHandle        file,
             DBGroupAndItem      id,
@@ -1638,7 +1638,7 @@ This routine is just like **DBInsertAt()**, except it is passed a
 **Include:** dbase.h
 
 ----------
-#### DBItemFromGroupAndItem()
+### DBItemFromGroupAndItem()
     DBItem  DBItemFromGroupAndItem(
             DBGroupAndItem      id);
 
@@ -1647,7 +1647,7 @@ This macro returns the **DBItem** portion of a **DBGroupAndItem** value.
 **Include:** dbase.h
 
 ----------
-#### DBLock()
+### DBLock()
     void *  DBLock(
             VMFileHandle    file,
             DBGroup         group,
@@ -1662,7 +1662,7 @@ null pointer.
 **See Also:** DBLockGetRef(), DBLockUngrouped()
 
 ----------
-#### DBLockGetRef()
+### DBLockGetRef()
     void *  DBLockGetRef(
             VMFileHandle    file,
             DBGroup         group,
@@ -1677,7 +1677,7 @@ passed address.
 **Warnings:** The optr is only valid until the DB item is unlocked.
 
 ----------
-#### DBLockGetRefUngrouped()
+### DBLockGetRefUngrouped()
     void *  DBLockGetRefUngrouped(
             VMFileHandle        file,
             DBGroupAndItem      id,
@@ -1689,7 +1689,7 @@ This routine is the same as **DBLockGetRef()**, except that it is passed a
 **Include:** dbase.h
 
 ----------
-#### DBLockMap()
+### DBLockMap()
     void *  DBLockMap(
             VMFileHandle        file);
 
@@ -1701,7 +1701,7 @@ unlock the map item, call **DBUnlock()** normally.
 **See Also:** DBUnlock()
 
 ----------
-#### DBLockUngrouped()
+### DBLockUngrouped()
     void *  DBLockUngrouped(
             VMFileHandle        file,
             DBGroupAndItem      id);
@@ -1712,7 +1712,7 @@ This routine is the same as **DBLock()**, except that it is passed a
 **Include:** dbase.h
 
 ----------
-#### DBReAlloc()
+### DBReAlloc()
     void    DBReAlloc(
             VMFileHandle    file,
             DBGroup         group,
@@ -1730,7 +1730,7 @@ invalidated. Space added is not zero-initialized.
 **Include:** dbase.h
 
 ----------
-#### DBReAllocUngrouped()
+### DBReAllocUngrouped()
     void    DBReAllocUngrouped(
             VMFileHandle        file,
             DBGroupAndItem      id,
@@ -1745,7 +1745,7 @@ invalidated. Space added is not zero-initialized.
 **Include:** dbase.h
 
 ----------
-#### DBSetMap()
+### DBSetMap()
     void    DBSetMap(
             VMFileHandle    file,
             DBGroup         group,
@@ -1759,7 +1759,7 @@ map item; it does not return anything.
 **Include:** dbase.h
 
 ----------
-#### DBSetMapUngrouped()
+### DBSetMapUngrouped()
     void    DBSetMapUngrouped(
             VMFileHandle        file,
             DBGroupAndItem      id);
@@ -1770,7 +1770,7 @@ This routine is just like **DBSetMap()**, except it is passed a
 **Include:** dbase.h
 
 ----------
-#### DBUnlock()
+### DBUnlock()
     void    DBUnlock(
             void *  ptr); /* address of item to unlock */
 
@@ -1785,7 +1785,7 @@ unlock it.
 **Include:** dbase.h
 
 ----------
-#### DiskCheckInUse()
+### DiskCheckInUse()
     Boolean DiskCheckInUse(
             DiskHandle      disk);
 
@@ -1801,7 +1801,7 @@ in use).
 **Include:** disk.h
 
 ----------
-#### DiskCheckUnnamed()
+### DiskCheckUnnamed()
     Boolean DiskCheckUnnamed(   /* returns true if disk is unnamed */
             DiskHandle      disk);
 
@@ -1819,7 +1819,7 @@ about the disk containing the main **geos.ini** file.
 **Include:** disk.h
 
 ----------
-#### DiskCheckWritable()
+### DiskCheckWritable()
     Boolean DiskCheckWritable(
             DiskHandle      disk);
 
@@ -1833,7 +1833,7 @@ about the disk containing the main **geos.ini** file.
 **Include:** disk.h
 
 ----------
-#### DiskCopy()
+### DiskCopy()
     DiskCopyError   DiskCopy(
             word        source,
             word        dest,
@@ -1937,7 +1937,7 @@ ERR_CANT_FORMAT_DEST
 **Include:** disk.h
 
 ----------
-#### DiskFind()
+### DiskFind()
     DiskHandle  DiskFind(
             const char *        fname,  /* Null-terminated volume name */
             DiskFindResult *    code);  /* DiskFindResult written here */
@@ -1971,7 +1971,7 @@ disk handle was returned.
 **Include:** disk.h
 
 ----------
-#### DiskForEach()
+### DiskForEach()
     DiskHandle  DiskForEach(
             Boolean _pascal (* callback) (DiskHandle disk))
 
@@ -1991,7 +1991,7 @@ routine simply returns *true*, and **DiskForEach()** returns the disk's handle.
 **Include:** disk.h
 
 ----------
-#### DiskFormat()
+### DiskFormat()
     FormatError     DiskFormat(
             word        driveNumber,
             MediaType   media,      /* Format to this size */
@@ -2064,7 +2064,7 @@ constants:
 **Include:** disk.h
 
 ----------
-#### DiskGetDrive()
+### DiskGetDrive()
     word    DiskGetDrive(
             DiskHandle      dh);
 
@@ -2080,7 +2080,7 @@ about the disk containing the main **geos.ini** file.
 **Include:** disk.h
 
 ----------
-#### DiskGetVolumeFreeSpace()
+### DiskGetVolumeFreeSpace()
     dword   DiskGetVolumeFreeSpace( 
             DiskHandle      dh);
 
@@ -2098,7 +2098,7 @@ about the disk containing the main **geos.ini** file.
 **Include:** disk.h
 
 ----------
-#### DiskGetVolumeInfo()
+### DiskGetVolumeInfo()
     word    DiskGetVolumeInfo(  /* Returns 0 if successful */
             DiskHandle      dh,
             DiskInfoStruct  *info);     /* Routine fills this structure */
@@ -2136,7 +2136,7 @@ about the disk containing the main **geos.ini** file.
 **Include:** disk.h
 
 ----------
-#### DiskGetVolumeName()
+### DiskGetVolumeName()
     void    DiskGetVolumeName(
             DiskHandle  dh,
             char *      buffer);    /* Must be VOLUME_NAME_LENGTH_ZT bytes
@@ -2156,7 +2156,7 @@ about the disk containing the main **geos.ini** file.
 **See Also:** DiskGetVolumeInfo(), DiskSetVolumeName()
 
 ----------
-#### DiskRegisterDisk()
+### DiskRegisterDisk()
     DiskHandle  DiskRegisterDisk(
                 word    driveNumber); 
 This routine registers a disk in the specified drive and assigns it a disk 
@@ -2180,7 +2180,7 @@ want to get the disk handle for the disk in a specific drive, you can simply cal
 **Include:** disk.h
 
 ----------
-#### DiskRegisterDiskSilently()
+### DiskRegisterDiskSilently()
     DiskHandle  DiskRegisterDiskSilently(
                 word        driveNumber);
 
@@ -2193,7 +2193,7 @@ temporary name to the disk, it will not present an alert box to the user.
 **Include:** disk.h
 
 ----------
-#### DiskRestore()
+### DiskRestore()
     DiskHandle  DiskRestore(
             void *      buffer,         /* buffer written by DiskSave() */
             DiskRestoreError _pascal (*callback)    
@@ -2272,7 +2272,7 @@ The appropriate drive is busy with a time-consuming operation
 **Include:** disk.h
 
 ----------
-#### DiskSave()
+### DiskSave()
     Boolean DiskSave(
             DiskHandle  disk,
             void *      buffer,         /* data will be written here */
@@ -2295,7 +2295,7 @@ other reason, it will return false and set **bufferSize* to zero.
 **Include:** disk.h
 
 ----------
-#### DiskSetVolumeName()
+### DiskSetVolumeName()
     word    DiskSetVolumeName(
             DiskHandle      dh,
             const char *    name);      /* Change the name to this */
@@ -2318,7 +2318,7 @@ only happens with network drives.
 **Include:** disk.h
 
 ----------
-#### DosExec()
+### DosExec()
     word    DosExec(
             const char *        prog,
             DiskHandle          progDisk,
@@ -2365,7 +2365,7 @@ ERROR_ARGS_TOO_LONG.
 **Include:** system.h
 
 ----------
-#### DriveGetDefaultMedia()
+### DriveGetDefaultMedia()
     MediaType   DriveGetDefaultMedia(
                 word        driveNumber);
 
@@ -2381,7 +2381,7 @@ default media type of MEDIA_1M44, but it can read from, write to, and format
 **Include:** drive.h
 
 ----------
-#### DriveGetExtStatus()
+### DriveGetExtStatus()
     word    DriveGetExtStatus(
             word        driveNumber);
 
@@ -2410,7 +2410,7 @@ If an error condition exists, **DriveGetExtStatus()** returns zero.
 **Include:** drive.h
 
 ----------
-#### DriveGetName()
+### DriveGetName()
     char *  DriveGetName(
             word    driveNumber,    /* Get name of this drive */
             char *  buffer,         /* Write name to this buffer */
@@ -2425,7 +2425,7 @@ not exist, or the buffer is too small, **DriveGetName()** returns a null pointer
 **Include:** drive.h
 
 ----------
-#### DriveGetStatus()
+### DriveGetStatus()
     word    DriveGetStatus(
             word    driveNumber);
 
@@ -2452,7 +2452,7 @@ If an error condition exists, **DriveGetStatus()** returns zero.
 **Include:** drive.h
 
 ----------
-#### DriveTestMediaSupport()
+### DriveTestMediaSupport()
     Boolean DriveTestMediaSupport(
             word        DriveNumber,            
             MediaType   media);         /* Desired disk size */

--- a/TechDocs/Markdown/Routines/rroute_f.md
+++ b/TechDocs/Markdown/Routines/rroute_f.md
@@ -1,6 +1,6 @@
 ## 3.2 Routines E-F
 ----------
-#### EC()
+### EC()
     void    EC(line);
 
 This macro defines a line of code that will only be compiled into the 
@@ -10,7 +10,7 @@ will be treated as a normal line of code; when the non-EC version is compiled,
 the line will be ignored.
 
 ----------
-#### EC_BOUNDS()
+### EC_BOUNDS()
     void    EC_BOUNDS(addr);
 
 This macro adds an address check to the error-checking version of a program. 
@@ -25,7 +25,7 @@ to **FatalError()**.
 **See Also:** ECCheckBounds()
 
 ----------
-#### EC_ERROR()
+### EC_ERROR()
     void    EC_ERROR(code);
 
 This macro inserts a call to **FatalError()** in the error-checking version of the 
@@ -35,7 +35,7 @@ specified error *code*. If a condition should be checked before calling
 **FatalError()**, you can use EC_ERROR_IF() instead.
 
 ----------
-#### EC_ERROR_IF()
+### EC_ERROR_IF()
     void    EC_ERROR_IF(test, code);
 
 This macro inserts a conditional call to **FatalError()** in the error-checking 
@@ -44,7 +44,7 @@ parameter is a Boolean value that, if *true*, will cause the **FatalError()** ca
 to be made. If test is *false*, **FatalError()** will not be called.
 
 ----------
-#### EC_WARNING()
+### EC_WARNING()
     EC_WARNING(word warningCode);
 
 This macro generates a warning for the debugger when executed by 
@@ -53,7 +53,7 @@ error-checking code; it has no effect when in non-EC code.
 **Include:** ec.h
 
 ----------
-#### EC_WARNING_IF()
+### EC_WARNING_IF()
     EC_WARNING_IF(<expr>, word warningCode)
 
 When this macro is executed in error-checking code, it tests <*expr*>; if  <*expr*> 
@@ -64,7 +64,7 @@ In non-EC code, the macro has no effect (and <*expr*> is not evaluated).
 **Include:** ec.h
 
 ----------
-#### ECCheckBounds()
+### ECCheckBounds()
     void    ECCheckBounds(
             void    *address);
 
@@ -74,7 +74,7 @@ into which it points. If assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckChunkArray()
+### ECCheckChunkArray()
     void    ECCheckChunkArray(
             optr    o);
 
@@ -84,7 +84,7 @@ fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckChunkArrayHandles()
+### ECCheckChunkArrayHandles()
     void    ECCheckChunkArrayHandles(
             MemHandle mh,
             ChunkHandle ch);
@@ -95,7 +95,7 @@ fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckClass()
+### ECCheckClass()
     void    ECCheckClass(
             ClassStruct *class);
 
@@ -105,7 +105,7 @@ definition. If the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckDriverHandle()
+### ECCheckDriverHandle()
     void    ECCheckDriverHandle(
             GeodeHandle gh);
 
@@ -115,7 +115,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckEventHandle()
+### ECCheckEventHandle()
     void    ECCheckEventHandle(
             EventHandle eh);
 
@@ -125,7 +125,7 @@ message. If the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckFileHandle()
+### ECCheckFileHandle()
     void    ECCheckFileHandle(
             FileHandle file);
 
@@ -135,7 +135,7 @@ references a file. If the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckGeodeHandle()
+### ECCheckGeodeHandle()
     void    ECCheckGeodeHandle(
             GeodeHandle gh);
 
@@ -145,7 +145,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckGStateHandle()
+### ECCheckGStateHandle()
     void    ECCheckGStateHandle(
             GStateHandle gsh);
 
@@ -155,7 +155,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckHugeArray()
+### ECCheckHugeArray()
     void    ECCheckHugeArray(
             VMFileHandle        vmFile,
             VMBlockHandle       vmBlock);
@@ -166,7 +166,7 @@ is not the directory block of a Huge Array, the routine fails.
 **Include:** ec.h
 
 ----------
-#### ECCheckLibraryHandle()
+### ECCheckLibraryHandle()
     void    ECCheckLibraryHandle(
             GeodeHandle gh);
 
@@ -176,7 +176,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckLMemChunk()
+### ECCheckLMemChunk()
     void    ECCheckLMemChunk(
             void * chunkPtr);
 
@@ -186,7 +186,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckLMemHandle()
+### ECCheckLMemHandle()
     void    ECCheckLMemHandle(
             MemHandle mh);
 
@@ -196,7 +196,7 @@ references a local memory block. If the assertions fail, a fatal error will occu
 **Include:** ec.h
 
 ----------
-#### ECCheckLMemHandleNS()
+### ECCheckLMemHandleNS()
     void    ECCheckLMemHandleNS(
             MemHandle mh);
 
@@ -208,7 +208,7 @@ fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckLMemObject()
+### ECCheckLMemObject()
     void    ECCheckLMemObject(
             optr    obj);
 
@@ -218,7 +218,7 @@ stored in an object block. If the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckLMemObjectHandles()
+### ECCheckLMemObjectHandles()
     void    ECCheckLMemObjectHandles(
             MemHandle mh,
             ChunkHandle ch);
@@ -229,7 +229,7 @@ stored in an object block. If the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckLMemOD()
+### ECCheckLMemOD()
     void    ECCheckLMemOD(
             optr    o);
 
@@ -239,7 +239,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckLMemODHandles()
+### ECCheckLMemODHandles()
     void    ECCheckLMemODHandles(
             MemHandle objHan,
             ChunkHandle objCh);
@@ -250,7 +250,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckMemHandle()
+### ECCheckMemHandle()
     void    ECCheckMemHandle(
             MemHandle mh);
 
@@ -260,7 +260,7 @@ references a memory block. If the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckMemHandleNS()
+### ECCheckMemHandleNS()
     void    ECCheckMemHandleNS(
             MemHandle mh);
 
@@ -272,7 +272,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckObject()
+### ECCheckObject()
     void    ECCheckObject(
             optr    obj);
 
@@ -282,7 +282,7 @@ fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckObjectHandles()
+### ECCheckObjectHandles()
     void    ECCheckObjectHandles(
             Memhandle mh,
             ChunkHandle ch);
@@ -291,7 +291,7 @@ This routine checks the validity of the given locked object. If the assertions
 fail, a fatal error will occur.
 
 ----------
-#### ECCheckOD()
+### ECCheckOD()
     void    ECCheckOD(
             optr    obj);
 
@@ -300,7 +300,7 @@ This routine checks the validity of the given object. Unlike
 specified. If assertions fail, a fatal error will occur.
 
 ----------
-#### ECCheckODHandles()
+### ECCheckODHandles()
     void    ECCheckODHandles(
             MemHandle objHan,
             ChunkHandle objCh);
@@ -312,7 +312,7 @@ specified. If assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckProcessHandle()
+### ECCheckProcessHandle()
     void    ECCheckProcessHandle(
             GeodeHandle gh);
 
@@ -322,7 +322,7 @@ the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckQueueHandle()
+### ECCheckQueueHandle()
     void    ECCheckQueueHandle(
             QueueHandle qh);
 
@@ -332,7 +332,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckResourceHandle()
+### ECCheckResourceHandle()
     void    ECCheckResourceHandle(
             MemHandle mh);
 
@@ -342,7 +342,7 @@ the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckStack()
+### ECCheckStack()
     void    ECCheckStack();
 
 This routine checks to make sure the current stack has not overflown (and is 
@@ -352,7 +352,7 @@ bottom and the stack pointer. If assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckThreadHandle()
+### ECCheckThreadHandle()
     void    ECCheckThreadHandle(
             ThreadHandle th);
 
@@ -362,7 +362,7 @@ the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECCheckWindowHandle()
+### ECCheckWindowHandle()
     void    ECCheckWindowHandle(
             WindowHandle wh);
 
@@ -372,7 +372,7 @@ the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECLMemExists()
+### ECLMemExists()
     void    ECLMemExists(
             optr    o);
 
@@ -383,7 +383,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECLMemExistsHandles()
+### ECLMemExistsHandles()
     void    ECLMemExistsHandles(
             MemHandle mh,
             ChunkHandle ch);
@@ -395,7 +395,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECLMemValidateHandle()
+### ECLMemValidateHandle()
     void    ECLMemValidateHandle(
             optr    o);
 
@@ -405,7 +405,7 @@ the assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECLMemValidateHandleHandles()
+### ECLMemValidateHandleHandles()
     void    ECLMemValidateHandleHandles(
             MemHandle mh,
             ChunkHandle ch);
@@ -416,7 +416,7 @@ reference a local memory chunk. If the assertions fail, a fatal error will occur
 **Include:** ec.h
 
 ----------
-#### ECLMemValidateHeap()
+### ECLMemValidateHeap()
     void    ECLMemValidateHeap(
             MemHandle mh);
 
@@ -426,7 +426,7 @@ internally and should not be needed by application programmers.
 **Include:** ec.h
 
 ----------
-#### ECMemVerifyHeap()
+### ECMemVerifyHeap()
     void    ECMemVerifyHeap()
 
 This routine makes sure the global heap is in a consistent state. If the 
@@ -436,7 +436,7 @@ by anything other than the EC kernel.
 **Include:** ec.h
 
 ----------
-#### ECVMCheckMemHandle()
+### ECVMCheckMemHandle()
     void    ECVMCheckMemHandle(
             MemHandle han);
 
@@ -446,7 +446,7 @@ block handle. If assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECVMCheckVMBlockHandle()
+### ECVMCheckVMBlockHandle()
     void    ECVMCheckVMBlockHandle(
             VMFileHandle file,
             VMBlockHandle block);
@@ -457,7 +457,7 @@ assertions fail, a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ECVMCheckVMFile()
+### ECVMCheckVMFile()
     void    ECVMCheckVMFile(
         VMFileHandle file);
 
@@ -467,7 +467,7 @@ a fatal error will occur.
 **Include:** ec.h
 
 ----------
-#### ElementArrayAddElement ()
+### ElementArrayAddElement ()
     word    ElementArrayAddElement(
             optr    arr,            /* Handle of element array */
             void *  element,        /* Element to add (if necessary) */
@@ -504,7 +504,7 @@ reference count by calling **ElementArrayAddReference()**.
 **See Also:** ElementArrayAddReference()
 
 ----------
-#### ElementArrayAddElementHandles()
+### ElementArrayAddElementHandles()
     word    ElementArrayAddElementHandles(
             MemHandle       mh,             /* Global handle of LMem heap */
             ChunkHandle     chunk           /* Chunk handle of element array */
@@ -527,7 +527,7 @@ reference count by calling **ElementArrayAddReferenceHandles()**.
 **See Also:** ElementArrayAddReferenceHandles()
 
 ----------
-#### ElementArrayAddReference()
+### ElementArrayAddReference()
     void    ElementArrayAddReference(
             optr    arr,        /* optr to element array */
             word    token);     /* Index number of element */
@@ -539,7 +539,7 @@ This routine increments the reference count of a member of an element array.
 **See Also:** ElementArrayAddElement()
 
 ----------
-#### ElementArrayAddReferenceHandles()
+### ElementArrayAddReferenceHandles()
     void    ElementArrayAddReferenceHandles(
             MemHandle       mh,         /* Handle of LMem heap's block */
             ChunkHandle     ch,         /* Handle of element array */
@@ -552,7 +552,7 @@ of with an optr).
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayCreate()
+### ElementArrayCreate()
     ChunkHandle ElementArrayCreate(
             MemHandle   mh,             /* Handle of LMem heap's block */
             word        elementSize,    /* Size of each element, or zero
@@ -586,7 +586,7 @@ fixed). If you pass a header size, make sure it is larger than
 **sizeof(ElementArrayHeader)**.
 
 ----------
-#### ElementArrayCreateAt
+### ElementArrayCreateAt
     ChunkHandle     ElementArrayCreateAt(
             optr    arr,            /* optr of chunk for array */
             word    elementSize,    /* Size of each element, or zero
@@ -603,7 +603,7 @@ will be overwritten.
 pointers to chunks in that block.
 
 ----------
-#### ElementArrayCreateAtHandles
+### ElementArrayCreateAtHandles
     ChunkHandle     ElementArrayCreateAtHandles(
             MemHandle   mh,             /* Handle of LMem heap */
             ChunkHandle ch              /* Create array in this chunk */
@@ -621,7 +621,7 @@ with an optr).
 pointers to chunks in that block.
 
 ----------
-#### ElementArrayDelete()
+### ElementArrayDelete()
     void    ElementArrayDelete(
             optr    arr,        /* optr to element array */
             word    token);     /* index of element to delete */
@@ -641,7 +641,7 @@ elements are preserved.
 **See Also:** ElementArrayRemoveReference()
 
 ----------
-#### ElementArrayDeleteHandles()
+### ElementArrayDeleteHandles()
     void    ElementArrayDeleteHandles(
             MemHandle   mh,         /* Handle of LMem heap */
             ChunkHandle ch,         /* Chunk handle of element array */
@@ -658,7 +658,7 @@ optr).
 **See Also:** ElementArrayRemoveReference()
 
 ----------
-#### ElementArrayElementChanged()
+### ElementArrayElementChanged()
     void    ElementArrayElementChanged(
             optr    arr,                /* optr to element array */
             word    token,              /* Index number of element */
@@ -687,7 +687,7 @@ do a bytewise comparison of the elements.
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayElementChangedHandles()
+### ElementArrayElementChangedHandles()
     void    ElementArrayElementChangedHandles(
             MemHandle       memHandle,      /* Handle of LMem heap's block */
             ChunkHandle     chunkHandle,    /* Chunk handle of element array */
@@ -706,7 +706,7 @@ except that the element array is specified by its global and chunk handles
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayGetUsedCount()
+### ElementArrayGetUsedCount()
     word    ElementArrayGetUsedCount(
             optr    arr,            /* optr to element array */
             dword   callbackData,           /* This is passed to callback routine */
@@ -729,7 +729,7 @@ pointer.
 **See Also:** ElementArrayTokenToUsedIndex(), ElementArrayUsedIndexToToken()
 
 ----------
-#### ElementArrayGetUsedCountHandles()
+### ElementArrayGetUsedCountHandles()
     void    ElementArrayGetUsedCountHandles(
             MemHandle   mh,             /* Handle of LMem heap's block */
             ChunkHandle ch,             /* Chunk handle of element array */
@@ -744,7 +744,7 @@ of with an optr).
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayRemoveReference()
+### ElementArrayRemoveReference()
     void    ElementArrayRemoveReference(
             optr    arr,            /* optr of element array */
             word    token,          /* Index of element to unreference */
@@ -771,7 +771,7 @@ elements are preserved.
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayRemoveReferenceHandles()
+### ElementArrayRemoveReferenceHandles()
     void    ElementArrayRemoveReferenceHandles(
             MemHandle   mh,             /* Handle of LMem heap */
             ChunkHandle ch,             /* Chunk handle of element array */
@@ -787,7 +787,7 @@ except that the element array is specified by its global and chunk handles
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayTokenToUsedIndex()
+### ElementArrayTokenToUsedIndex()
     word    ElementArrayTokenToUsedIndex(
             optr    arr,                /* Handle of element array */
             word    token,              /* Index of element to unreference */
@@ -807,7 +807,7 @@ passed, every used element will be counted.
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayTokenToUsedIndexHandles()
+### ElementArrayTokenToUsedIndexHandles()
     word    ElementArrayTokenToUsedIndexHandles(
             MemHandle   mh,             /* Handle of LMem heap */
             ChunkHandle ch,             /* Chunk handle of element array */
@@ -824,7 +824,7 @@ except that the element array is specified by its global and chunk handles
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayUsedIndexToToken()
+### ElementArrayUsedIndexToToken()
     word    ElementArrayUsedIndexToToken(
             optr    arr,                /* optr to element array */
             word    index,              /* Find token of element with this index */
@@ -848,7 +848,7 @@ returns CA_NULL_ELEMENT.
 **Include:** chunkarr.h
 
 ----------
-#### ElementArrayUsedIndexToTokenHandles()
+### ElementArrayUsedIndexToTokenHandles()
     word    ElementArrayUsedIndexToTokenHandles(
             MemHandle   mh,             /* Handle of LMem heap's block */
             ChunkHandle     ch,         /* Handle of element array */
@@ -864,7 +864,7 @@ except that the element array is specified by its global and chunk handles
 **Include:** chunkarr.h
 
 ----------
-#### EvalExpression()
+### EvalExpression()
     int EvalExpression(
             byte    * tokenBuffer,      /* Pointer to the parsed expression */
             byte    * scratchBuffer,    /* Pointer to the base of a scratch buffer
@@ -881,14 +881,14 @@ portion of the parse library and will be used only rarely by applications.
 **Include:** parse.h
 
 ----------
-#### FatalError()
+### FatalError()
     void    FatalError(
             word errorCode);
 
 This routine causes a fatal error, leaving *errorCode* for the debugger.
 
 ----------
-#### FileClose()
+### FileClose()
     word    FileClose( /* returns error */
             FileHandle  fh,             /* File to close */
             Boolean     noErrorFlag);   /* Set if app. can't handle
@@ -904,7 +904,7 @@ member of the **FileError** enumerated type. If the routine fails and
 **Include:** file.h
 
 ----------
-#### FileCommit()
+### FileCommit()
     word    FileCommit( /* returns error */
             FileHandle  fh,
             Boolean     noErrorFlag);   /* set if can't handle errors */
@@ -919,7 +919,7 @@ non-zero), the routine will fatal-error.
 **Include:** file.h
 
 ----------
-#### FileConstructFullPath()
+### FileConstructFullPath()
     DiskHandle  FileConstructFullPath(
             char        * * buffer,     /* Path string is written here */
             word        bufSize,        /* Length of buffer (in bytes) */
@@ -970,7 +970,7 @@ path string will begin with the drive's name and a colon.
 **Include:** file.h
 
 ----------
-#### FileCopy()
+### FileCopy()
     word    FileCopy( /* returns error */
             const char  * source,       /* Source path and file name */
             const char  * dest,         /* Destination path and file name */
@@ -1010,7 +1010,7 @@ There was not enough room on the destination disk.
 **Include:** file.h
 
 ----------
-#### FileCreate()
+### FileCreate()
     FileHandle  FileCreate( /* sets thread's error value */
             const char      * name,         /* relative to working directory */
             FileCreateFlags flags,          /* see below */
@@ -1107,7 +1107,7 @@ format, or vice versa.
 **Include:** file.h
 
 ----------
-#### FileCreateDir()
+### FileCreateDir()
     word    FileCreateDir( /* Returns error & sets thread's error value */
             const char * name);     /* Relative path of new directory */
 
@@ -1136,7 +1136,7 @@ The volume is write-protected.
 **Include:** file.h
 
 ----------
-#### FileCreateTempFile()
+### FileCreateTempFile()
     FileHandle FileCreateTempFile( /* Sets thread's error value */
             char        * dir,      /* directory, relative to working dir.;
                                      * file name replaces 14 trailing null
@@ -1161,7 +1161,7 @@ value to a member of the **FileError** enumerated type.
 **Include:** file.h
 
 ----------
-#### FileDelete()
+### FileDelete()
     word    FileDelete( /* returns error */
             const char  * name);   /* path relative to working directory */
 
@@ -1186,7 +1186,7 @@ Some geode has that file open.
 **Include:** file.h
 
 ----------
-#### FileDeleteDir()
+### FileDeleteDir()
     word    FileDeleteDir( /* Returns error & sets thread's error value */
             const char * name);   /* Relative path of directory to delete */
 
@@ -1221,7 +1221,7 @@ before it can be deleted.
 **Include:** file.h
 
 ----------
-#### FileDuplicateHandle()
+### FileDuplicateHandle()
     FileHandle FileDuplicateHandle( /* Sets thread's error value */
             FileHandle fh);
 
@@ -1234,7 +1234,7 @@ thread's error value.
 **Include:** file.h
 
 ----------
-#### FileEnum()
+### FileEnum()
     word    FileEnum( /* returns number of files returned */
             FileEnumParams  * params,       /* described below */
             MemHandle       * bufCreated,   /* FileEnum will allocate a return-
@@ -1496,7 +1496,7 @@ constant might nevertheless be SP_TOP.
 **Include:** fileEnum.h
 
 ----------
-#### FileEnumLocateAttr()
+### FileEnumLocateAttr()
     void *  FileEnumLocateAttr( /* returns NULL if attr not found */
             FileEnumCallbackData*   fecd,   /* Passed to callback routine */
             FileExtendedAttribute   attr,   /* Search for this attribute */
@@ -1513,7 +1513,7 @@ array, **FileEnumLocateAttr()** will return a null pointer.
 **Include:** fileEnum.h
 
 ----------
-#### FileEnumWildcard()
+### FileEnumWildcard()
     Boolean FileEnumWildcard(
             FileEnumCallbackData    * fecd,     /* Passed to callback routine */
             word                    frame);     /* Inherited stack frame */
@@ -1534,14 +1534,14 @@ Otherwise, it returns *false*.
 **Include:** fileEnum.h
 
 ----------
-#### FileFromTransferBlockID()
+### FileFromTransferBlockID()
     VMFileHandle     FileFromTransferBlockID(id);
             TransferBlockID id;
 
 This macro extracts a VMFileHandle from a value of type **TransferBlockID**.
 
 ----------
-#### FileGetAttributes()
+### FileGetAttributes()
     FileAttrs   FileGetAttributes( /* Sets thread's error value */
             const char * path);     /* file's path relative to current
                                      * working directory */
@@ -1556,7 +1556,7 @@ this routine sets the thread's error.
 **Include:** file.h
 
 ----------
-#### FileGetCurrentPath()
+### FileGetCurrentPath()
     DiskHandle FileGetCurrentPath(
             char *  buffer,         /* Path string is written here */
             word    bufferSize);    /* Size of buffer in bytes */
@@ -1570,7 +1570,7 @@ will be returned.
 **Include:** file.h
 
 ----------
-#### FileGetDateAndTime()
+### FileGetDateAndTime()
     FileDateAndTime     FileGetDateAndTime( /* sets thread's error value */
             FileHandle fh);
 
@@ -1584,7 +1584,7 @@ FEA_MODIFICATION. If unsuccessful, it sets the thread's error value.
 **Include:** file.h
 
 ----------
-#### FileGetDiskHandle()
+### FileGetDiskHandle()
     DiskHandle FileGetDiskHandle( /* sets thread's error value */
             FileHandle fh);
 
@@ -1594,7 +1594,7 @@ unsuccessful, it sets the thread's error value.
 **Include:** file.h
 
 ----------
-#### FileGetHandleExtAttributes()
+### FileGetHandleExtAttributes()
     word    FileGetHandleExtAttributes(
             FileHandle              fh,         /* open file's handle */
             FileExtendedAttribute   attr,       /* attribute to get */
@@ -1633,7 +1633,7 @@ FEA_MULTIPLE, and using a **FileExtAttrDesc** to describe the attribute.
 **Include:** file.h
 
 ----------
-#### FileGetPathExtAttributes()
+### FileGetPathExtAttributes()
     word    FileGetPathExtAttributes(
             const char              * path,     /* path relative to current
                                                  * working directory */
@@ -1672,7 +1672,7 @@ FEA_MULTIPLE, and using a **FileExtAttrDesc** to describe the attribute.
 **Include:** file.h
 
 ----------
-#### FileLockRecord()
+### FileLockRecord()
     word    FileLockRecord(     /* returns error */
             FileHandle      fh,
             dword           filePos,    /* lock starting at this position... */
@@ -1691,7 +1691,7 @@ applications use this mechanism, they have to make sure to call
 **See Also:** FileUnlockRecord(), HandleP()
 
 ----------
-#### FileMove()
+### FileMove()
     word    FileMove( /* Returns error */
             const char      * source,   /* source path and file name */
             const char      * dest,     /* destination path and file name */
@@ -1734,7 +1734,7 @@ There was not enough room on the destination disk.
 **Include:** file.h
 
 ----------
-#### FileOpen()
+### FileOpen()
     FileHandle FileOpen( /* sets thread's error value */
             const char          * name,     /* relative to working dir */
             FileAccessFlags     flags);     /* Permissions/exclusions */
@@ -1773,7 +1773,7 @@ write-protected volume.
 **Include:** file.h
 
 ----------
-#### FileParseStandardPath()
+### FileParseStandardPath()
     StandardPath FileParseStandardPath(
             DiskHandle      disk,
             const char      ** path);
@@ -1791,7 +1791,7 @@ be returned, and the pointer will not be changed.
 **Include:** file.h
 
 ----------
-#### FilePopDir()
+### FilePopDir()
     void    FilePopDir();
 
 **FilePopDir()** pops the top directory off the thread's directory stack and 
@@ -1802,7 +1802,7 @@ makes it the current working directory.
 **Include:** file.h
 
 ----------
-#### FilePos()
+### FilePos()
     dword   FilePos( /* Sets thread's error value */
             FileHandle      fh,
             dword           posOrOffset,
@@ -1835,7 +1835,7 @@ mode FILE_POS_RELATIVE and offset zero.
 **Include:** file.h
 
 ----------
-#### FilePushDir()
+### FilePushDir()
     void    FilePushDir();
 
 **FilePushDir()** pushes the current working directory onto the thread's 
@@ -1846,7 +1846,7 @@ directory stack. It does not change the current working directory.
 **Include:** file.h
 
 ----------
-#### FileRead()
+### FileRead()
     word    FileRead( /* sets thread's error value */
             FileHandle      fh,             /* handle of open file */
             void            * buf,          /* copy data to this buffer */
@@ -1870,7 +1870,7 @@ fatal-error if an error occurs (including an ERROR_SHORT_READ_WRITE).
 **Include:** file.h
 
 ----------
-#### FileRename()
+### FileRename()
     word    FileRename(
             const char * oldName,       /* Relative to working directory */
             const char * newName);      /* Name only, without path */
@@ -1901,7 +1901,7 @@ file, and the name was not an appropriate native name.
 **Include:** file.h
 
 ----------
-#### FileResolveStandardPath()
+### FileResolveStandardPath()
     DiskHandle FileResolveStandardPath(
             char        ** buffer,              /* Write path here; update pointer
                          * to point to end of path */
@@ -1931,7 +1931,7 @@ and return accordingly.
 **Include:** file.h
 
 ----------
-#### FileSetAttributes()
+### FileSetAttributes()
     word    FileSetAttributes( /* returns error value */
             const char  * path,     /* file's path relative to current
                                      * working directory */
@@ -1946,7 +1946,7 @@ attribute FEA_FILE_ATTR.
 **Include:** file.h
 
 ----------
-#### FileSetCurrentPath()
+### FileSetCurrentPath()
     DiskHandle FileSetCurrentPath(
             DiskHandle      disk,       /* May be a standard path constant */
             const char      * path);    /* path string, null-terminated */
@@ -1969,7 +1969,7 @@ current path; this may be a standard path constant. If
 **Include:** file.h
 
 ----------
-#### FileSetDateAndTime()
+### FileSetDateAndTime()
     word    FileSetDateAndTime( /* returns error */
             FileHandle          fh,             /* handle of open file */
             FileDateAndTime     dateAndTime);   /* new modification time */
@@ -1985,7 +1985,7 @@ the thread's error value.
 **Include:** file.h
 
 ----------
-#### FileSetHandleExtAttributes()
+### FileSetHandleExtAttributes()
     word    FileGetPathExtAttributes( /* returns error */
             FileHandle              fh,         /* handle of open file */
             FileExtendedAttribute   attr,       /* attribute to get */
@@ -2027,7 +2027,7 @@ FEA_MULTIPLE, and using a **FileExtAttrDesc** to describe the attribute.
 **Include:** file.h
 
 ----------
-#### FileSetPathExtAttributes()
+### FileSetPathExtAttributes()
     word    FileSetPathExtAttributes(
             const char              * path,     /* path relative to current
                                                  * working directory */
@@ -2071,7 +2071,7 @@ FEA_MULTIPLE, and using a **FileExtAttrDesc** to describe the attribute.
 **Include:** file.h
 
 ----------
-#### FileSetStandardPath()
+### FileSetStandardPath()
     void    FileSetStandardPath(
             StandardPath path);         /* StandardPath to set */
 
@@ -2081,7 +2081,7 @@ StandardPath directories. Pass a standard path.
 **Include:** file.h
 
 ----------
-#### FileSize()
+### FileSize()
     dword   FileSize(
             FileHandle fh);     /* handle of open file */
 
@@ -2090,7 +2090,7 @@ This routine returns the size of the open file specified.
 **Include:** file.h
 
 ----------
-#### FileTruncate()
+### FileTruncate()
     word    FileTruncate(
             FileHandle      fh,         /* handle of open file */
             dword           offset);    /* offset at which to truncate */
@@ -2101,7 +2101,7 @@ parameter can also be thought of as the desired file size.
 **Include:** file.h
 
 ----------
-#### FileUnlockRecord()
+### FileUnlockRecord()
     word    FileUnlockRecord( /* returns error */
             FileHandle      fh,             /* handle of open file
             dword       filePos,                /* Release lock that starts here */
@@ -2115,7 +2115,7 @@ previously placed with **FileLockRecord()**.
 **Include:** file.h
 
 ----------
-#### FileWrite()
+### FileWrite()
     word    FileWrite( /* sets thread's error value */
             FileHandle      fh,             /* handle of open file */
             const void      * buf,          /* Copy from here into file */
@@ -2141,7 +2141,7 @@ fatal-error if an error occurs.
 **Include:** file.h
 
 ----------
-#### FormatIDFromManufacturerAndType
+### FormatIDFromManufacturerAndType
     dword   FormatIDFromManufacturerAndType(mfr, type);
             ManufacturerIDs             mfr;
             ClipboardItemFormat             type;
@@ -2151,7 +2151,7 @@ combines them into a dword argument of the type
 **ClipboardItemFormatID**.
 
 ----------
-#### free()
+### free()
     void    free(
             void * blockPtr);       /* address of memory to free */
 
@@ -2179,7 +2179,7 @@ actions, including possibly erasing other memory or crashing the system.
 **See Also:** calloc(), malloc(), GeoFree(), realloc()
 
 ----------
-#### FractionOf()
+### FractionOf()
     word    FractionOf(
             WWFixedAsDWord      wwf);
 

--- a/TechDocs/Markdown/Routines/rroutg_g.md
+++ b/TechDocs/Markdown/Routines/rroutg_g.md
@@ -1,6 +1,6 @@
 ## 3.3 Routines G-G
 ----------
-#### GCNListAdd()
+### GCNListAdd()
     Boolean GCNListAdd(
             optr            OD,         /* optr to add to list */
             ManufacturerID  manufID,    /* manufacturer ID of list */
@@ -18,7 +18,7 @@ if it currently exists on that list.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListAddHandles()
+### GCNListAddHandles()
     Boolean GCNListAddHandles(
             MemHandle           mh,         /* handle of object to add */
             ChunkHandle         ch,         /* chunk of object to add */
@@ -31,7 +31,7 @@ memory and chunk handles of the object rather than a complete optr.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListAddToBlock()
+### GCNListAddToBlock()
     Boolean GCNListAddToBlock(
             optr            OD,         /* optr of list to add */
             ManufacturerID  manufID,    /* manufacturer ID of list */
@@ -54,7 +54,7 @@ pointers after calling this routine.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListCreateBlock()
+### GCNListCreateBlock()
     ChunkHandle GCNListCreateBlock(
             MemHandle mh);      /* handle of the locked LMem block */
 
@@ -65,7 +65,7 @@ the list should be created.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListDestroyBlock()
+### GCNListDestroyBlock()
     void    GCNListDestroyBlock(
             MemHandle       mh,             /* handle of locked block to
                                              * be destroyed */
@@ -78,7 +78,7 @@ the chunk handle of the chunk containing the list of lists.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListDestroyList()
+### GCNListDestroyList()
     void    GCNListDestroyList(
             optr    list);      /* optr of the GCN list to be destroyed */
 
@@ -87,7 +87,7 @@ This routine destroys the specified GCN list.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListRelocateBlock()
+### GCNListRelocateBlock()
     void    GCNListRelocateBlock(
             MemHandle       mh,             /* handle of locked LMem block
                                              * containing GCN lists */
@@ -104,7 +104,7 @@ dereference pointers after calling it.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListRemove()
+### GCNListRemove()
     Boolean GCNListRemove(
             optr            OD,         /* the optr to be removed */
             ManufacturerID  manufID,    /* manufacturer ID of the list */
@@ -121,7 +121,7 @@ could not be removed.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListRemoveFromBlock()
+### GCNListRemoveFromBlock()
     Boolean GCNListRemoveFromBlock(
             optr            OD,             /* optr of GCN list to remove */
             ManufacturerID  manufID,        /* manufacturer of list to remove */
@@ -136,7 +136,7 @@ therein.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListRemoveHandles()
+### GCNListRemoveHandles()
     Boolean GCNListRemoveHandles(
             MemHandle           mh,
             ChunkHandle         ch,
@@ -151,7 +151,7 @@ the object to be removed via handles rather than an optr.
 **See Also:** GCNListRemove()
 
 ----------
-#### GCNListSend()
+### GCNListSend()
     word    GCNListSend(
             ManufacturerID  manufID,            /* manufacturer of list */
             word            listType,           /* notification type */
@@ -185,7 +185,7 @@ sent out.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListSendToBlock()
+### GCNListSendToBlock()
     word    GCNListSendToBlock(
             ManufacturerID      manufID,    /* manufacturer id of list */
             word                listType,   /* notification type */
@@ -207,7 +207,7 @@ instance of the GCN list by specifying the appropriate list of lists in *mh* and
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListSendToList()
+### GCNListSendToList()
     void    GCNListSendToList(
             optr                list,       /* optr of GCN list */
             EventHandle         event,      /* event to send to list */
@@ -229,7 +229,7 @@ set, the event passed will be set as the list's status message.
 **See Also:** GCNListSend()
 
 ----------
-#### GCNListSendToListHandles()
+### GCNListSendToListHandles()
     void    GCNListSendToListHandles(
             MemHandle           mh,         /* handle of list's block */
             ChunkHandle         ch,         /* chunk of list */
@@ -246,7 +246,7 @@ handles.
 **Include:** gcnlist.goh
 
 ----------
-#### GCNListUnRelocateBlock()
+### GCNListUnRelocateBlock()
     Boolean GCNListUnRelocateBlock(
             MemHandle   mh,             /* handle of the locked lmem block
                                          * containing the list of lists */
@@ -266,7 +266,7 @@ saved to the state file normally.
 **Include:** gcnlist.goh
 
 ----------
-#### GenCopyChunk()
+### GenCopyChunk()
     word    GenCopyChunk(
             MemHandle       destBlock,  /* handle of locked LMem block into
                                          * which chunk will be copied */
@@ -290,7 +290,7 @@ dereference pointers after calling it.
 **Include:** genC.goh
 
 ----------
-#### GenFindObjectInTree()
+### GenFindObjectInTree()
     optr    GenFindObjectInTree(
             optr    startObject,    /* optr of object at which to start search */
             dword   childTable);    /* pointer to table of bytes, each indicating
@@ -309,7 +309,7 @@ byte of -1 indicates the end of the table. The object found will be returned.
 **Include:** genC.goh
 
 ----------
-#### GenInsertChild()
+### GenInsertChild()
     void    GenInsertChild(
             MemHandle       mh,                 /* handle of parent */
             ChunkHandle     chnk,               /* chunk of parent */
@@ -329,7 +329,7 @@ must dereference pointers after calling it.
 **Include:** genC.goh
 
 ----------
-#### GenProcessAction()
+### GenProcessAction()
     void    GenProcessAction(
             MemHandle       mh,     /* handle of object calling the routine */
             ChunkHandle     chnk,   /* chunk of object calling the routine */
@@ -352,7 +352,7 @@ must dereference pointers after calling it.
 **Include:** genC.goh
 
 ----------
-#### GenProcessGenAttrsAfterAction()
+### GenProcessGenAttrsAfterAction()
     void    GenProcessGenAttrsAfterAction(
             MemHandle       mh,     /* handle of object calling the routine */
             ChunkHandle     chnk);  /* chunk of object calling the routine */
@@ -367,7 +367,7 @@ must dereference pointers after calling it.
 **Include:** genC.goh
 
 ----------
-#### GenProcessGenAttrsBeforeAction()
+### GenProcessGenAttrsBeforeAction()
     void    GenProcessGenAttrsBeforeAction(
             MemHandle   mh,     /* handle of object calling the routine */
             ChunkHandle chnk);  /* chunk of object calling the routine */
@@ -382,7 +382,7 @@ must dereference pointers after calling it.
 **Include:** genC.goh
 
 ----------
-#### GenProcessUndoGetFile()
+### GenProcessUndoGetFile()
     VMFileHandle GenProcessUndoGetFile();
 
 This routine returns the handle of the file that holds the process' undo 
@@ -391,7 +391,7 @@ information.
 **Include:** Objects/gProcC.goh
 
 ----------
-#### GenProcessUndoCheckIfIgnoring()
+### GenProcessUndoCheckIfIgnoring()
     Boolean GenProcessUndoCheckIfIgnoring();
 
 This routine returns *true* if the process is currently ignoring actions.
@@ -399,7 +399,7 @@ This routine returns *true* if the process is currently ignoring actions.
 **Include:** Objects/gProcC.goh
 
 ----------
-#### GenRemoveDownwardLink()
+### GenRemoveDownwardLink()
     void    GenRemoveDownwardLink(
             MemHandle   mh,         /* handle of calling object */
             ChunkHandle chnk,       /* chunk of calling object */
@@ -417,7 +417,7 @@ must dereference pointers after calling it.
 **Include:** genC.goh
 
 ----------
-#### GenSetUpwardLink()
+### GenSetUpwardLink()
     void    GenSetUpwardLink(
             MemHandle       mh,         /* handle of calling object */
             ChunkHandle     chnk,       /* chunk of calling object */
@@ -430,7 +430,7 @@ parent composite.
 **Include:** genC.goh
 
 ----------
-#### GeodeAllocQueue()
+### GeodeAllocQueue()
     QueueHandle GeodeAllocQueue();
 
 This routine allocates an event queue which can then be attached to a thread 
@@ -444,7 +444,7 @@ kernel only in exceptional circumstances.
 **Include:** geode.h
 
 ----------
-#### GeodeDuplicateResource()
+### GeodeDuplicateResource()
     MemHandle GeodeDuplicateResource(
             MemHandle mh);      /* handle of geode resource to duplicate */
 
@@ -456,7 +456,7 @@ returned.
 **Include:** resource.h
 
 ----------
-#### GeodeFind()
+### GeodeFind()
     GeodeHandle GeodeFind(
             const char  * name,         /* geode's permanent name */
             word        numChars,       /* number of characters to match:
@@ -484,7 +484,7 @@ for a positive match.
 **Include:** geode.h
 
 ----------
-#### GeodeFindResource()
+### GeodeFindResource()
     word    GeodeFindResource(
             FileHandle  file,           /* geode's executable file */
             word        resNum,         /* resource number to find */
@@ -520,7 +520,7 @@ first byte of the resource.
 **Include:** geode.h
 
 ----------
-#### GeodeFlushQueue()
+### GeodeFlushQueue()
     void    GeodeFlushQueue(
             QueueHandle     source,     /* source queue to flush */
             QueueHandle     dest,       /* queue to hold flushed events */
@@ -549,7 +549,7 @@ this flag is not passed, events will be appended to the queue.
 **Include:** geode.h
 
 ----------
-#### GeodeFreeQueue()
+### GeodeFreeQueue()
     void    GeodeFreeQueue(
             QueueHandle     qh);        /* handle of queue being freed */
 
@@ -560,7 +560,7 @@ must pass the handle of the queue to be freed.
 **Include:** geode.h
 
 ----------
-#### GeodeFreeDriver()
+### GeodeFreeDriver()
     void    GeodeFreeDriver(
             GeodeHandle     gh);        /* handle of the driver */
 
@@ -571,7 +571,7 @@ that routine.
 **Include:** driver.h
 
 ----------
-#### GeodeFreeLibrary()
+### GeodeFreeLibrary()
     void    GeodeFreeLibrary(
             GeodeHandle     gh);        /* handle of the library */
 
@@ -581,7 +581,7 @@ This routine frees a library geode that had been loaded with
 **Include:** library.h
 
 ----------
-#### GeodeGetAppObject()
+### GeodeGetAppObject()
     optr    GeodeGetAppObject(
             GeodeHandle     gh);    /* handle of the application geode */
 
@@ -592,7 +592,7 @@ application object.
 **Include:** geode.h
 
 ----------
-#### GeodeGetCodeProcessHandle()
+### GeodeGetCodeProcessHandle()
     GeodeHandle GeodeGetCodeProcessHandle();
 
 This routine returns the geode handle of the geode that owns the block in 
@@ -601,7 +601,7 @@ which the code which calls this routine resides.
 **Include:** geode.h
 
 ----------
-#### GeodeGetDefaultDriver()
+### GeodeGetDefaultDriver()
     GeodeHandle GeodeGetDefaultDriver(
             GeodeDefaultDriverType  type);  /* type of default driver to get */
 
@@ -618,7 +618,7 @@ GDDT_TASK(12).
 **Include:** driver.h
 
 ----------
-#### GeodeGetInfo()
+### GeodeGetInfo()
     word    GeodeGetInfo(
             GeodeHandle         gh,         /* handle of the subject geode */
             GeodeGetInfoType    info,       /* type of information to return */
@@ -683,7 +683,7 @@ permanent name. The buffer must be at least nine bytes.
 **Include:** geode.h
 
 ----------
-#### GeodeGetOptrNS()
+### GeodeGetOptrNS()
     optr    GeodeGetOptrNS(
             optr    obj);
 
@@ -693,7 +693,7 @@ actual global handle.
 **Include:** resource.h
 
 ----------
-#### GeodeGetProcessHandle()
+### GeodeGetProcessHandle()
     GeodeHandle GeodeGetProcessHandle();
 
 This routine returns the geode handle of the current executing process (i.e. 
@@ -703,14 +703,14 @@ application's geode handle or Process object's handle to a routine or message.
 **Include:** geode.h
 
 ----------
-#### GeodeGetUIData()
+### GeodeGetUIData()
     word    GeodeGetUIData(
             GeodeHandle     gh);
 
 **Include:** geode.h
 
 ----------
-#### GeodeInfoDriver()
+### GeodeInfoDriver()
     DriverInfoStruct  * GeodeInfoDriver(
             GeodeHandle gh); /* handle of the driver to get information about */
 
@@ -730,7 +730,7 @@ entry.
 **Include:** driver.h
 
 ----------
-#### GeodeInfoQueue()
+### GeodeInfoQueue()
     word    GeodeInfoQueue(
             QueueHandle qh);            /* queue to query */
 
@@ -742,7 +742,7 @@ currently in the queue.
 **Include:** geode.h
 
 ----------
-#### GeodeLoad()
+### GeodeLoad()
     GeodeHandle GeodeLoad(
             const char *        name,           /* file name of geode */
             GeodeAttrs          attrMatch,      /* GeodeAttrs that must be set */
@@ -786,7 +786,7 @@ it when you are done with **GeodeFree()**.
 **See Also:** UserLoadApplication() 
 
 ----------
-#### GeodeLoadDGroup
+### GeodeLoadDGroup
     void    GeodeLoadDGroup(
             MemHandle       mh);
 
@@ -795,7 +795,7 @@ This routine forces the **dgroup** segment into the data-segment register.
 **Include:** resource.h
 
 ----------
-#### GeodePrivAlloc()
+### GeodePrivAlloc()
     word    GeodePrivAlloc(
             GeodeHandle     gh,         /* handle of the owner of the
                                          * newly-allocated private data */
@@ -818,7 +818,7 @@ written are returned as all zeros.
 **Include:** geode.h
 
 ----------
-#### GeodePrivFree()
+### GeodePrivFree()
     void    GeodePrivFree(
             word    offset,     /* offset returned by GeodePrivAlloc() */
             word    numWords);  /* number of words to free */
@@ -831,7 +831,7 @@ areas. The space must previously have been allocated with
 **Include:** geode.h
 
 ----------
-#### GeodePrivRead()
+### GeodePrivRead()
     void    GeodePrivRead(
             GeodeHandle gh,         /* handle of owner of private data */
             word        offset,     /* offset returned by
@@ -856,7 +856,7 @@ be read. It must be at least numWords words long.
 **Include:** geode.h
 
 ----------
-#### GeodePrivWrite()
+### GeodePrivWrite()
     void    GeodePrivWrite(
             GeodeHandle gh,         /* handle of owner of private data */
             word        offset,     /* offset returned by
@@ -882,7 +882,7 @@ written.
 **Include:** geode.h
 
 ----------
-#### GeodeSetDefaultDriver()
+### GeodeSetDefaultDriver()
     void    GeodeSetDefaultDriver(
             GeodeDefaultDriverType  type,   /* type of default driver to set */
             GeodeHandle             gh);    /* driver to set as the default */
@@ -901,13 +901,13 @@ GDDT_TASK(12)
 **Include:** driver.h
 
 ----------
-#### GeodeSetUIData()
+### GeodeSetUIData()
     void    GeodeSetUIData(
             GeodeHandle     gh,
             word            data)
 
 ----------
-#### GeodeUseDriver()
+### GeodeUseDriver()
     GeodeHandle GeodeUseDriver(
             const   char    * name,         /* file name of driver to load */
             word            protoMajor,     /* expected major protocol */
@@ -939,7 +939,7 @@ use **GeodeFreeDriver()** to free it when you are done using it.
 **Include:** driver.h
 
 ----------
-#### GeodeUseLibrary()
+### GeodeUseLibrary()
     GeodeHandle GeodeUseLibrary(
             const char *        name,       /* file name of library to load */
             word                protoMajor, /* expected major protocol */
@@ -968,7 +968,7 @@ manually free it when finished, with **GeodeFreeLibrary()**.
 **Include:** library.h
 
 ----------
-#### GeoFree()
+### GeoFree()
     void    * GeoFree(
             void            * blockPtr,     /* address of memory to free */
             GeodeHandle     geodeHan);      /* owner of block to be used */
@@ -988,7 +988,7 @@ the system.
 **See Also:** free()
 
 ----------
-#### GeoMalloc()
+### GeoMalloc()
     void    * GeoMalloc(
             size_t          blockSize,      /* # of bytes to allocate*/
             GeodeHandle     geodeHan,       /* Owner of block to be used */
@@ -1011,7 +1011,7 @@ initialized to null bytes; otherwise, the memory will be left uninitialized.
 **See Also:** malloc()
 
 ----------
-#### GeoReAlloc()
+### GeoReAlloc()
     void    * GeoReAlloc(
             void            * blockPtr,     /* address of memory to resize */
             size_t          newSize,        /* New size in bytes */
@@ -1037,7 +1037,7 @@ the system.
 **See Also:** realloc()
 
 ----------
-#### GrApplyRotation()
+### GrApplyRotation()
     void    GrApplyRotation(
             GStateHandle        gstate,     /* GState to alter */
             WWFixedAsDWord      angle);     /* degrees counterclockwise */
@@ -1047,7 +1047,7 @@ Apply a rotation to the GState's transformation matrix.
 **Include:** graphics.h 
 
 ----------
-#### GrApplyScale()
+### GrApplyScale()
     void    GrApplyScale(
             GStateHandle        gstate,     /* GState to alter */
             WWFixedAsDWord      xScale,     /* new x scale factor */
@@ -1058,7 +1058,7 @@ Apply a scale factor to the GState's transformation matrix.
 **Include:** graphics.h 
 
 ----------
-#### GrApplyTransform()
+### GrApplyTransform()
     void    GrApplyTransform(
             GStateHandle        gstate,     /* GState to draw to */
             const TransMatrix   *tm);       /* transformation matrix to apply */
@@ -1069,7 +1069,7 @@ coordinate system.
 **Include:** graphics.h 
 
 ----------
-#### GrApplyTranslation()
+### GrApplyTranslation()
     void    GrApplyTranslation(
             GStateHandle        gstate,         /* GState to alter */
             WWFixedAsDWord      xTrans,         /* translation in x */
@@ -1080,7 +1080,7 @@ Apply a translation to the GState.
 **Include:** graphics.h 
 
 ----------
-#### GrApplyTranslationDWord()
+### GrApplyTranslationDWord()
     void    GrApplyTranslationDWord(
             GStateHandle    gstate,         /* GState to alter */
             sdword          xTrans,         /* extended translation in x */
@@ -1091,7 +1091,7 @@ Apply a 32-bit integer extended translation to the GState.
 **Include:** graphics.h 
 
 ----------
-#### GrBeginPath()
+### GrBeginPath()
     void    GrBeginPath(
             GStateHandle        gstate,         /* GState to alter */
             PathCombineType     params);        /* path parameters */
@@ -1105,7 +1105,7 @@ path, or may be combined with the old path by intersection or union.
 **Include:** graphics.h 
 
 ----------
-#### GrBeginUpdate()
+### GrBeginUpdate()
     void    GrBeginUpdate(
             GStateHandle gstate);           /* GState to draw to */
 
@@ -1116,7 +1116,7 @@ MSG_META_EXPOSED handler. Blanks out the invalid area.
 **Include:** win.h
 
 ----------
-#### GrBitBlt()
+### GrBitBlt()
     void    GrBitBlt(
             GStateHandle    gstate,     /* GState to draw to */
             sword           sourceX,    /* original x origin */
@@ -1142,7 +1142,7 @@ involve moving a drawing around the screen.
 **Include:** graphics.h 
 
 ----------
-#### GrBrushPolyline()
+### GrBrushPolyline()
     void    GrBrushPolyline(
             GStateHandle    gstate,     /* GState to draw to */
             const Point     * points,   /* array of Point structures to draw */
@@ -1157,7 +1157,7 @@ pixels.
 **Include:** graphics.h 
 
 ----------
-#### GrCharMetrics()
+### GrCharMetrics()
     dword   GrCharMetrics(
             GStatehandle    gstate,     /* GState to get metrics for */
             GCM_info        info,       /* information to return */
@@ -1186,7 +1186,7 @@ character-by-character), use **GrCharWidth()** instead.
 **Include:** font.h
 
 ----------
-#### GrCharWidth()
+### GrCharWidth()
     dword   GrCharWidth(    /* Returns width << 16 */
             GStateHandle    gstate,     /* GState to query */
             word            ch);        /* character of type Chars */
@@ -1198,7 +1198,7 @@ attributes that apply to multiple characters.
 **Include:** graphics.h 
 
 ----------
-#### GrCheckFontAvailID()
+### GrCheckFontAvailID()
     FontID  GrCheckFontAvailID(
             FontEnumFlags   flags,
             word            family,
@@ -1209,7 +1209,7 @@ See if font (identified by ID) exists.
 **Include:** graphics.h 
 
 ----------
-#### GrCheckFontAvailName()
+### GrCheckFontAvailName()
     FontID  GrCheckFontAvailName(
             FontEnumFlags   flags,
             word            family,
@@ -1220,7 +1220,7 @@ See if font (identified by name) exists.
 **Include:** graphics.h 
 
 ----------
-#### GrClearBitmap()
+### GrClearBitmap()
     void    GrClearBitmap(
             GStateHandle    gstate);    /* GState to affect */
 
@@ -1232,7 +1232,7 @@ mask is cleared and the data portion is left alone.
 **Include:** graphics.h 
 
 ----------
-#### GrCloseSubPath()
+### GrCloseSubPath()
     void    GrCloseSubPath(
             GStateHandle gstate);       /* GState to affect */
 
@@ -1242,7 +1242,7 @@ still call **GrEndPath()** to end the path definition.
 **Include:** graphics.h 
 
 ----------
-#### GrComment()
+### GrComment()
     void    GrComment(
             GStateHandle    gstate,         /* GState to affect */
             const void      * data,         /* comment string */
@@ -1253,7 +1253,7 @@ Write a comment out to a graphics string.
 **Include:** graphics.h 
 
 ----------
-#### GrCopyGString()
+### GrCopyGString()
     GSRetType GrCopyGString(
             GStateHandle    source,     /* GState from which to get GString */
             GStateHandle    dest,       /* GState to which to copy GString */
@@ -1289,7 +1289,7 @@ The return value can be any one of **GSRetType**, a byte-size field:
 **Include:** gstring.h 
 
 ----------
-#### GrCreateBitmap()
+### GrCreateBitmap()
     VMBlockHandle GrCreateBitmap(
             BMFormat        initFormat,     /* color fomat of bitmap */
             word            initWidth,      /* initial width of bitmap */
@@ -1354,7 +1354,7 @@ The bitmap's raw data is in the VM block, but outside of the header area.
 **Include:** graphics.h 
 
 ----------
-#### GrCreateGString()
+### GrCreateGString()
     GStateHandle GrCreateGString(
             Handle      han,        /* memory, stream, or VM file handle */
             GStringType hanType,    /* type of handle in han parameter */
@@ -1368,7 +1368,7 @@ GST_VMEM.
 **Include:** gstring.h 
 
 ----------
-#### GrCreatePalette()
+### GrCreatePalette()
     word    GrCreatePalette( /* Returns # of entries in color table
                               * or 0 for monochrome or 24-bit */
             GStateHandle gstate);
@@ -1379,7 +1379,7 @@ Initialize the table entries to the default palette for the device.
 **Include:** graphics.h 
 
 ----------
-#### GrCreateState()
+### GrCreateState()
     GStateHandle GrCreateState(
             WindowHandle win);  /* Window in which GState will be active */
 
@@ -1391,7 +1391,7 @@ with it.
 **Include:** graphics.h 
 
 ----------
-#### GrDeleteGStringElement()
+### GrDeleteGStringElement()
     void    GrDeleteGStringElement(
             GStateHandle    gstate,     /* GState containing GString */
             word            count);     /* number of elements to delete */
@@ -1401,7 +1401,7 @@ Delete a range of GString elements from the GString in the passed GState.
 **Include:** graphics.h 
 
 ----------
-#### GrDestroyBitmap()
+### GrDestroyBitmap()
     void    GrDestroyBitmap(
             GStateHandle    gstate,     /* GState containing bitmap */
             BMDestroy       flags);     /* flags for removing data */
@@ -1420,7 +1420,7 @@ in a drawable state.
 **Include:** graphics.h 
 
 ----------
-#### GrDestroyGString()
+### GrDestroyGString()
     void    GrDestroyGString(
             Handle              gstring,    /* Handle of GString */
             GStateHandle        gstate,     /* NULL, or handle of another
@@ -1442,7 +1442,7 @@ routine will do some cleaning up.
 **Include:** gstring.h 
 
 ----------
-#### GrDestroyPalette()
+### GrDestroyPalette()
     void    GrDestroyPalette(
             GStateHandle gstate);       /* GState of palette to destroy */
 
@@ -1451,7 +1451,7 @@ Free any custom palette associated with the current window.
 **Include:** graphics.h 
 
 ----------
-#### GrDestroyState()
+### GrDestroyState()
     void    GrDestroyState(
             GStateHandle gstate);       /* GState to be destroyed */
 
@@ -1460,7 +1460,7 @@ Free a graphics state block.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawArc()
+### GrDrawArc()
     void    GrDrawArc(
             GStateHandle    gstate,         /* GState to draw to */
             sword           left,           /* bounds of box outlining arc */
@@ -1477,7 +1477,7 @@ starting angle to the ending angle.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawArc3Point()
+### GrDrawArc3Point()
     void    GrDrawArc3Point(
             GStateHandle                gstate,     /* GState to draw to */
             const ThreePointArcParams   *params);           
@@ -1487,7 +1487,7 @@ other point on the arc.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawArc3PointTo()
+### GrDrawArc3PointTo()
     void    GrDrawArc3PointTo(
             GStateHandle                gstate,     /* GState to draw to */
             const ThreePointArcToParams *params);
@@ -1498,7 +1498,7 @@ automatically used as one of the endpoints.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawBitmap()
+### GrDrawBitmap()
     void    GrDrawBitmap(
             GStateHandle    gstate,         /* GState to draw to */
             sword           x,              /* x starting point */
@@ -1518,7 +1518,7 @@ allows the bitmap to be drawn in horizontal bands, or swaths.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawBitmapAtCP()
+### GrDrawBitmapAtCP()
     void    GrDrawBitmapAtCP(
             GStateHandle        gstate,         /* GState to draw to */
             const   Bitmap      * bm,           /* pointer to the bitmap */
@@ -1530,7 +1530,7 @@ bitmap is drawn at the current position.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawChar()
+### GrDrawChar()
     void    GrDrawChar(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x,          /* x position at which to draw */
@@ -1543,7 +1543,7 @@ attributes.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawCharAtCP()
+### GrDrawCharAtCP()
     void    GrDrawCharAtCP(
             GStateHandle    gstate,         /* GState to draw to */
             word            ch);            /* character of type Chars */
@@ -1554,7 +1554,7 @@ attributes.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawCurve()
+### GrDrawCurve()
     void    GrDrawCurve(
             GStateHandle        gstate,         /* GState to draw to */
             const Point         *points);       /* array of four Points */
@@ -1564,7 +1564,7 @@ Draw a Bezier curve.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawCurveTo()
+### GrDrawCurveTo()
     void    GrDrawCurveTo(
             GStateHandle        gstate,         /* GState to draw to */
             const Point         *points);       /* array of three Points */
@@ -1574,7 +1574,7 @@ Draw a Bezier curve, using the current postion as the first point.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawEllipse()
+### GrDrawEllipse()
     void    GrDrawEllipse(
             GStateHandle    gstate,     /* GState to draw to */
             sword           left,       /* bounding box bounds */
@@ -1587,7 +1587,7 @@ Draw an ellipse, defined by its bounding box.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawGString()
+### GrDrawGString()
     GSRetType GrDrawGString(
             GStateHandle    gstate,         /* GState to draw to */
             Handle          gstringToDraw,  /* GString to draw */
@@ -1636,7 +1636,7 @@ element was present.
 **Include:** gstring.h 
 
 ----------
-#### GrDrawGStringAtCP()
+### GrDrawGStringAtCP()
     GSRetType GrDrawGStringAtCP(
             GStateHandle        gstate,         /* GState to draw to */
             GStringeHandle      gstringToDraw,  /* GString to draw */
@@ -1676,7 +1676,7 @@ element was present.
 **Include:** gstring.h 
 
 ----------
-#### GrDrawHLine()
+### GrDrawHLine()
     void    GrDrawHLine(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x1,         /* first horizontal coordinate */
@@ -1688,7 +1688,7 @@ Draw a horizontal line.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawHLineTo()
+### GrDrawHLineTo()
     void    GrDrawHLineTo(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x);         /* ending horizontal coordinate */
@@ -1698,7 +1698,7 @@ Draw a horizontal line starting from the current position.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawHugeBitmap()
+### GrDrawHugeBitmap()
     void    GrDrawHugeBitmap(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x           /* Point at which to draw */
@@ -1714,7 +1714,7 @@ Draw a bitmap that resides in a HugeArray.
 GrDrawHugeImage() 
 
 ----------
-#### GrDrawHugeBitmapAtCP()
+### GrDrawHugeBitmapAtCP()
     void    GrDrawHugeBitmapAtCP(
             GStateHandle        gstate,     /* GState to draw to */
             VMFileHandle        vmFile,     /* VM file containing HugeArray */
@@ -1728,7 +1728,7 @@ current position.
 **See Also:** GrDrawBitmapAtCP(), GrDrawHugeBitmap() 
 
 ----------
-#### GrDrawHugeImage()
+### GrDrawHugeImage()
     void    GrDrawHugeImage(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x           /* point at which to draw */
@@ -1762,7 +1762,7 @@ bitmap pixel.
 **See Also:** GrDrawImage() , GrDrawHugeBitmapAtCP()
 
 ----------
-#### GrDrawImage()
+### GrDrawImage()
     void    GrDrawImage(
             GStateHandle        gstate,         /* GState to draw to */
             sword       x           /* point at which to draw */
@@ -1794,7 +1794,7 @@ so that a square of device pixels displays each bitmap pixel.
 **See Also:** GrDrawHugeImage() , GrDrawBitmap() 
 
 ----------
-#### GrDrawLine()
+### GrDrawLine()
     void    GrDrawLine(
             GStateHandle    gstate, /* GState to draw to */
             sword           x1,     /* First coordinate of line */
@@ -1809,7 +1809,7 @@ Draw a line.
 **See Also:** GrDrawLineTo(), GrDrawHLine(), GrDrawVLine() 
 
 ----------
-#### GrDrawLineTo()
+### GrDrawLineTo()
     void    GrDrawLineTo(
             GStateHandle    gstate, /* GState to draw to */
             sword           x,      /* Second coordinate of line */
@@ -1822,7 +1822,7 @@ Draw a line starting from the current position.
 **See Also:** GrDrawLine(), GrDrawHLineTo(), GrDrawVLineTo() 
 
 ----------
-#### GrDrawPath()
+### GrDrawPath()
     void    GrDrawPath(
             GStateHandle gstate);       /* GState to draw to */
 
@@ -1832,7 +1832,7 @@ attributes.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawPoint()
+### GrDrawPoint()
     void    GrDrawPoint(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x,          /* Coordinates of point to draw */
@@ -1843,7 +1843,7 @@ Draw a pixel.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawPointAtCP()
+### GrDrawPointAtCP()
     void    GrDrawPointAtCP(
             GStateHandle gstate);       /* GState to draw to */
 
@@ -1852,7 +1852,7 @@ Draw a pixel.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawPolygon()
+### GrDrawPolygon()
     void    GrDrawPolygon(
             GStateHandle    gstate,         /* GState to draw to */
             const   Point   * points,       /* array of points in polygon */
@@ -1863,7 +1863,7 @@ Draws a connected polygon.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawPolyline()
+### GrDrawPolyline()
     void    GrDrawPolyline(
             GStateHandle    gstate,         /* GState to draw to */
             const   Point   * points,       /* array of points in polyline */
@@ -1874,7 +1874,7 @@ Draws a simple polyline.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRect()
+### GrDrawRect()
     void    GrDrawRect(
             GStateHandle    gstate,     /* GState to draw to */
             sword           left,       /* bounds of rectangle to draw */
@@ -1887,7 +1887,7 @@ Draws the outline of a rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRectTo()
+### GrDrawRectTo()
     void    GrDrawRectTo(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x,          /* opposite corner of rectangle */
@@ -1899,7 +1899,7 @@ position.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRegion()
+### GrDrawRegion()
     void    GrDrawRegion(
             GStateHandle    gstate,     /* GState to draw to */
             sword           xPos,       /* Position at which to draw */
@@ -1916,7 +1916,7 @@ attributes.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRegionAtCP()
+### GrDrawRegionAtCP()
     void    GrDrawRegionAtCP(
             GStateHandle    gstate, /* GState to draw to */
             const Region    * reg,  /* region definition */
@@ -1931,7 +1931,7 @@ with the GState's area attributes.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRelArc3PointTo()
+### GrDrawRelArc3PointTo()
     void    GrDrawRelArc3PointTo(
             const ThreePointRelArcToParams  *params);
 
@@ -1942,7 +1942,7 @@ coordinates.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRelLineTo()
+### GrDrawRelLineTo()
     void    GrDrawRelLineTo(
             GStateHandle    gstate, /* GState to draw to */
             WWFixedAsDWord  x,      /* horizontal offset of second point */
@@ -1954,7 +1954,7 @@ current pen position to draw to.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRoundRect()
+### GrDrawRoundRect()
     void    GrDrawRoundRect(
             GStateHandle    gstate,         /* GState to draw to */
             sword           left,           /* bounds of rectangle */
@@ -1968,7 +1968,7 @@ Draw the outline of a rounded rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawRoundRectTo()
+### GrDrawRoundRectTo()
     void    GrDrawRoundRectTo(
             GStateHandle    gstate,         /* GState to draw to */
             sword           x,              /* opposite corner of bounds */
@@ -1981,7 +1981,7 @@ rectangle is the current position.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawSpline()
+### GrDrawSpline()
     void    GrDrawSpline(
             GStateHandle    gstate,         /* GState to draw   to */
             const Point     * points,       /* array of points */
@@ -1994,7 +1994,7 @@ Draw a Bezier spline.
 **See Also:** GrDrawCurve() 
 
 ----------
-#### GrDrawSplineTo()
+### GrDrawSplineTo()
     void    GrDrawSplineTo(
             GStateHandle    gstate,         /* GState to draw to */
             const Point     *points,        /* array of points */
@@ -2007,7 +2007,7 @@ Draw a Bezier spline, using the current position as one endpoint.
 **See Also:** GrDrawCurveTo() 
 
 ----------
-#### GrDrawText()
+### GrDrawText()
     void    GrDrawText(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x,          /* point at which to draw */
@@ -2025,7 +2025,7 @@ null-terminated.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawTextAtCP()
+### GrDrawTextAtCP()
     void    GrDrawTextAtCP(
             GStateHandle    gstate,     /* GState to draw to */
             const Chars     * str,      /* pointer to character string */
@@ -2040,7 +2040,7 @@ null-terminated.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawVLine()
+### GrDrawVLine()
     void    GrDrawVLine(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x,          /* horizontal position of line */
@@ -2052,7 +2052,7 @@ Draw a vertical line.
 **Include:** graphics.h 
 
 ----------
-#### GrDrawVLineTo()
+### GrDrawVLineTo()
     void    GrDrawVLine(
             GStateHandle    gstate,     /* GState to draw to */
             sword           y);         /* second vertical position */
@@ -2062,7 +2062,7 @@ Draw a vertical line starting from the current position.
 **Include:** graphics.h 
 
 ----------
-#### GrEditBitmap()
+### GrEditBitmap()
     GStateHandle GrEditBitmap(
             VMFileHandle    vmFile,         /* VM file of bitmap */
             VMBlockHandle   vmBlock,        /* VM block of bitmap */
@@ -2074,7 +2074,7 @@ may be be sent to the bitmap.
 **Include:** graphics.h 
 
 ----------
-#### GrEditGString()
+### GrEditGString()
     GStateHandle GrEditGString(
             Handle  vmFile,     /* VM file containing the GString */
             word    vmBlock);   /* VM block containing the GString */
@@ -2087,7 +2087,7 @@ appended to the GString.
 **Include:** graphics.h 
 
 ----------
-#### GrEndGString()
+### GrEndGString()
     GStringErrorType GrEndGString( 
             GStateHandle gstate);           /* GState to draw to */
 
@@ -2103,7 +2103,7 @@ Finish the definition of a graphics string.
 **Include:** graphics.h 
 
 ----------
-#### GrEndPath()
+### GrEndPath()
     void    GrEndPath(
             GStateHandle gstate);       /* GState to draw to */
 
@@ -2113,7 +2113,7 @@ display, as normal.
 **Include:** graphics.h 
 
 ----------
-#### GrEndUpdate()
+### GrEndUpdate()
     void    GrEndUpdate(
             GStateHandle gstate);       /* GState to draw to */
 
@@ -2122,7 +2122,7 @@ Unlocks window from an update.
 **Include:** win.h 
 
 ----------
-#### GrEnumFonts()
+### GrEnumFonts()
     word    GrEnumFonts( /* Return value = number of fonts found */
             FontEnumStruct  * buffer,   /* buffer for returned values */
             word            size,       /* number of structures to return */
@@ -2142,7 +2142,7 @@ font's ID and a string name.
 **Include:** font.h 
 
 ----------
-#### GrEscape()
+### GrEscape()
     void    GrEscape(
             GStateHandle    gstate,         /* GState to draw to */
             word            code,           /* escape code */
@@ -2154,7 +2154,7 @@ Write an escape code to a graphics string.
 **Include:** graphics.h 
 
 ----------
-#### GrFillArc()
+### GrFillArc()
     void    GrFillArc(
             GStateHandle    gstate,         /* GState to draw to */
             sword           left,           /* bounding rectangle */
@@ -2172,7 +2172,7 @@ either a wedge or a chord fill.
 **Include:** graphics.h 
 
 ----------
-#### GrFillArc3Point()
+### GrFillArc3Point()
     void    GrFillArc3Point(
             GStateHandle            gstate,     /* GState to draw to */
             const ThreePointParams  *params);
@@ -2184,7 +2184,7 @@ other point, all of which must lie on the arc.
 **Include:** graphics.h 
 
 ----------
-#### GrFillArc3PointTo()
+### GrFillArc3PointTo()
     void    GrFillArc3PointTo(
             GStateHandle                gstate,     /* GState to draw to */
             const ThreePointArcParams   *params);
@@ -2195,7 +2195,7 @@ by the current position.
 **Include:** graphics.h 
 
 ----------
-#### GrFillBitmap()
+### GrFillBitmap()
     void    GrFillBitmap (
             GStateHandle        gstate,     /* GState to draw to */
             sword               x,          /* point at which to draw */
@@ -2209,7 +2209,7 @@ to this routine are the same as those for **GrDrawBitmap()**.
 **Include:** graphics.h 
 
 ----------
-#### GrFillBitmapAtCP()
+### GrFillBitmapAtCP()
     void    GrFillBitmapAtCP (
             GStateHandle    gstate,         /* GState to draw to */
             const Bitmap    * bm,           /* pointer to bitmap */
@@ -2222,7 +2222,7 @@ as those for **GrDrawBitmapAtCP()**.
 **Include:** graphics.h 
 
 ----------
-#### GrFillEllipse()
+### GrFillEllipse()
     void    GrFillEllipse(
             GStateHandle    gstate,     /* GState to draw to */
             sword           left,       /* Bounds of bounding rectangle */
@@ -2236,7 +2236,7 @@ box.
 **Include:** graphics.h 
 
 ----------
-#### GrFillPath()
+### GrFillPath()
     void    GrFillPath(
             GStateHandle    gstate,         /* GState to draw to */
             RegionFillRule  rule);          /* ODD_EVEN or WINDING */
@@ -2246,7 +2246,7 @@ Fill an area whose outline is defined by the GState's path.
 **Include:** graphics.h 
 
 ----------
-#### GrFillPolygon()
+### GrFillPolygon()
     void    GrFillPolygon(
             GStateHandle        gstate,         /* GState to draw to */
             RegionFillRule      windingRule,    /* ODD_EVEN or WINDING */
@@ -2258,7 +2258,7 @@ Fill polygon. The polygon is defined by the passed array of points.
 **Include:** graphics.h 
 
 ----------
-#### GrFillRect()
+### GrFillRect()
     void    GrFillRect(
             GStateHandle    gstate,         /* GState to draw to */
             sword           left,           /* bounds of rectangle */
@@ -2271,7 +2271,7 @@ Draw a filled rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrFillRectTo()
+### GrFillRectTo()
     void    GrFillRectTo(
             GStateHandle    gstate,     /* GState to draw to */
             sword           x,          /* opposite corner of rectangle */
@@ -2282,7 +2282,7 @@ Draw a filled rectangle. The current position will define one of the corners.
 **Include:** graphics.h 
 
 ----------
-#### GrFillRoundRect()
+### GrFillRoundRect()
     void    GrFillRoundRect(
             GStateHandle    gstate,         /* GState to draw to */
             sword           left,           /* bounds of rectangle */
@@ -2296,7 +2296,7 @@ Draw a filled rounded rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrFillRoundRectTo()
+### GrFillRoundRectTo()
     void    GrFillRoundRectTo(
             GStateHandle    gstate,         /* GState to draw to */
             sword           x,              /* opposite corner of rectangle */
@@ -2309,7 +2309,7 @@ corner of the bounding rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrFindNearestPointsize()
+### GrFindNearestPointsize()
     Boolean GrFindNearestPointsize( /* If false, then FontID invalid */
             FontID      id,                 /* fond ID */
             dword       sizeSHL16,          /* point size */
@@ -2325,7 +2325,7 @@ return valued will be *true*.
 **Include:** font.h 
 
 ----------
-#### GrFontMetrics()
+### GrFontMetrics()
     dword   GrFontMetrics(
             GStateHandle    gstate,     /* subject GState */
             GFM_info        info);      /* Type of information to return */
@@ -2375,7 +2375,7 @@ based on the *info* parameter.
 **Include:** font.h 
 
 ----------
-#### GrGetAreaColor()
+### GrGetAreaColor()
     RGBColorAsDWord     GrGetAreaColor(
             GStateHandle gstate);       /* GState of which to get color */
 
@@ -2384,7 +2384,7 @@ Get the color which is being used to fill areas.
 **Include:** graphics.h 
 
 ----------
-#### GrGetAreaColorMap()
+### GrGetAreaColorMap()
     ColorMapMode GrGetAreaColorMap(
             GStateHandle  gstate);  /* GState of which to get area color map */
 
@@ -2393,7 +2393,7 @@ Get the mapping mode used for filling areas with unavailable colors.
 **Include:** graphics.h 
 
 ----------
-#### GrGetAreaMask()
+### GrGetAreaMask()
     SysDrawMask GrGetAreaMask(
             GStateHandle    gstate,     /* GState of which to get mask */
             DrawMask        * dm);      /* buffer for returned mask */
@@ -2407,7 +2407,7 @@ from top row to bottom.
 **Include:** graphics.h 
 
 ----------
-#### GrGetAreaPattern()
+### GrGetAreaPattern()
     GraphicPattern  GrGetAreaPattern(
             GStateHandle    gstate,             /* GState of area pattern */
             const MemHandle * customPattern,    /* pointer to handle of block for
@@ -2420,7 +2420,7 @@ Get the area pattern used when filling areas.
 **Include:** graphics.h 
 
 ----------
-#### GrGetBitmap()
+### GrGetBitmap()
     MemHandle GrGetBitmap(
             GStateHandle    gstate,         /* GState containing bitmap */
             sword           x,              /* bitmap origin */
@@ -2436,7 +2436,7 @@ bitmap successfully copied.
 **Include:** graphics.h 
 
 ----------
-#### GrGetBitmapMode()
+### GrGetBitmapMode()
     BitmapMode  GrGetBitmapMode(
             GStateHandle    gstate);    /* GState containing bitmap */
 
@@ -2445,7 +2445,7 @@ Get mode bits for an editable bitmap.
 **Include:** graphics.h 
 
 ----------
-#### GrGetBitmapRes()
+### GrGetBitmapRes()
     XYValueAsDWord GrGetBitmapRes(
             const Bitmap    * bm);      /* pointer to the bitmap */
 
@@ -2454,7 +2454,7 @@ Get the resolution of a bitmap.
 **Include:** graphics.h 
 
 ----------
-#### GrGetBitmapSize()
+### GrGetBitmapSize()
     XYValueAsDWord GrGetBitmapSize(
             const Bitmap    * bm);      /* pointer to the bitmap */
 
@@ -2463,7 +2463,7 @@ Get the dimensions, in points, of a bitmap.
 **Include:** graphics.h 
 
 ----------
-#### GrGetClipRegion()
+### GrGetClipRegion()
     MemHandle GrGetClipRegion(
             GStateHandle    gstate,         /* subject GState */
             RegionFillRule  rule);          /* ODD_EVEN or WINDING */
@@ -2474,7 +2474,7 @@ paths are set for the GState.
 **Include:** graphics.h 
 
 ----------
-#### GrGetCurPos()
+### GrGetCurPos()
     XYValueAsDWord GrGetCurPos(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2483,7 +2483,7 @@ Get the current pen position.
 **Include:** graphics.h 
 
 ----------
-#### GrGetCurPosWWFixed()
+### GrGetCurPosWWFixed()
     void    GrGetCurPosWWFixed(
             GStateHandle    gstate,         /* subject GState */
             PointWWFixed    *cp);           /* buffer in which to return cur. pos. */
@@ -2493,7 +2493,7 @@ Get the current pen position.
 **Include:** graphics.h 
 
 ----------
-#### GrGetDefFontID()
+### GrGetDefFontID()
     FontID  GrGetDefFontID(
             dword   * sizeSHL16);   /* pointer to buffer for returned size */
 
@@ -2502,7 +2502,7 @@ Get the system default font (including size).
 **Include:** font.h 
 
 ----------
-#### GrGetFont()
+### GrGetFont()
     FontID  GrGetFont(
             GStateHandle    gstate,         /* subject GState */
             WWFixedAsDWord  * pointSize);   /* pointer to buffer for
@@ -2513,7 +2513,7 @@ Get the passed GState's current font, including point size.
 **Include:** graphics.h 
 
 ----------
-#### GrGetFontName()
+### GrGetFontName()
     FontID  GrGetFontName(
             FontID          id,         /* ID of font */
             const char      * name);    /* buffer for returned name string */
@@ -2525,7 +2525,7 @@ FID_NAME_LEN in size.
 **Include:** font.h 
 
 ----------
-#### GrGetFontWeight()
+### GrGetFontWeight()
     FontWeight GrGetFontWeight(
             GStateHandle    gstate);    /* GState containing the font */
 
@@ -2534,7 +2534,7 @@ Get the current font weight set for the passed GState.
 **Include:** font.h 
 
 ----------
-#### GrGetFontWidth()
+### GrGetFontWidth()
     FontWidth GrGetFontWidth(
             GStateHandle    gstate);    /* GState containing the font */
 
@@ -2543,7 +2543,7 @@ Get the current font width set for the passed GState.
 **Include:** font.h 
 
 ----------
-#### GrGetGStringBounds()
+### GrGetGStringBounds()
     void    GrGetGStringBounds(
             GStringHandle   source,         /* GString to be checked */
             GStateHandle    dest,           /* handle of GState to use */
@@ -2558,7 +2558,7 @@ containing rectangle will be returned in the structure pointed to by *bounds*.
 **Include:** gstring.h 
 
 ----------
-#### GrGetGStringBoundsDWord
+### GrGetGStringBoundsDWord
     void    GrGetGStringBoundsDWord(
             Handle          gstring,        /* GString to be checked */
             GStateHandle    gstate,         /* handle of GState to use */
@@ -2576,7 +2576,7 @@ containing rectangle will be returned in the structure pointed to by *bounds*.
 **Include:** gstring.h 
 
 ----------
-#### GrGetGStringElement()
+### GrGetGStringElement()
     GStringElement GrGetGStringElement(
             GStateHandle    gstate,                 /* handle of GString's GState */
             void            * buffer,               /* pointer to return buffer */
@@ -2591,7 +2591,7 @@ explicitly. The routine's data can be returned in a buffer.
 **Include:** gstring.h 
 
 ----------
-#### GrGetInfo()
+### GrGetInfo()
     void    GrGetInfo(
             GStateHandle    gstate,     /* GState to get information about */
             GrInfoTypes     type,       /* type of information to get */
@@ -2611,7 +2611,7 @@ GState.
 **Include:** graphics.h 
 
 ----------
-#### GrGetLineColor()
+### GrGetLineColor()
     RGBColorAsDWord GrGetLineColor(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2620,7 +2620,7 @@ Get the color used when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrGetLineColorMap()
+### GrGetLineColorMap()
     ColorMapMode GrGetLineColorMap(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2629,7 +2629,7 @@ Get the mode used when drawing lines in an unavailable color.
 **Include:** graphics.h 
 
 ----------
-#### GrGetLineEnd()
+### GrGetLineEnd()
     LineEnd GrGetLineEnd(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2638,7 +2638,7 @@ Get the end used when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrGetLineJoin()
+### GrGetLineJoin()
     LineJoin GrGetLineJoin(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2647,7 +2647,7 @@ Get the join used when drawing corners.
 **Include:** graphics.h 
 
 ----------
-#### GrGetLineMask()
+### GrGetLineMask()
     SysDrawMask GrGetLineMask(
             GStateHandle    gstate,     /* subject GState */
             DrawMask        * dm);      /* buffer for returned custom mask */
@@ -2661,7 +2661,7 @@ ordered from top row to bottom.
 **Include:** graphics.h 
 
 ----------
-#### GrGetLineStyle()
+### GrGetLineStyle()
     LineStyle GrGetLineStyle(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2670,7 +2670,7 @@ Get the style, or "dottedness," used when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrGetLineWidth()
+### GrGetLineWidth()
     WWFixedAsDWord  GrGetLineWidth(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2679,7 +2679,7 @@ Get the current line width.
 **Include:** graphics.h 
 
 ----------
-#### GrGetMaskBounds()
+### GrGetMaskBounds()
     void    GrGetMaskBounds(
             GStateHandle    gstate,         /* subject GState */
             Rectangle       * bounds);      /* buffer for returned bounds */
@@ -2689,7 +2689,7 @@ Get the 16-bit bounds of the current clip rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrGetMaskBoundsDWord()
+### GrGetMaskBoundsDWord()
     void    GrGetMaskBoundsDWord(
             GStateHandle    gstate,         /* subject GState */
             RectDWord       * bounds);      /* buffer for returned bounds */
@@ -2700,7 +2700,7 @@ point.
 **Include:** graphics.h 
 
 ----------
-#### GrGetMiterLimit()
+### GrGetMiterLimit()
     WWFixedAsDWord GrGetMiterLimit(
             GStateHandle    gstate);            /* subject GState */
 
@@ -2709,7 +2709,7 @@ Get the miter limit to use when drawing mitered corners.
 **Include:** graphics.h 
 
 ----------
-#### GrGetMixMode()
+### GrGetMixMode()
     MixMode GrGetMixMode(
             GStateHandle    gstate);            /* subject GState */
 
@@ -2718,7 +2718,7 @@ Get the current mixing mode.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPalette()
+### GrGetPalette()
     MemHandle GrGetPalette(
             GStateHandle    gstate,         /* subject GState */
             GetPalType      flag,           /* GPT_ACTIVE, GPT_CUSTOM, or
@@ -2731,7 +2731,7 @@ handle of a block containing all the returned palette entries.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPath()
+### GrGetPath()
     MemHandle   GrGetPath(
             GStateHandle    gstate,         /* subject GState */
             GetPathType     ptype);         /* Which path to retrieve */
@@ -2743,7 +2743,7 @@ clipping path may be retrieved.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPathBounds()
+### GrGetPathBounds()
     Boolean GrGetPathBounds(
             GStateHandle    gstate,         /* subject GState */
             GetPathType     ptype,
@@ -2756,7 +2756,7 @@ for the GState.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPathBoundsDWord()
+### GrGetPathBoundsDWord()
     Boolean GrGetPathBoundsDWord(
             GStateHandle    gstate,         /* subject GState */
             GetPathType     ptype,
@@ -2769,7 +2769,7 @@ for the GState.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPathPoints()
+### GrGetPathPoints()
     MemHandle   GrGetPathPoints(
             GStateHandle    gstate,         /* subject GState */
             word            resolution);    /* dots per inch */
@@ -2780,7 +2780,7 @@ points are in document coordinates.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPathRegion()
+### GrGetPathRegion()
     MemHandle GrGetPathRegion(
             GStateHandle        gstate,         /* subject GState */
             RegionFillRule      rule);          /* ODD_EVEN or WINDING */
@@ -2790,7 +2790,7 @@ Get the region enclosed by a path.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPoint()
+### GrGetPoint()
     RGBColorAsDWord GrGetPoint(
             GStateHandle    gstate,     /* subject GState */
             sword           x,          /* coordinates of pixel */
@@ -2801,7 +2801,7 @@ Get the color of the pixel corresponding to the specified coordinates.
 **Include:** graphics.h 
 
 ----------
-#### GrGetPtrRegBounds()
+### GrGetPtrRegBounds()
     word    GrGetPtrRegBounds( /* Returns size of Region data struct. */
             const Region    * reg,          /* pointer to region */
             Rectangle       * bounds);      /* returned bounds of region */
@@ -2811,7 +2811,7 @@ Get the bounds of the passed region.
 **Include:** graphics.h 
 
 ----------
-#### GrGetSubscriptAttr()
+### GrGetSubscriptAttr()
     ScriptAttrAsWord GrGetSubscriptAttr(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2822,7 +2822,7 @@ percentage of the font size from the top at which the character gets drawn.
 **Include:** font.h 
 
 ----------
-#### GrGetSuperscriptAttr()
+### GrGetSuperscriptAttr()
     ScriptAttrAsWord GrGetSuperscriptAttr(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2834,7 +2834,7 @@ drawn.
 **Include:** font.h 
 
 ----------
-#### GrGetTextBounds()
+### GrGetTextBounds()
     Boolean GrGetTextBounds(
             GStateHandle    gstate,     /* subject GState */
             word            xpos,       /* position where text would be drawn */
@@ -2849,7 +2849,7 @@ is zero, the string is assumed to be null-terminated.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTextColor()
+### GrGetTextColor()
     RGBColorAsDWord GrGetTextColor(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2858,7 +2858,7 @@ Get the color used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTextColorMap()
+### GrGetTextColorMap()
     ColorMapMode    GrGetTextColorMap(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2867,7 +2867,7 @@ Get the mode used when drawing text in an unavailable color.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTextMask()
+### GrGetTextMask()
     SystemDrawMask  GrGetTextMask(
             GStateHandle    gstate,         /* subject GState */
             DrawMask        * dm);          /* returned custom mask, if any */
@@ -2881,7 +2881,7 @@ from top row to bottom.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTextMode()
+### GrGetTextMode()
     TextMode    GrGetTextMode(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2891,7 +2891,7 @@ drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTextPattern()
+### GrGetTextPattern()
     GraphicPattern  GrGetTextPattern(
             GStateHandle    gstate,             /* subject GState */
             const MemHandle * customPattern,    /* pointer to returned handle
@@ -2904,7 +2904,7 @@ Get the graphics pattern used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTextSpacePad()
+### GrGetTextSpacePad()
     WWFixedAsDWord GrGetTextSpacePad(
             GStateHandle    gstate);            /* subject GState */
 
@@ -2913,7 +2913,7 @@ Get the space pad used when drawing strings of text.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTextStyle()
+### GrGetTextStyle()
     TextStyle   GrGetTextStyle(
             GStateHandle    gstate);            /* subject GState */
 
@@ -2922,7 +2922,7 @@ Get the style used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrGetTrackKern()
+### GrGetTrackKern()
     word    GrGetTrackKern(
             GStateHandle    gstate);            /* subject GState */
 
@@ -2931,7 +2931,7 @@ Get the track kerning used when drawing strings of text.
 **Include:**    graphics.h 
 
 ----------
-#### GrGetTransform()
+### GrGetTransform()
     void    GrGetTransform(
             GStateHandle    gstate,     /* subject GState */
             TransMatrix     * tm);      /* pointer to returned TransMatrix */
@@ -2941,7 +2941,7 @@ Get the current coordinate transformation, expressed as a matrix.
 **Include:** graphics.h 
 
 ----------
-#### GrGetWinBounds()
+### GrGetWinBounds()
     void    GrGetWinBounds(
             GStateHandle    gstate,         /* subject GState */
             Rectangle       * bounds);      /* returned window bounds */
@@ -2951,7 +2951,7 @@ Get the bounds of the GState's associated window.
 **Include:** graphics.h 
 
 ----------
-#### GrGetWinBoundsDWord()
+### GrGetWinBoundsDWord()
     void    GrGetWinBoundsDWord(
             GStateHandle    gstate,         /* subject GState */
             RectDWord       * bounds);      /* returned window bounds */
@@ -2962,7 +2962,7 @@ point.
 **Include:** graphics.h 
 
 ----------
-#### GrGetWinHandle()
+### GrGetWinHandle()
     WindowHandle GrGetWinHandle(
             GStateHandle    gstate);        /* subject GState */
 
@@ -2971,7 +2971,7 @@ Get the handle of the GState's associated window.
 **Include:** graphics.h 
 
 ----------
-#### GrGrabExclusive()
+### GrGrabExclusive()
     GStateHandle GrGrabExclusive(
             GeodeHandle     videoDriver,        /* NULL for default */
             GStateHandle    gstate);            /* subject GState */
@@ -2981,7 +2981,7 @@ Start drawing exclusively to a video driver.
 **Include:** graphics.h 
 
 ----------
-#### GrInitDefaultTransform()
+### GrInitDefaultTransform()
     void    GrInitDefaultTransform(
             GStateHandle    gstate);            /* subject GState */
 
@@ -2991,7 +2991,7 @@ transformation.
 **Include:** graphics.h 
 
 ----------
-#### GrInvalRect()
+### GrInvalRect()
     void    GrInvalRect(
             GStateHandle    gstate,     /* subject GState */
             sword           left,       /* bounds to be invalidated */
@@ -3004,7 +3004,7 @@ Invalidate the passed rectangular area. This area will be redrawn.
 **Include:** graphics.h 
 
 ----------
-#### GrInvalRectDWord()
+### GrInvalRectDWord()
     void    GrInvalRectDWord(
             GStateHandle        gstate,     /* subject GState */
             const RectDWord     * bounds);  /* bounds to be invalidated */
@@ -3014,7 +3014,7 @@ Invalidate the passed rectangular area. This area will be redrawn.
 **Include:** graphics.h 
 
 ----------
-#### GrLabel()
+### GrLabel()
     void    GrLabel(
             GStringHandle   gstate,         /* subject GState */
             word            label);         /* label to write to GString */
@@ -3024,7 +3024,7 @@ Write the passed label into the passed GString.
 **Include:** gstring.h 
 
 ----------
-#### GrLoadGString()
+### GrLoadGString()
     GStringHandle GrLoadGString(
             Handle          han,        /* handle of GString source */
             GStringType     hanType,    /* handle type */
@@ -3045,7 +3045,7 @@ addressed GStrings.
 **Include:** gstring.h 
 
 ----------
-#### GrMapColorIndex()
+### GrMapColorIndex()
     RGBColorAsDWord GrMapColorIndex(
             GStateHandle    gstate,         /* GState to use for mapping */
             Color           c);             /* source color to be mapped */
@@ -3056,7 +3056,7 @@ the passed GState.
 **Include:** graphics.h 
 
 ----------
-#### GrMapColorRGB()
+### GrMapColorRGB()
     RGBColorAsDWord GrMapColorRGB(
             GStateHandle    gstate,         /* GState to use for mapping */
             word            red,            /* RGB values to map */
@@ -3068,7 +3068,7 @@ Map an RGB color to an index.
 **Include:** graphics.h 
 
 ----------
-#### GrMoveReg()
+### GrMoveReg()
     void    GrMoveReg(
             Region  * reg,      /* pointer to region */
             sword   xOffset,    /* amount to shift horizontally */
@@ -3081,7 +3081,7 @@ way for the changes to have any visible effect.
 **Include:** graphics.h 
 
 ----------
-#### GrMoveTo()
+### GrMoveTo()
         void    GrMoveTo(
             GStateHandle    gstate,     /* subject GState */
             sword           x,          /* new absolute pen position */
@@ -3092,7 +3092,7 @@ Change the pen position.
 **Include:** graphics.h 
 
 ----------
-#### GrMulDWFixed()
+### GrMulDWFixed()
     void    GrMulDWFixed(
             const DWFixed   * i,            /* first number */
             const DWFixed   * j,            /* second number */
@@ -3103,7 +3103,7 @@ Multiply two fixed point numbers.
 **Include:** graphics.h 
 
 ----------
-#### GrMulWWFixed()
+### GrMulWWFixed()
     WWFixedAsDWord GrMulWWFixed(
             WWFixedAsDWord  i,          /* first number */
             WWFixedAsDWord  j);         /* second number */
@@ -3113,7 +3113,7 @@ Multiply two fixed point numbers.
 **Include:** graphics.h 
 
 ----------
-#### GrNewPage()
+### GrNewPage()
     void    GrNewPage(
             GStateHandle        gstate,
             PageEndCommand      pageEndCommand);
@@ -3123,7 +3123,7 @@ Begin drawing a new page. Normally used when printing documents.
 **Include:** graphics.h 
 
 ----------
-#### GrNullOp()
+### GrNullOp()
     void    GrNullOp(
             GStateHandle    gstate);        /* subject GState */
 
@@ -3132,7 +3132,7 @@ Write a null operation element to a GString.
 **Include:** graphics.h 
 
 ----------
-#### GrQuickArcSine()
+### GrQuickArcSine()
     WWFixedAsDWord GrQuickArcSine(
             WWFixedAsDWord  deltaYDivDistance,  /* delta y / distance */
             word            origDeltaX);        /* original delta x */
@@ -3143,7 +3143,7 @@ of the positive x axis.
 **Include:** graphics.h 
 
 ----------
-#### GrQuickCosine()
+### GrQuickCosine()
     WWFixedAsDWord GrQuickCosine(
             WWFixedAsDWord  angle);         /* angle to cosine */
 
@@ -3153,7 +3153,7 @@ of the positive x axis.
 **Include:** graphics.h 
 
 ----------
-#### GrQuickSine()
+### GrQuickSine()
     WWFixedAsDWord GrQuickSine(
             WWFixedAsDWord  angle);         /* angle to sine */
 
@@ -3163,7 +3163,7 @@ the positive x axis.
 **Include:** graphics.h 
 
 ----------
-#### GrQuickTangent()
+### GrQuickTangent()
     WWFixedAsDWord GrQuickTangent(
             WWFixedAsDWord  angle);         /* angle to tangent */
 
@@ -3173,7 +3173,7 @@ of the positive x axis.
 **Include:** graphics.h 
 
 ----------
-#### GrReleaseExclusive()
+### GrReleaseExclusive()
     void    GrReleaseExclusive( /* TRUE if system had to force a redraw */
             GeodeHandle     videoDriver,    /* handle of video driver */
             GStateHandle    gstate,         /* GState that was drawing */
@@ -3184,7 +3184,7 @@ Stop drawing exclusively to a video driver.
 **Include:** graphics.h 
 
 ----------
-#### GrRelMoveTo()
+### GrRelMoveTo()
     void    GrRelMoveTo(
             GStateHandle        gstate,     /* subject GState */
             WWFixedAsDWord      x,          /* offsets to new pen position */
@@ -3196,7 +3196,7 @@ position.
 **Include:** graphics.h 
 
 ----------
-#### GrRestoreState()
+### GrRestoreState()
     void    GrRestoreState(
             GStateHandle    gstate);        /* subject GState */
 
@@ -3205,7 +3205,7 @@ Restore the values of a saved GState.
 **Include:**    graphics.h 
 
 ----------
-#### GrSaveState()
+### GrSaveState()
     void    GrSaveState(
             GStateHandle    gstate);        /* subject GState */
 
@@ -3215,7 +3215,7 @@ Save the values of a GState, so that they may be restored by
 **Include:** graphics.h 
 
 ----------
-#### GrSDivDWFByWWF()
+### GrSDivDWFByWWF()
     void GrSDivDWFByWWF(
             const DWFixed       * dividend,
             const WWFixed       * divisor,
@@ -3226,7 +3226,7 @@ Divide two fixed point numbers.
 **Include:** graphics.h 
 
 ----------
-#### GrSDivWWFixed()
+### GrSDivWWFixed()
     WWFixedAsDWord GrSDivWWFixed(
             WWFixedAsDWord  dividend,
             WWFixedAsDWord  divisor)
@@ -3236,7 +3236,7 @@ Divide two fixed point numbers.
 **Include:** graphics.h 
 
 ----------
-#### GrSetAreaAttr()
+### GrSetAreaAttr()
     void    GrSetAreaAttr(
             GStateHandle    gstate,         /* subject GState */
             const AreaAttr  * aa);          /* AreaAttr structure */
@@ -3255,7 +3255,7 @@ Set all of the attributes used when filling areas.
 **Include:** graphics.h 
 
 ----------
-#### GrSetAreaColor()
+### GrSetAreaColor()
     void    GrSetAreaColor(
             GStateHandle    gstate,         /* GState to set color for */
             ColorFlag       flag,           /* flag of how to set color */
@@ -3269,7 +3269,7 @@ Set the color to use when filling areas. The flag parameter may be CF_RGB
 **Include:** graphics.h 
 
 ----------
-#### GrSetAreaColorMap()
+### GrSetAreaColorMap()
     void    GrSetAreaColorMap(
             GStateHandle    gstate,         /* subject GState */
             ColorMapMode    colorMap);      /* color mapping mode */
@@ -3279,7 +3279,7 @@ Set mode to use when trying to fill an area with an unavailable color.
 **Include:** graphics.h 
 
 ----------
-#### GrSetAreaMaskCustom()
+### GrSetAreaMaskCustom()
     void    GrSetAreaMaskCustom(
             GStateHandle        gstate,         /* subject GState */
             const DrawMask      * dm);          /* pointer to new custom mask */
@@ -3289,7 +3289,7 @@ Set the drawing mask to use when filling areas.
 **Include:** graphics.h 
 
 ----------
-#### GrSetAreaMaskSys()
+### GrSetAreaMaskSys()
     void    GrSetAreaMaskSys(
             GStateHandle    gstate,         /* subject GState */
             SystemDrawMask  sysDM);         /* new system area mask */
@@ -3299,7 +3299,7 @@ Set the drawing mask to use when filling areas.
 **Include:** graphics.h 
 
 ----------
-#### GrSetAreaPattern()
+### GrSetAreaPattern()
     void    GrSetAreaPattern(
             GStateHandle    gstate,         /* subject GState */
             GraphicPattern  pattern);       /* new pattern */
@@ -3309,7 +3309,7 @@ Set the graphics pattern to use when filling areas.
 **Include:** graphics.h 
 
 ----------
-#### GrSetBitmapMode()
+### GrSetBitmapMode()
     void    GrSetBitmapMode(
             GStateHandle    gstate,     /* subject GState */
             word            flags,      /* BM_EDIT_MASK or BM_CLUSTERED_DITHER */
@@ -3321,7 +3321,7 @@ turning on clustered dithering.
 **Include:** graphics.h 
 
 ----------
-#### GrSetBitmapRes()
+### GrSetBitmapRes()
     Boolean GrSetBitmapRes(
             GStateHandle    gstate,         /* subject GState */
             word            xRes,           /* new resolutions */
@@ -3332,7 +3332,7 @@ Set a complex bitmap's resolution.
 **Include:** graphics.h 
 
 ----------
-#### GrSetClipPath()
+### GrSetClipPath()
     void    GrSetClipPath(
             GStateHandle        gstate,     /* subject GState */
             PathCombineType     params,     /* how paths should be combined */
@@ -3343,7 +3343,7 @@ Restrict the clipping region by intersecting it with the passed path.
 **Include:** graphics.h 
 
 ----------
-#### GrSetClipRect()
+### GrSetClipRect()
     void    GrSetClipRect(
             GStateHandle        gstate,     /* subject GState */
             PathCombineType     flags,      /* how paths should be combined */
@@ -3357,7 +3357,7 @@ Restrict the clipping region by intersecting it with the passed rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrSetCustomAreaPattern()
+### GrSetCustomAreaPattern()
     void    GrSetCustomAreaPattern(
             GStateHandle    gstate,         /* subject GState */
             GraphicPattern  pattern,        /* new area pattern */
@@ -3369,7 +3369,7 @@ Set the graphics pattern to use when filling areas.
 **Include:** graphics.h 
 
 ----------
-#### GrSetCustomTextPattern()
+### GrSetCustomTextPattern()
     void    GrSetCustomTextPattern(
             GStateHandle    gstate,             /* subject GState */
             GraphicPattern  pattern,            /* new pattern */
@@ -3380,7 +3380,7 @@ Set the graphic pattern used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetDefaultTransform()
+### GrSetDefaultTransform()
     void    GrSetDefaultTransform(
             GStateHandle    gstate);            /* subject GState */
 
@@ -3390,7 +3390,7 @@ transformation.
 **Include: **graphics.h 
 
 ----------
-#### GrSetFont()
+### GrSetFont()
     void    GrSetFont(
             GStateHandle        gstate,         /* subject GState */
             FontID              id,             /* new font ID */
@@ -3401,7 +3401,7 @@ Set the font to use when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetFontWeight()
+### GrSetFontWeight()
     void    GrSetFontWeight(
             GStateHandle    gstate,         /* subject GState */
             FontWeight      weight);        /* new font weight */
@@ -3411,7 +3411,7 @@ Set the font weight to use when drawing text.
 **Include:** font.h 
 
 ----------
-#### GrSetFontWidth()
+### GrSetFontWidth()
     void    GrSetFontWidth(
             GStateHandle    gstate,             /* subject GState */
             FontWidth       width);             /* new font width */
@@ -3421,7 +3421,7 @@ Set the font width to use when drawing text.
 **Include:** font.h 
 
 ----------
-#### GrSetGStringBounds()
+### GrSetGStringBounds()
     void    GrSetGStringBounds(
             Handle      gstate,         /* GState or GString handle */
             sword       left,           /* new bounds of GString */
@@ -3436,7 +3436,7 @@ whenever that routine is called upon the affected GString.
 **Include:** graphics.h 
 
 ----------
-#### GrSetGStringPos()
+### GrSetGStringPos()
     void    GrSetGStringPos(
             GStateHandle        gstate,     /* subject GState */
             GStringSetPosType   type,       /* how to set position */
@@ -3456,7 +3456,7 @@ draw only selected elements of a GString.
 **Include:** gstring.h 
 
 ----------
-#### GrSetLineAttr()
+### GrSetLineAttr()
     void    GrSetLineAttr(
             GStateHandle        gstate,         /* subject GState */
             const LineAttr      * la);          /* new line attributes */
@@ -3466,7 +3466,7 @@ Set all attributes to use when drawing lines and corners.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineColor()
+### GrSetLineColor()
     void    GrSetLineColor(
             GStateHandle    gstate,         /* subject GState */
             ColorFlag       flag,           /* color flag */
@@ -3479,7 +3479,7 @@ Set the color to use when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineColorMap()
+### GrSetLineColorMap()
     void    GrSetLineColorMap(
             GStateHandle    gstate,         /* subject GState */
             ColorMapMode    colorMap);      /* new color map mode for lines */
@@ -3489,7 +3489,7 @@ Set the mode to use when trying to draw lines in an unavailable color.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineEnd()
+### GrSetLineEnd()
     void    GrSetLineEnd(
             GStateHandle    gstate,         /* subject GState */
             LineEnd         end);           /* new line end specification */
@@ -3499,7 +3499,7 @@ Set the end to use when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineJoin()
+### GrSetLineJoin()
     void    GrSetLineJoin(
             GStateHandle    gstate,         /* subject GState */
             LineJoin        join);          /* new line join specification */
@@ -3509,7 +3509,7 @@ Set the line join to use when drawing corners.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineMaskCustom()
+### GrSetLineMaskCustom()
     void    GrSetLineMaskCustom(
             GStateHandle    gstate,         /* subject GState */
             const DrawMask  * dm);          /* new line draw mask */
@@ -3519,7 +3519,7 @@ Set the drawing mask used when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineMaskSys()
+### GrSetLineMaskSys()
     void    GrSetLineMaskSys(
             GStateHandle        gstate,         /* subject GState */
             SystemDrawMask      sysDM);         /* the new system line mask */
@@ -3529,7 +3529,7 @@ Set the drawing mask used when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineStyle()
+### GrSetLineStyle()
     void    GrSetLineStyle(
             GStateHandle        gstate,         /* subject GState */
             LineStyle           style,          /* new line style */
@@ -3542,7 +3542,7 @@ Set the style, or "dottedness," to use when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrSetLineWidth()
+### GrSetLineWidth()
     void    GrSetLineWidth(
             GStateHandle        gstate,         /* subject GState */
             WWFixedAsDWord      width);         /* new line width */
@@ -3552,7 +3552,7 @@ Set the line width to use when drawing lines.
 **Include:** graphics.h 
 
 ----------
-#### GrSetMiterLimit()
+### GrSetMiterLimit()
     void    GrSetMiterLimit(
             GStateHandle        gstate,         /* subject GState */
             WWFixedAsDWord      limit);         /* new miter limit */
@@ -3562,7 +3562,7 @@ Set the miter limit to use when drawing mitered corners.
 **Include:** graphics.h 
 
 ----------
-#### GrSetMixMode()
+### GrSetMixMode()
     void    GrSetMixMode(
             GStateHandle    gstate,             /* subject GState */
             MixMode         mode);              /* new mix mode */
@@ -3573,7 +3573,7 @@ is drawn on top of an existing drawing.
 **Include:** graphics.h 
 
 ----------
-#### GrSetNullTransform()
+### GrSetNullTransform()
     void    GrSetNullTransform(
             GStateHandle    gstate);            /* subject GState */
 
@@ -3584,7 +3584,7 @@ replace the coordinate transformation with the default transformation using
 **Include:** graphics.h 
 
 ----------
-#### GrSetPalette()
+### GrSetPalette()
     void    GrSetPalette(
             GStateHandle    gstate,         /* subject GState */
             SetPalType      type,           /* SPT_DEFAULT or SPT_CUSTOM */
@@ -3597,7 +3597,7 @@ Set one or more entries in a palette, a window's color lookup table.
 **Include:** graphics.h 
 
 ----------
-#### GrSetPaletteEntry()
+### GrSetPaletteEntry()
     void    GrSetPaletteEntry(
             GStateHandle    gstate,     /* subject GState */
             word            index,      /* index in palette to set */
@@ -3610,7 +3610,7 @@ Set one entry in a palette, a GState's color lookup table.
 **Include:** graphics.h 
 
 ----------
-#### GrSetPath()
+### GrSetPath()
     void    GrSetPath(
             GStateHandle    gstate,             /* subject GState */
             MemHandle       pathGString);       /* handle of path's block */
@@ -3621,7 +3621,7 @@ passed handle. To get such a handle, call **GrGetPath()**
 **Include:** graphics.h 
 
 ----------
-#### GrSetPrivateData()
+### GrSetPrivateData()
     void    GrSetPrivateData(
             GStateHandle    gstate,             /* subject GState */
             word            dataAX,             /* data to set */
@@ -3634,7 +3634,7 @@ Set the private data for a GState.
 **Include:** graphics.h 
 
 ----------
-#### GrSetStrokePath()
+### GrSetStrokePath()
     void    GrSetStrokePath(
             GStateHandle    gstate);            /* subject GState */
 
@@ -3645,7 +3645,7 @@ clipping.
 **Include:** graphics.h 
 
 ----------
-#### GrSetSubscriptAttr()
+### GrSetSubscriptAttr()
     void    GrSetSubscriptAttr(
             GStateHandle        gstate,         /* subject GState */
             ScriptAttrAsWord    attrs);         /* new subscript percentages */
@@ -3655,7 +3655,7 @@ Get the attributes used when drawing subscript characters.
 **Include:** font.h 
 
 ----------
-#### GrSetSuperscriptAttr()
+### GrSetSuperscriptAttr()
     void    GrSetSuperscriptAttr(
             GStateHandle        gstate,     /* subject GState */
             ScriptAttrAsWord    attrs);     /* new superscript percentages */
@@ -3665,7 +3665,7 @@ Get the attributes used when drawing superscript characters.
 **Include:** font.h 
 
 ----------
-#### GrSetTextAttr()
+### GrSetTextAttr()
     void    GrSetTextAttr(
             GStateHandle        gstate,     /* subject GState */
             const   TextAttr    * ta);      /* pointer to text attributes */
@@ -3675,7 +3675,7 @@ Set all attributes used when drawing characters and text strings.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextColor()
+### GrSetTextColor()
     void    GrSetTextColor(
             GStateHandle    gstate,         /* subject GState */
             ColorFlag       flag,           /* color flag */
@@ -3688,7 +3688,7 @@ Set the color used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextColorMap()
+### GrSetTextColorMap()
     void    GrSetTextColorMap(
             GStateHandle        gstate,         /* subject GState */
             ColorMapMode        colorMap);      /* new color mapping mode */
@@ -3698,7 +3698,7 @@ Set the mode used when trying to draw text in an unavailable color.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextMaskCustom()
+### GrSetTextMaskCustom()
     void    GrSetTextMaskCustom(
             GStateHandle        gstate,         /* subject GState */
             const DrawMask      * dm);          /* pointer to custom mask */
@@ -3708,7 +3708,7 @@ Set the drawing mask used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextMaskSys()
+### GrSetTextMaskSys()
     void    GrSetTextMaskSys(
             GStateHandle        gstate,         /* subject GState */
             SystemDrawMask      sysDM);         /* new system draw mask */
@@ -3718,7 +3718,7 @@ Set the drawing mask used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextMode()
+### GrSetTextMode()
     void    GrSetTextMode(
             GStateHandle    gstate,             /* subject GState */
             TextMode        bitsToSet,          /* TextMode flags to set */
@@ -3730,7 +3730,7 @@ to change the vertical offset used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextPattern()
+### GrSetTextPattern()
     void    GrSetTextPattern(
             GStateHandle        gstate,         /* subject GState */
             GraphicPattern      pattern);       /* new graphic pattern for text */
@@ -3740,7 +3740,7 @@ Set the graphic pattern used when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextSpacePad()
+### GrSetTextSpacePad()
     void    GrSetTextSpacePad(
             GStateHandle        gstate,         /* subject GState */
             WWFixedAsDWord      padding);       /* new space padding */
@@ -3750,7 +3750,7 @@ Set the space pad used when drawing text strings.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTextStyle()
+### GrSetTextStyle()
     void    GrSetTextStyle(
             GStateHandle    gstate,             /* subject GState */
             TextStyle       bitsToSet,          /* TextStyle flags to set */
@@ -3761,7 +3761,7 @@ Set the style to use when drawing text.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTrackKern()
+### GrSetTrackKern()
     void    GrSetTrackKern(
             GStateHandle    gstate,         /* subject GState */
             word            tk);            /* degree of track kerning */
@@ -3771,7 +3771,7 @@ Set the track kerning to use when drawing text strings.
 **Include:** graphics.h 
 
 ----------
-#### GrSetTransform()
+### GrSetTransform()
     void    GrSetTransform(
             GStateHandle        gstate,         /* subject GState */
             const TransMatrix   * tm);          /* new transformation matrix */
@@ -3781,7 +3781,7 @@ Set the GState's coordinate transformation.
 **Include:** graphics.h 
 
 ----------
-#### GrSetVMFile()
+### GrSetVMFile()
     void    GrSetVMFile(
             GStateHandle    gstate,         /* subject GState */
             VMFileHandle    vmFile);        /* new transformation matrix */
@@ -3792,7 +3792,7 @@ with certain kinds of bitmaps and GStrings).
 **Include:** graphics.h 
 
 ----------
-#### GrSetWinClipPath()
+### GrSetWinClipPath()
     void    GrSetWinClipPath(
             GStateHandle        gstate,         /* subject GState */
             PathCombineType     params,         /* how paths are combined */
@@ -3803,7 +3803,7 @@ Restrict the window's clipping region by intersecting it with the passed path.
 **Include:** graphics.h 
 
 ----------
-#### GrSetWinClipRect()
+### GrSetWinClipRect()
     void    GrSetWinClipRect(
             GStateHandle        gstate,     /* subject GState */
             PathCombineType     flags,      /* how paths are combined */
@@ -3818,7 +3818,7 @@ rectangle.
 **Include:** graphics.h 
 
 ----------
-#### GrSqrRootWWFixed()
+### GrSqrRootWWFixed()
     WWFixedAsDWord GrSqrRootWWFixed(
             WWFixedAsDWord  i);         /* number to get the square root of */
 
@@ -3827,7 +3827,7 @@ Compute the square root of a fixed point number.
 **Include:** graphics.h 
 
 ----------
-#### GrTestPath()
+### GrTestPath()
     Boolean GrTestPath(
             GStateHandle    gstate,         /* subject GState */
             GetPathType     ptype);         /* Type of path to check for */
@@ -3837,7 +3837,7 @@ Determine whether the GState has a path of the specified type.
 **Include:** graphics.h 
 
 ----------
-#### GrTestPointInPath()
+### GrTestPointInPath()
     Boolean GrTestPointInPath(
             GStateHandle    gstate,             /* subject GState */
             word            xPos,               /* point to test */
@@ -3849,7 +3849,7 @@ Determine whether the passed point falls in the interior of the GState's path.
 **Include:** graphics.h 
 
 ----------
-#### GrTestPointInPolygon()
+### GrTestPointInPolygon()
     Boolean GrTestPointInPolygon(
             GStateHandle    gstate,         /* subject GState */
             RegionFillRule  rule,           /* ODD_EVEN or WINDING */
@@ -3864,7 +3864,7 @@ polygon.
 **Include:** graphics.h 
 
 ----------
-#### GrTestPointInReg()
+### GrTestPointInReg()
     Boolean     GrTestPointInReg( 
             const Region    * reg,          /* pointer to region */
             sword           x,              /* coordinates of point to test */
@@ -3878,7 +3878,7 @@ in the region, the return value is *true*.
 **Include:** graphics.h 
 
 ----------
-#### GrTestRectInReg()
+### GrTestRectInReg()
     TestRectReturnType GrTestRectInReg( 
             const Region    * reg       /* pointer to region */
             sword           left,       /* bounds of rectangle to be tested */
@@ -3898,7 +3898,7 @@ Determine whether a rectangle lies within the clip region.
 **Include:** graphics.h 
 
 ----------
-#### GrTextWidth()
+### GrTextWidth()
     word    GrTextWidth(
             GStateHandle    gstate,         /* subject GState */
             const Chars     * str,          /* text string to check */
@@ -3911,7 +3911,7 @@ Compute the space the passed text string would require in a line of text. Use
 **Include:** graphics.h 
 
 ----------
-#### GrTextWidthWWFixed()
+### GrTextWidthWWFixed()
     WWFixedAsDWord  GrTextWidthWWFixed( /* returns width << 16 */
             GStateHandle    gstate,         /* subject GState */
             const Chars     * str,          /* text string to check */
@@ -3925,7 +3925,7 @@ area necessary to render the text.
 **Include:** graphics.h 
 
 ----------
-#### GrTransform()
+### GrTransform()
     XYValueAsDWord  GrTransform(
             GStateHandle    gstate,         /* subject GState */
             sword           xCoord,         /* coordinates to transform */
@@ -3936,7 +3936,7 @@ Apply the device's transformation to the passed point.
 **Include:** graphics.h 
 
 ----------
-#### GrTransformDWFixed()
+### GrTransformDWFixed()
     void    GrTransformDWFixed(
             GStateHandle    gstate,         /* subject GState */
             PointDWFixed    * coord);       /* coordinates to transform */
@@ -3946,7 +3946,7 @@ Apply the device's transformation to the passed point.
 **Include:** graphics.h 
 
 ----------
-#### GrTransformDWord()
+### GrTransformDWord()
     void    GrTransformDWord(
             GStateHandle    gstate,         /* subject GState */
             sdword          xCoord,         /* coordinates to transform */
@@ -3959,7 +3959,7 @@ Apply the device's transformation to the passed point.
 **Include:** graphics.h 
 
 ----------
-#### GrTransformWWFixed()
+### GrTransformWWFixed()
     void    GrTransformWWFixed(
             GStateHandle    gstate,             /* subject GState */
             WWFixedAsDWord  xPos,               /* coordinates to transform */
@@ -3972,7 +3972,7 @@ Apply the device's transformation to the passed point.
 **Include:** graphics.h 
 
 ----------
-#### GrUDivWWFixed()
+### GrUDivWWFixed()
     WWFixedAsDWord GrUDivWWFixed(
             WWFixedAsDWord      dividend,
             WWFixedAsDWord      divisor);
@@ -3982,7 +3982,7 @@ Compute an unsigned division of two fixed point numbers.
 **Include:** graphics.h 
 
 ----------
-#### GrUntransform()
+### GrUntransform()
     XYValueAsDWord GrUnTransformCoord(
             GStateHandle    gstate,         /* subject GState */
             sword           xCoord,         /* coordinates to untransform */
@@ -3993,7 +3993,7 @@ Apply the reverse of the device's transformation to the passed point.
 **Include:** graphics.h 
 
 ----------
-#### GrUntransformDWFixed()
+### GrUntransformDWFixed()
     void    GrUnTransCoordDWFixed(
             GStateHandle    gstate,         /* subject GState */
             PointDWFixed    * coord);       /* coordinates to untransform */
@@ -4003,7 +4003,7 @@ Apply the reverse of the device's transformation to the passed point.
 **Include:** graphics.h 
 
 ----------
-#### GrUntransformDWord()
+### GrUntransformDWord()
     void    GrUnTransformExtCoord(
             GStateHandle    gstate,         /* subject GState */
             sdword          xCoord,         /* coordinates to untransform */
@@ -4016,7 +4016,7 @@ Apply the reverse of the device's transformation to the passed point.
 **Include:** graphics.h 
 
 ----------
-#### GrUntransformWWFixed()
+### GrUntransformWWFixed()
     void    GrUnTransCoordWWFixed(
             GStateHandle        gstate,         /* subject GState */
             WWFixedAsDWord      xPos,           /* coordinates to untransform */

--- a/TechDocs/Markdown/Routines/rrouth_l.md
+++ b/TechDocs/Markdown/Routines/rrouth_l.md
@@ -1,6 +1,6 @@
 ## 3.4 Routines H-L
 ----------
-#### HAL_COUNT()
+### HAL_COUNT()
     word    HAL_COUNT(
             dword   val);
 
@@ -9,7 +9,7 @@ word of the **HugeArrayLock()** return value. This is the number of elements
 in the Huge Array block after the locked one (counting that locked one).
 
 ----------
-#### HAL_PREV
+### HAL_PREV
     word    HAL_PREV(
             dword   val);
 
@@ -18,7 +18,7 @@ word of the **HugeArrayLock()** return value. This is the number of elements
 in the Huge Array block before the locked one (counting that locked one).
 
 ----------
-#### HandleModifyOwner()
+### HandleModifyOwner()
     void    HandleModifyOwner(
             MemHandle       mh,         /* Handle of block to modify */
             GeodeHandle     owner);     /* Handle of block's new owner */
@@ -36,7 +36,7 @@ ownership.
 **See Also:** MemGetInfo(), MemModifyFlags(), MemModifyOtherInfo()
 
 ----------
-#### HandleP()
+### HandleP()
     void    HandleP(
             MemHandle       mh);        /* Handle of block to grab */
 
@@ -78,7 +78,7 @@ non-sharable block owned by another thread, **HandleP()** will fatal-error.
 **See Also:** HandleV(), MemPLock(), MemUnlockV()
 
 ----------
-#### HandleToOptr()
+### HandleToOptr()
     optr    HandleToOptr(
             Handle  han;
 
@@ -88,7 +88,7 @@ the resultant optr to be zero.
 **See Also:** ConstructOptr(), OptrToHandle(), OptrToChunk()
 
 ----------
-#### HandleV()
+### HandleV()
     void    HandleV(
             MemHandle       mh);        /* Handle of block to grab */
 
@@ -125,7 +125,7 @@ and returns.
 **See Also:** HandleP(), MemPLock(), MemUnlockV()
 
 ----------
-#### HugeArrayAppend()
+### HugeArrayAppend()
     void    HugeArrayAppend(
             VMFileHandle        file,
             VMBlockhandle       vmBlock,    /* Handle of directory block */
@@ -143,7 +143,7 @@ a single element; this element will be *numElem* bytes long.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayCompressBlocks()
+### HugeArrayCompressBlocks()
     void    HugeArrayCompressBlocks(
             VMFileHandle    vmFile,         /* File containing Huge Array */
             VMBlockHandle   vmBlock);       /* handle of directory block */
@@ -155,7 +155,7 @@ in the Huge Array.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayContract()
+### HugeArrayContract()
     word    HugeArrayContract(
             void **     elemPtr,        /* **elemPtr is first element to
                                          * delete */
@@ -169,7 +169,7 @@ necessary.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayCreate()
+### HugeArrayCreate()
     VMBlockhandle   HugeArrayCreate(
             VMFileHandle    vmFile,         /* Create in this VM file */
             word            elemSize,       /* Pass zero for variable-size
@@ -182,7 +182,7 @@ returns the handle of the Huge Array's directory block.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayDelete()
+### HugeArrayDelete()
     void    HugeArrayDelete(
             VMFileHandle    vmFile,
             VMBlockHandle   vmBlock,    /* handle of directory block */
@@ -195,7 +195,7 @@ and frees blocks as necessary.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayDirty()
+### HugeArrayDirty()
     void    HugeArrayDirty(
             const void *    elemPtr);       /* Element in dirty block */
 
@@ -208,7 +208,7 @@ pointer to anywhere in a dirty element; that element's block will be dirtied.
 block may be discarded before you can dirty it.
 
 ----------
-#### HugeArrayDestroy()
+### HugeArrayDestroy()
     void    HugeArrayDestroy(
             VMFileHandle    vmFile,
             VMBlockHandle   vmBlock);       /* Handle of directory block */
@@ -218,7 +218,7 @@ This routine destroys a HugeArray by freeing all of its blocks.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayEnum()
+### HugeArrayEnum()
     Boolean HugeArrayEnum(
             VMFileHandle    vmFile,         /* subject to override */
             VMBlockHandle   vmBlock,        /* Handle of the Huge Array's directory
@@ -267,7 +267,7 @@ The starting element must be an element in the array. If you pass a starting
 index which is out-of-bounds, the results are undefined.
 
 ----------
-#### HugeArrayExpand()
+### HugeArrayExpand()
     word    HugeArrayExpand(
             void **         elemPtr,    /* **elemPtr is element at location
                                          * where new elements will be
@@ -288,7 +288,7 @@ this element will be *numElem* bytes long.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayGetCount()
+### HugeArrayGetCount()
     dword   HugeArrayGetCount(
             VMFileHandle        vmFile,
             VMBlockHandle       vmBlock);   /* Handle of directory block */
@@ -298,7 +298,7 @@ This routine returns the number of elements in a Huge Array.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayInsert()
+### HugeArrayInsert()
     void    HugeArrayInsert(
             VMFileHandle    vmFile,
             VMBlockHandle   vmBlock,    /* Handle of directory block */
@@ -318,7 +318,7 @@ this element will be *numElem* bytes long.
 **Include:** heap.h
 
 ----------
-#### HugeArrayLock()
+### HugeArrayLock()
     dword   HugeArrayLock(
             VMFileHandle    vmFile,
             VMBlockhandle   vmBlock,        /* Handle of directory block */
@@ -340,7 +340,7 @@ elements in the block without making further calls to **HugeArrayLock()**.
 **See Also:** HAL_COUNT(), HAL_PREV()
 
 ----------
-#### HugeArrayNext()
+### HugeArrayNext()
     word    HugeArrayNext(
             void **     elemPtr);
 
@@ -358,7 +358,7 @@ the element, writes a null pointer to **elemPtr*, and returns zero.
 if you need to mark the block as dirty, do so before making this call.
 
 ----------
-#### HugeArrayPrev()
+### HugeArrayPrev()
     word    HugeArrayPrev(
             void **     elemPtr1,       /* indicates current element */
             void **     elemPtr2);
@@ -379,7 +379,7 @@ returns zero.
 if you need to mark the block as dirty, do so before making this call.
 
 ----------
-#### HugeArrayReplace()
+### HugeArrayReplace()
     void    HugeArrayReplace(
             VMFileHandle    file,
             VMBlockHandle   vmblock,        /* Handle of directory block */
@@ -398,7 +398,7 @@ size will be *enumData* bytes long.
 **See Also:** HugeArrayResize()
 
 ----------
-#### HugeArrayResize()
+### HugeArrayResize()
     void    HugeArrayResize(
             VMFileHandle    vmFile,
             VMBlockHandle   vmBlock,        /* Handle of directory block */
@@ -412,7 +412,7 @@ will be zero-initialized. If it is smaller, the element will be truncated.
 **Include:** hugearr.h
 
 ----------
-#### HugeArrayUnlock()
+### HugeArrayUnlock()
     void    HugeArrayUnlock(
             void *      elemPtr);
 
@@ -426,7 +426,7 @@ element.
 be discarded.
 
 ----------
-#### IACPConnect()
+### IACPConnect()
     IACPConnection IACPConnect(
             GeodeToken          *list, 
             IACPConnectFlags    flags, 
@@ -444,7 +444,7 @@ IACPCF_CLIENT_OD_SPECIFIED flag is set in the flags parameter.
 **Include:** iacp.goh
 
 ----------
-#### IACPCreateDefaultLaunchBlock()
+### IACPCreateDefaultLaunchBlock()
     MemHandle IACPCreateDefaultLaunchBlock(
             word        appMode);
 
@@ -456,7 +456,7 @@ MSG_GEN_PROCESS_OPEN_ENGINE.
 **Include:** iacp.goh
 
 ----------
-#### IACPFinishConnect()
+### IACPFinishConnect()
     void    IACPFinishConnect(
             IACPConnection      connection,
             optr                server);
@@ -467,7 +467,7 @@ non-interactible to interactible.
 **Include:** iacp.goh
 
 ----------
-#### IACPLostConnection()
+### IACPLostConnection()
     void IACPLostConnection(
             optr                oself, 
             IACPConnection      connection);
@@ -478,7 +478,7 @@ connection.
 **Include:** iacp.goh
 
 ----------
-#### IACPProcessMessage()
+### IACPProcessMessage()
     void IACPProcessMessage(
             optr                oself, 
             EventHandle         msgToSend, 
@@ -491,7 +491,7 @@ object by an IACP connection.
 **Include:** iacp.goh
 
 ----------
-#### IACPRegisterDocument()
+### IACPRegisterDocument()
     void IACPRegisterDocument(
             optr    server,
             word    disk,
@@ -506,7 +506,7 @@ connect to a server that is not the creator of the document in question.
 **Include:** iacp.goh
 
 ----------
-#### IACPRegisterServer()
+### IACPRegisterServer()
     void    IACPRegisterServer(
             GeodeToken          *list, 
             optr                server,
@@ -519,7 +519,7 @@ by the passed token.
 **Include:** iacp.goh
 
 ----------
-#### IACPSendMessage()
+### IACPSendMessage()
     word IACPSendMessage(
             IACPConnection      connection, 
             EventHandle         msgToSend, 
@@ -533,7 +533,7 @@ an IACP connection.
 **Include:** iacp.goh
 
 ----------
-#### IACPSendMessageToServer()
+### IACPSendMessageToServer()
     word IACPSendMessageToServer(
             IACPConnection      connection, 
             EventHandle         msgToSend, 
@@ -547,7 +547,7 @@ connection.
 **Include:** iacp.goh
 
 ----------
-#### IACPShutdown()
+### IACPShutdown()
     void IACPShutdown(
             IACPConnection      connection, 
             optr                serverOD);
@@ -557,7 +557,7 @@ This routine removes a server or client from an IACP connection.
 **Include:** iacp.goh
 
 ----------
-#### IACPShutdownAll()
+### IACPShutdownAll()
     void IACPShutdownAll(
             optr    obj);
 
@@ -568,7 +568,7 @@ application is exiting.
 **Include:** iacp.goh
 
 ----------
-#### IACPUnregisterDocument()
+### IACPUnregisterDocument()
     void IACPUnregisterDocument(
             optr    server,
             word    disk,
@@ -579,7 +579,7 @@ This routine unregisters an open document and the server object for it.
 **Include:** iacp.goh
 
 ----------
-#### IACPUnregisterServer()
+### IACPUnregisterServer()
     void IACPUnregisterServer(
             GeodeToken      *token, 
             optr        object);
@@ -589,7 +589,7 @@ This removes the specified server object from the indicated IACP server list.
 **Include:** iacp.goh
 
 ----------
-#### ImpexCreateTempFile()
+### ImpexCreateTempFile()
     TransError ImpexCreateTempFile(
             char *          buffer,
             word            fileType,
@@ -635,7 +635,7 @@ contain a random value. Do not use **errString* if the routine did not return
 TE_CUSTOM.
 
 ----------
-#### ImpexDeleteTempFile()
+### ImpexDeleteTempFile()
     TransError ImpexDeleteTempFile(
             const char *        buffer,
             FileHandle          tempFile,
@@ -671,7 +671,7 @@ contain a random value. Do not use **errString* if the routine did not return
 TE_CUSTOM.
 
 ----------
-#### ImpexExportToMetafile()
+### ImpexExportToMetafile()
     TransError  ImpexExportToMetafile(
             Handle          xlatLib,
             VMFileHandle    xferFile,
@@ -692,7 +692,7 @@ contain a random value. Do not use **errString* if the routine did not return
 TE_CUSTOM.
 
 ----------
-#### ImpexImportExportCompleted()
+### ImpexImportExportCompleted()
     void    ImpexImportExportCompleted(
             ImpexTranslationParams *        itParams);
 
@@ -714,7 +714,7 @@ an output file. Therefore, an application should not call this routine
 until it is absolutely finished with the transfer file.
 
 ----------
-#### ImpexImportFromMetafile()
+### ImpexImportFromMetafile()
     TransError  ImpexExportToMetafile(
             Handle          xlatLib,
             VMFileHandle    xferFile,
@@ -735,7 +735,7 @@ contain a random value. Do not use **errString* if the routine did not return
 TE_CUSTOM.
 
 ----------
-#### InitFileCommit()
+### InitFileCommit()
     void    InitFileCommit(void);
 
 This routine commits any changes to the GEOS.INI file, removing and 
@@ -745,7 +745,7 @@ the file during the commit operation.
 **Include:** initfile.h
 
 ----------
-#### InitFileDeleteCategory()
+### InitFileDeleteCategory()
     void    InitFileDeleteCategory(
             const char      *category);
 
@@ -759,7 +759,7 @@ case-insensitive.
 **Include:** initfile.h
 
 ----------
-#### InitFileDeleteEntry()
+### InitFileDeleteEntry()
     void    InitFileDeleteEntry(
             const char      *category,
             const char      *key);
@@ -776,7 +776,7 @@ be deleted.
 **Include:** initfile.h
 
 ----------
-#### InitFileDeleteStringSection()
+### InitFileDeleteStringSection()
     void    InitFileDeleteStringSection(
             const char *        category,
             const char *        key,
@@ -797,7 +797,7 @@ stringNum - The zero-based string section number.
 **Include:** initfile.h
 
 ----------
-#### InitFileEnumStringSection()
+### InitFileEnumStringSection()
     Boolean InitFileEnumStringSection(
             const char *            category,
             const char *            key,
@@ -852,7 +852,7 @@ processed.
 **Include:** initfile.h
 
 ----------
-#### InitFileGetTimeLastModified()
+### InitFileGetTimeLastModified()
     dword   InitFileGetTimeLastModified(void);
 
 This routine returns the time when the GEOS.INI file was last modified. The 
@@ -862,7 +862,7 @@ written.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadBoolean()
+### InitFileReadBoolean()
     Boolean InitFileReadBoolean(
             const char *        category,
             const char *        key,
@@ -895,7 +895,7 @@ file. That value is returned in the Boolean pointed to by *bool*.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadDataBlock()
+### InitFileReadDataBlock()
     Boolean InitFileReadDataBlock(
             const char *        category,
             const char *        key,
@@ -931,7 +931,7 @@ not be found; it will be *false* otherwise.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadDataBuffer()
+### InitFileReadDataBuffer()
     Boolean InitFileReadDataBuffer(
             const char *        category,
             const char *        key,
@@ -970,7 +970,7 @@ not be found; it will be *false* otherwise.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadInteger()
+### InitFileReadInteger()
     Boolean InitFileReadInteger(
             const char *        category,
             const char *        key,
@@ -999,7 +999,7 @@ not be found; it will be *false* otherwise.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadStringBlock()
+### InitFileReadStringBlock()
     Boolean InitFileReadStringBlock(
             const char *        category,
             const char *        key,
@@ -1041,7 +1041,7 @@ not be found; it will be *false* otherwise.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadStringBuffer()
+### InitFileReadStringBuffer()
     Boolean InitFileReadStringBuffer(
             const char *        category,
             const char *        key,
@@ -1082,7 +1082,7 @@ not be found; it will be *false* otherwise.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadStringSectionBlock()
+### InitFileReadStringSectionBlock()
     Boolean InitFileReadStringSectionBlock(
             const char *        category,
             const char *        key,
@@ -1126,7 +1126,7 @@ not be found; it will be *false* otherwise.
 **Include:** initfile.h
 
 ----------
-#### InitFileReadStringSectionBuffer()
+### InitFileReadStringSectionBuffer()
     Boolean InitFileReadStringSectionBuffer(
             const char *        category,
             const char *        key,
@@ -1172,7 +1172,7 @@ not be found; it will be *false* otherwise.
 **Include:** initfile.h
 
 ----------
-#### InitFileRevert()
+### InitFileRevert()
     Boolean InitFileRevert(void);
 
 This routine restores the GEOS.INI file from its saved backup version. It 
@@ -1183,7 +1183,7 @@ file; *false* indicates success.
 **Include:** initfile.h
 
 ----------
-#### InitFileSave()
+### InitFileSave()
     Boolean InitFileSave(void);
 
 This routine saves the GEOS.INI file synchronously by updating the backup 
@@ -1195,7 +1195,7 @@ represents an error in trying to save the file; *false* indicates success.
 **Include:** initfile.h
 
 ----------
-#### InitFileWriteBoolean()
+### InitFileWriteBoolean()
     void    InitFileWriteBoolean(
             const char *        category,
             const char *        key,
@@ -1220,7 +1220,7 @@ Once written, the Boolean value can be read with **InitFileReadBoolean()**.
 **Include:** initfile.h
 
 ----------
-#### InitFileWriteData()
+### InitFileWriteData()
     void    InitFileWriteData(
             const char      *category,
             const char      *key,
@@ -1248,7 +1248,7 @@ Once data has been written to the INI file, it can be read with
 **Include:** initfile.h
 
 ----------
-#### InitFileWriteInteger()
+### InitFileWriteInteger()
     void    InitFileWriteInteger(
             const char      *category,
             const char      *key,
@@ -1271,7 +1271,7 @@ The integer, once written, can be read with **InitFileReadInteger()**.
 **Include:** initfile.h
 
 ----------
-#### InitFileWriteString()
+### InitFileWriteString()
     void    InitFileWriteString(
             const char      *category,
             const char      *key,
@@ -1299,7 +1299,7 @@ or **InitFileReadStringBuffer()**.
 **Include:** initfile.h
 
 ----------
-#### InitFileWriteStringSection()
+### InitFileWriteStringSection()
     void    InitFileWriteStringSection(
             const char      *category,
             const char      *key,
@@ -1326,7 +1326,7 @@ Once written, the segment may be read with
 **Include:** initfile.h
 
 ----------
-#### InkDBGetDisplayInfo()
+### InkDBGetDisplayInfo()
     void    InkDBGetDisplayInfo(
             InkDBDisplayInfo *      retVal,
             VMFileHandle            fh);
@@ -1346,7 +1346,7 @@ folder, and the page number, if applicable.
 **Include:** pen.goh
 
 ----------
-#### InkDBGetHeadFolder()
+### InkDBGetHeadFolder()
     dword   InkDBGetHeadFolder(
             VMFileHandle        fh);
 
@@ -1355,7 +1355,7 @@ This routine returns the dword ID of the head folder of an Ink Database file.
 **Include:** pen.goh
 
 ----------
-#### InkDBInit()
+### InkDBInit()
     void    InkDBInit(
             VMFileHandle        fh);
 
@@ -1365,7 +1365,7 @@ creating all needed maps and a top-level folder.
 **Include:** pen.goh
 
 ----------
-#### InkDBSetDisplayInfo()
+### InkDBSetDisplayInfo()
     void    InkDBSetDisplayInfo(
             VMFileHandle    fh,
             dword           ofh,    /* Parent Folder dword ID# */
@@ -1381,7 +1381,7 @@ a note.
 **Include:** pen.goh
 
 ----------
-#### InkFolderCreateSubFolder()
+### InkFolderCreateSubFolder()
     dword   InkFolderCreateSubFolder(
             dword           tag,    /* ID# of parent folder (0 for top-level) */
             VMFileHandle    fh);    /* Handle of Ink DB file */
@@ -1393,7 +1393,7 @@ folder's dword ID number.
 **Include:** pen.goh
 
 ----------
-#### InkFolderDelete()
+### InkFolderDelete()
     void    InkFolderDelete(
             dword           tag,        /* ID# of folder */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1403,7 +1403,7 @@ This routine removes an Ink Database folder.
 **Include:** pen.goh
 
 ----------
-#### InkFolderDepthFirstTraverse()
+### InkFolderDepthFirstTraverse()
     word    InkFolderDepthFirstTraverse(
             dword           rfldr,      /* ID# of folder at root of search tree */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1421,7 +1421,7 @@ search will return *false*.
 **Include:** pen.goh
 
 ----------
-#### InkFolderDisplayChildInList()
+### InkFolderDisplayChildInList()
     void    InkFolderDisplayChildInList(
             dword           fldr,       /* ID# of folder */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1436,7 +1436,7 @@ children. It is normally called in an applications *GDLI_queryMsg* handler.
 **Include:** pen.goh
 
 ----------
-#### InkFolderGetChildInfo()
+### InkFolderGetChildInfo()
     Boolean     InkFolderDisplayChildInfo( /* true if folder; else note */
             dword           fldr,       /* ID# of folder */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1450,7 +1450,7 @@ addition, the passed dword pointer will point to the child's dword ID number.
 **Include:** pen.goh
 
 ----------
-#### InkFolderGetChildNumber()
+### InkFolderGetChildNumber()
     word    InkFolderDisplayChildInList( 
             dword           fldr,       /* ID# of folder */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1462,7 +1462,7 @@ passed parent folder.
 **Include:** pen.goh
 
 ----------
-#### InkFolderGetContents()
+### InkFolderGetContents()
     DBGroupAndItem  InkFolderGetContents(
             dword               tag,            /* ID# of folder */
             VMFileHandle        fh,             /* Handle of Ink DB file */
@@ -1477,7 +1477,7 @@ ID numbers of the subfolders.
 **Include:** pen.goh
 
 ----------
-#### InkFolderGetNumChildren()
+### InkFolderGetNumChildren()
     dword   InkFolderGetNumChildren( /* Subfolders:Notes */
             dword           fldr,       /* ID# of folder */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1489,7 +1489,7 @@ word holds the number of notes.
 **Include:** pen.goh
 
 ----------
-#### InkFolderMove()
+### InkFolderMove()
     void    InkFolderMove(
             dword       fldr,       /* ID# of folder to move */
             dword       pfldr);     /* ID# of new parent folder */
@@ -1500,7 +1500,7 @@ tree.
 **Include:** pen.goh
 
 ----------
-#### InkFolderSetTitle()
+### InkFolderSetTitle()
     void    InkFolderSetTitle(
             dword           tag,        /* ID# of folder */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1512,7 +1512,7 @@ null-terminated.
 **Include:** pen.goh
 
 ----------
-#### InkFolderSetTitleFromTextObject()
+### InkFolderSetTitleFromTextObject()
     void    InkFolderSetTitleFromTextObject(
             dword       tag,        /* ID# of folder */
             FileHandle  fh,         /* Handle of Ink DB file */
@@ -1524,7 +1524,7 @@ contents of the passed VisText object.
 **Include:** pen.goh
 
 ----------
-#### InkGetDocPageInfo()
+### InkGetDocPageInfo()
     void    InkGetDocPageInfo(
             PageSizeReport *    psr,    /* Structure to fill with return value */
             VMFileHandle        fh);
@@ -1534,7 +1534,7 @@ This routine returns the dword ID of the head folder of an Ink Database file.
 **Include:** pen.goh
 
 ----------
-#### InkGetDocCustomGString()
+### InkGetDocCustomGString()
     GStateHandle    InkGetDocCustomGString(
             VMFileHandle        dbfh);
 
@@ -1546,7 +1546,7 @@ determined using the **InkDBSetDocGString()** routine.
 **Include:** pen.goh
 
 ----------
-#### InkGetDocGString()
+### InkGetDocGString()
     InkBackgroundType   InkGetDocGString(
             VMFileHandle        dbfh);
 
@@ -1557,7 +1557,7 @@ be sure to also call **InkGetDocCustomGString()**.
 **Include:** pen.goh
 
 ----------
-#### InkGetParentFolder()
+### InkGetParentFolder()
     dword   InkGetParentFolder(
             dword           tag,        /* ID# of folder or note */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1567,7 +1567,7 @@ This message returns the dword ID of the passed Ink Database note or folder.
 **Include:** pen.goh
 
 ----------
-#### InkGetTitle()
+### InkGetTitle()
     word    InkGetTitle(
             dword           tag,        /* ID# of folder or note */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1580,7 +1580,7 @@ string (including the terminator).
 **Include:** pen.goh
 
 ----------
-#### InkNoteCopyMoniker()
+### InkNoteCopyMoniker()
     dword   InkNoteCopyMoniker(
             dword   title,      /* ID# of parent folder */
             optr    list,       /* Output list */
@@ -1594,7 +1594,7 @@ This routine copies the icon and title into the VisMoniker.
 **Include:** pen.goh
 
 ----------
-#### InkNoteCreate()
+### InkNoteCreate()
     dword   InkNoteCreate(
             dword           tag,        /* ID# of parent folder */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1605,7 +1605,7 @@ new note's dword ID is returned.
 **Include:** pen.goh
 
 ----------
-#### InkNoteCreatePage()
+### InkNoteCreatePage()
     word    InkNoteCreatePage(
             dword           tag,    /* ID# of note */
             VMFileHandle    fh,     /* Handle of Ink DB file */
@@ -1618,7 +1618,7 @@ number.
 **Include:** pen.goh
 
 ----------
-#### InkNoteDelete()
+### InkNoteDelete()
     void    InkNoteDelete(
             dword           tag,        /* ID# of note */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1628,7 +1628,7 @@ This message deletes the passed note. All references to the note are deleted.
 **Include:** pen.goh
 
 ----------
-#### InkNoteFindByKeywords()
+### InkNoteFindByKeywords()
     ChunkHandle     InkNoteFindByKeywords( 
                         /* Return value is chunk array with elements:
                          *  FindNoteHeader
@@ -1653,7 +1653,7 @@ match, only the first 20K will be returned.
 **Include:** pen.goh
 
 ----------
-#### InkNoteFindByTitle()
+### InkNoteFindByTitle()
     ChunkHandle     InkNoteFindByTitle( 
                         /* Return value is chunk array with elements:
                          *  FindNoteHeader
@@ -1678,7 +1678,7 @@ match, only the first 20K will be returned.
 **Include:** pen.goh
 
 ----------
-#### InkNoteGetCreationDate()
+### InkNoteGetCreationDate()
     dword   InkNoteGetCreationDate( 
             dword           tag,        /* ID# of note */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1688,7 +1688,7 @@ This routine gets a note's creation date.
 **Include:** pen.goh
 
 ----------
-#### InkNoteGetKeywords()
+### InkNoteGetKeywords()
     void    InkNoteGetKeywords(
             dword           tag,        /* ID# of note */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1701,7 +1701,7 @@ The string will be null-terminated.
 **Include:** pen.goh
 
 ----------
-#### InkNoteGetModificationDate()
+### InkNoteGetModificationDate()
     dword   InkNoteGetModificationDate( 
             dword           tag,        /* ID# of note */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1711,7 +1711,7 @@ This routine gets a note's modification date.
 **Include:** pen.goh
 
 ----------
-#### InkNoteGetNoteType()
+### InkNoteGetNoteType()
     NoteType    InkNoteGetNoteType( /* 0: Ink, 1: Text */
             dword           tag,        /* ID# of note */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1721,7 +1721,7 @@ This routine gets a note's **NoteType**: NT_INK or NT_TEXT.
 **Include:** pen.goh
 
 ----------
-#### InkNoteGetNumPages()
+### InkNoteGetNumPages()
     word    InkNoteGetNumPages(
             dword       tag);       /* ID# of note */
 
@@ -1730,7 +1730,7 @@ This routine returns the number of pages within the passed note.
 **Include:** pen.goh
 
 ----------
-#### InkNoteGetPages()
+### InkNoteGetPages()
     DBGroupAndItem  InkNoteGetPages(
             dword           tag,        /* ID# of note */
             VMFileHandle    fh);        /* Handle of Ink DB file */
@@ -1742,7 +1742,7 @@ pen data or text. Each array element holds one page of data.
 **Include:** pen.goh
 
 ----------
-#### InkNoteLoadPage()
+### InkNoteLoadPage()
     void    InkNoteLoadPage(
             dword           tag,        /* ID# of note */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1756,7 +1756,7 @@ Ink Database page. Be sure to load only the correct type of data into an object.
 **Include:** pen.goh
 
 ----------
-#### InkNoteMove()
+### InkNoteMove()
     void    InkNoteMove(
             dword           tag,        /* ID# of note */
             dword           pfolder,    /* ID# of new parent folder */
@@ -1768,7 +1768,7 @@ note are suitably altered.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSavePage()
+### InkNoteSavePage()
     void    InkNoteSavePage(
             dword           tag,        /* ID# of note */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1782,7 +1782,7 @@ Ink Database page.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSendKeywordsdToTextObject()
+### InkNoteSendKeywordsdToTextObject()
     void    InkNoteSendKeywordsToTextObject(
             dword           tag,        /* ID# of note */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1794,7 +1794,7 @@ from the passed folder or note of an Ink Database file.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSetKeywords()
+### InkNoteSetKeywords()
     void    InkNoteSetKeywords(
             dword           tag,            /* ID# of note */
             VMFileHandle    fh,             /* Handle of Ink DB file */
@@ -1806,7 +1806,7 @@ should be null-terminated.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSetKeywordsFromTextObject()
+### InkNoteSetKeywordsFromTextObject()
     void    InkNoteSetKeywordsFromTextObject(
             dword           tag,            /* ID# of note */
             VMFileHandle    fh,             /* Handle of Ink DB file */
@@ -1818,7 +1818,7 @@ passed text object.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSetModificationDate()
+### InkNoteSetModificationDate()
     void    InkNoteSetModificationDate( 
             word            tdft1,      /* First two words of */
             word            tdft2,      /* TimerDateAndTime structure */
@@ -1830,7 +1830,7 @@ This routine sets a note's modification date.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSetNoteType()
+### InkNoteSetNoteType()
     void    InkNoteSetNoteType( 
             dword           tag,        /* ID# of note */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1841,7 +1841,7 @@ This routine sets a note's type: text or ink.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSetTitle()
+### InkNoteSetTitle()
     void    InkNoteSetTitle(
             dword           tag,            /* ID# of note */
             VMFileHandle    fh,             /* Handle of Ink DB file */
@@ -1854,7 +1854,7 @@ INK_DB_MAX_NOTE_KEYWORDS_SIZE +1 in length.
 **Include:** pen.goh
 
 ----------
-#### InkNoteSetTitleFromTextObject()
+### InkNoteSetTitleFromTextObject()
     void    InkNoteSetTitleFromTextObject(
             dword           tag,        /* ID# of note */
             FileHandle      fh,         /* Handle of Ink DB file */
@@ -1866,7 +1866,7 @@ contents of the passed VisText object.
 **Include:** pen.goh
 
 ----------
-#### InkSendTitleToTextObject()
+### InkSendTitleToTextObject()
     void    InkSendTitleToTextObject(
             dword           tag,        /* ID# of folder or note */
             VMFileHandle    fh,         /* Handle of Ink DB file */
@@ -1878,7 +1878,7 @@ the passed folder or note of an Ink Database file.
 **Include:** pen.goh
 
 ----------
-#### InkSetDocCustomGString()
+### InkSetDocCustomGString()
     void    InkSetDocCustomGString(
             VMFileHandle        dbfh,
             Handle      gstring);
@@ -1891,7 +1891,7 @@ document's basic **InkBackgroundType** is IBT_CUSTOM. (Set this using the
 **Include:** pen.goh
 
 ----------
-#### InkSetDocGString()
+### InkSetDocGString()
     void    InkSetDocGString(
             VMFileHandle            dbfh,
             InkBackgroundType       type);
@@ -1903,7 +1903,7 @@ sure to also call **InkSetDocCustomGString()**.
 **Include:** pen.goh
 
 ----------
-#### InkSetDocPageInfo()
+### InkSetDocPageInfo()
     void    InkSetDocPageInfo(
             PageSizeReport *        psr,
             VMFileHandle            fh);
@@ -1913,7 +1913,7 @@ Set the page information for an Ink Database file.
 **Include:** pen.goh
 
 ----------
-#### IntegerOf()
+### IntegerOf()
     word    IntegerOf(
             WWFixedAsDWord      wwf)
 
@@ -1922,7 +1922,7 @@ This macro returns the integral portion of a WWFixedAsDWord value.
 **Include:** geos.h
 
 ----------
-#### LMemAlloc()
+### LMemAlloc()
     ChunkHandle  LMemAlloc(
             MemHandle   mh,             /* Handle of block containing heap */
             word        chunkSize);     /* Size of new chunk in bytes */
@@ -1946,7 +1946,7 @@ moved.
 **See Also:** LMemDeref(), LMemReAlloc()
 
 ----------
-#### LMemContract()
+### LMemContract()
     void    LMemContract(
             MemHandle       mh);        /* Handle of LMem heap */
 
@@ -1962,7 +1962,7 @@ move; however, all pointers to chunks will be invalidated.
 **Include:** lmem.h
 
 ----------
-#### LMemDeleteAt()
+### LMemDeleteAt()
     void    LMemDeleteAt(
             optr    chunk,          /* Chunk to resize */
             word    deleteOffset,   /* Offset within chunk of first 
@@ -1983,7 +1983,7 @@ indicate bytes that are not in the chunk, results are undefined.
 **See Also:** LMemReAlloc(), LMemInsertAt(), LMemDeleteAtHandles()
 
 ----------
-#### LMemDeleteAtHandles()
+### LMemDeleteAtHandles()
     void    LMemDeleteAtHandles(
             MemHandle       mh,             /* Handle of LMem heap */
             ChunkHandle     ch,             /* Handle of chunk to resize */
@@ -2002,7 +2002,7 @@ indicate bytes that are not in the chunk, results are undefined.
 **Include:** lmem.h
 
 ----------
-#### LMemDeref()
+### LMemDeref()
     void *  LMemDeref(
             optr    chunk); /* optr to chunk to dereference */
 
@@ -2018,7 +2018,7 @@ again.
 **See Also:** LMemDerefHandles()
 
 ----------
-#### LMemDerefHandles()
+### LMemDerefHandles()
     void *  LMemDerefHandles(
             MemHandle       mh,         /* Handle of LMem heap's block */
             ChunkHandle     chunk);     /* Handle of chunk to dereference */
@@ -2033,7 +2033,7 @@ specified by its global and chunk handles.
 **See Also:** LMemDeref()
 
 ----------
-#### LMemFree()
+### LMemFree()
     void    LMemFree(
             optr    chunk);         /*optr of chunk to free */
 
@@ -2049,7 +2049,7 @@ in the freed chunk, of course).
 **See Also:** LMemFreeHandles()
 
 ----------
-#### LMemFreeHandles()
+### LMemFreeHandles()
     void    LMemFreeHandles(
             MemHandle       mh,             /* Handle of LMem heap */
             ChunkHandle     chunk);         /* Handle of chunk to free */
@@ -2062,7 +2062,7 @@ specified by its global and chunk handles (instead of by an optr).
 **Include:** lmem.h
 
 ----------
-#### LMemGetChunkSize()
+### LMemGetChunkSize()
     word    LMemGetChunkSize(
             optr    chunk);             /* optr of subject chunk */
 
@@ -2079,7 +2079,7 @@ valid.
 **See Also:** LMemGetChunkSizeHandles()
 
 ----------
-#### LMemGetChunkSizeHandles()
+### LMemGetChunkSizeHandles()
     word    Routine(
             MemHandle       mh,         /* Handle of LMem heap */
             ChunkHandle     chunk);     /* Handle of chunk in question */
@@ -2094,7 +2094,7 @@ chunk is specified by its global and chunk handles (instead of by an optr).
 **See Also:** LMemGetChunkSize()
 
 ----------
-#### LMemInitHeap()
+### LMemInitHeap()
     void    LMemInitHeap(
             MemHandle           mh,         /* Handle of (locked or fixed)
                                              * block which will contain heap    */
@@ -2213,7 +2213,7 @@ large enough to accommodate the entire heap.
 MemFree(), VMAllocLMem()
 
 ----------
-#### LMemInsertAt()
+### LMemInsertAt()
     void    LMemInsertAt(
             optr    chunk,          /* optr of chunk to resize */
             word    insertOffset,   /* Offset within chunk of first byte
@@ -2237,7 +2237,7 @@ is out-of-bounds, results are undefined.
 **See Also:** LMemReAlloc(), LMemDeleteAt(), LMemInsertAtHandles()
 
 ----------
-#### LMemInsertAtHandles()
+### LMemInsertAtHandles()
     void    LMemInsertAtHandles(
             MemHandle       mh,             /* Handle of LMem heap */
             ChunkHandle     chunk,          /* Chunk to resize */
@@ -2260,7 +2260,7 @@ is out-of-bounds, results are undefined.
 **Include:** lmem.h
 
 ----------
-#### LMemReAlloc()
+### LMemReAlloc()
     Boolean LMemReAlloc(
             optr    chunk,              /* optr of chunk to resize */
             word    chunkSize);         /* New size of chunk in bytes */
@@ -2289,7 +2289,7 @@ or resized, invalidating pointers.
 **See Also:** LMemReAllocHandles(), LMemInsertAt(), LMemDeleteAt()
 
 ----------
-#### LMemReAllocHandles()
+### LMemReAllocHandles()
     void    LMemReAllocHandles(
             MemHandle       mh,             /* Handle of LMem heap */
             ChunkHandle     chunk,          /* Handle of chunk to resize */
@@ -2306,7 +2306,7 @@ or resized, invalidating pointers.
 **Include:** lmem.h
 
 ----------
-#### LocalAsciiToFixed()
+### LocalAsciiToFixed()
     WWFixedAsDWord LocalAsciiToFixed(
             const char *        buffer,
             char **             parseEnd);
@@ -2316,7 +2316,7 @@ This routines converts a string like "12.345" to a fixed point number.
 **Include:** localize.h
 
 ----------
-#### LocalCmpStrings()
+### LocalCmpStrings()
     sword   LocalCmpStrings(
             const char *        str1,
             const char *        str2,
@@ -2331,7 +2331,7 @@ alphabetical order.
 **Include:** localize.h
 
 ----------
-#### LocalCmpStringsDosToGeos()
+### LocalCmpStringsDosToGeos()
     sword   LocalCmpStringsDosToGeos(
             const char *                    str1,
             const char *                    str2,
@@ -2355,7 +2355,7 @@ at the same place in alphabetical order.
 **Include:**    localize.h
 
 ----------
-#### LocalCmpStringsNoCase()
+### LocalCmpStringsNoCase()
     sword   LocalCmpStringsNoCase(
             const char *        str1,
             const char *        str2,
@@ -2370,7 +2370,7 @@ strings appear at the same place in alphabetical order.
 **Include:** localize.h
 
 ----------
-#### LocalCodePageToGeos()
+### LocalCodePageToGeos()
     Boolean LocalCodePageToGeos(
             char *          str,
             word            strSize,    /* Size of the string, in bytes */
@@ -2384,7 +2384,7 @@ replaced by the passed default character.
 **Include:** localize.h
 
 ----------
-#### LocalCodePageToGeosChar()
+### LocalCodePageToGeosChar()
     word    LocalCodePageToGeosChar(
             word            ch,
             DosCodePage     codePage,
@@ -2397,7 +2397,7 @@ be replaced by the passed default character.
 **Include:**    localize.h
 
 ----------
-#### LocalCustomFormatDateTime()
+### LocalCustomFormatDateTime()
     word    LocalCustomFormatDateTime(
             char *                  str,        /* Buffer to save formatted text in */
             const char *            format,     /* Format string */
@@ -2409,7 +2409,7 @@ format.
 **Include:** localize.h
 
 ----------
-#### LocalCustomParseDateTime()
+### LocalCustomParseDateTime()
     word    LocalCustomParseDateTime(
             const char *            str,
             DateTimeFormat          format,
@@ -2427,7 +2427,7 @@ correctly.
 **Include:** localize.h
 
 ----------
-#### LocalDistanceFromAscii()
+### LocalDistanceFromAscii()
     WWFixedAsDword  LocalDistanceFromAscii( 
             const char *            buffer,
             DistanceUnit            distanceUnits,
@@ -2440,7 +2440,7 @@ centimeters, or some other measure as specified by the passed unit.
 **Include:** localize.h
 
 ----------
-#### LocalDistanceToAscii()
+### LocalDistanceToAscii()
     word    LocalDistanceToAscii( /* Length of string, including NULL */
             char *              buffer,     /*Buffer to save formatted text in */
             word                value,
@@ -2453,7 +2453,7 @@ containing a properly formatted distance.
 **Include:** localize.h
 
 ----------
-#### LocalDosToGeos()
+### LocalDosToGeos()
     Boolean LocalDosToGeos(
             char *  str,
             word    strSize,
@@ -2465,7 +2465,7 @@ GEOS equivalent will be replaced by the passed default character.
 **Include:** localize.h
 
 ----------
-#### LocalDosToGeosChar()
+### LocalDosToGeosChar()
     word    LocalDosToGeosChar(
             word    ch,
             word    defaultChar);
@@ -2476,7 +2476,7 @@ GEOS equivalent will be replaced by the passed default character.
 **Include:** localize.h
 
 ----------
-#### LocalDowncaseChar()
+### LocalDowncaseChar()
     word    LocalDowncaseChar(
             word    ch);
 
@@ -2485,7 +2485,7 @@ Return the lower case equivalent, if any, of the passed character.
 **Include:** localize.h
 
 ----------
-#### LocalDowncaseString()
+### LocalDowncaseString()
     void    LocalDowncaseString(
             char *  str,
             word    size);      /* Size of string, in bytes */
@@ -2495,7 +2495,7 @@ Convert the passed string to its all lower case equivalent.
 **Include:** localize.h
 
 ----------
-#### LocalFixedToAscii()
+### LocalFixedToAscii()
     void    LocalFixedToAscii(
             char *          buffer,
             WWFixedAsDWord  value,
@@ -2506,7 +2506,7 @@ This routine returns the ASCII expression of a fixed point number.
 **Include:** localize.h
 
 ----------
-#### LocalFormatDateTime()
+### LocalFormatDateTime()
     word    LocalFormatDateTime( /* Length of returned string */
             char *                      str,
             DateTimeFormat              format,
@@ -2518,7 +2518,7 @@ DateAndTime.
 **Include:**    localize.h
 
 ----------
-#### LocalGeosToCodePage()
+### LocalGeosToCodePage()
     Boolean LocalGeosToCodePage(
             char *          str,
             word            strSize,
@@ -2532,7 +2532,7 @@ passed default character.
 **Include:** localize.h
 
 ----------
-#### LocalGeosToCodePageChar()
+### LocalGeosToCodePageChar()
     word    LocalGeosToCodePageChar(
             word            ch,
             DosCodePage     codePage,
@@ -2545,7 +2545,7 @@ default character.
 **Include:** localize.h
 
 ----------
-#### LocalGeosToDos()
+### LocalGeosToDos()
     Boolean LocalGeosToDos(
             char *  str,
             word    strSize,
@@ -2557,7 +2557,7 @@ equivalent will be replaced by the passed default character.
 **Include:** localize.h
 
 ----------
-#### LocalGeosToDosChar()
+### LocalGeosToDosChar()
     word    LocalGeosToDosChar(
             word    ch,
             word    defaultChar);
@@ -2568,7 +2568,7 @@ DOS equivalent will be replaced by the passed default character.
 **Include:** localize.h
 
 ----------
-#### LocalGetCodePage()
+### LocalGetCodePage()
     DosCodePage LocalGetCodePage(void);
 
 This routine returns the current code page, used by DOS to handle 
@@ -2577,7 +2577,7 @@ international character sets.
 **Include:** localize.h
 
 ----------
-#### LocalGetCurrencyFormat()
+### LocalGetCurrencyFormat()
     void    LocalGetCurrencyFormat(
             LocalCurrencyFormat *   buf,
             char *                  symbol);
@@ -2587,7 +2587,7 @@ This routine returns the current currency format and symbol.
 **Include:** localize.h
 
 ----------
-#### LocalGetDateTimeFormat()
+### LocalGetDateTimeFormat()
     void    LocalGetDateTimeFormat(
             char *              str,
             DateTimeFormat      format);
@@ -2597,7 +2597,7 @@ This routine returns the user's preferred time and date formats.
 **Include:** localize.h
 
 ----------
-#### LocalGetDefaultPrintSizes()
+### LocalGetDefaultPrintSizes()
     void    LocalGetDefaultPrintSizes(
             DefaultPrintSizes *     sizes);
 
@@ -2606,7 +2606,7 @@ This routine returns the system's default page and document size.
 **Include:** localize.h
 
 ----------
-#### LocalGetMeasurementType()
+### LocalGetMeasurementType()
     MeasurementTypes LocalGetMeasurementType(void);
 
 This routine returns the user preference between US and metric 
@@ -2615,7 +2615,7 @@ measurement systems.
 **Include:** localize.h
 
 ----------
-#### LocalGetNumericFormat()
+### LocalGetNumericFormat()
     void    LocalGetNumericFormat(
             LocalNumericFormat *        buf);
 
@@ -2624,7 +2624,7 @@ This routine returns the user's preferred format for numbers.
 **Include:** localize.h
 
 ----------
-#### LocalGetQuotes()
+### LocalGetQuotes()
     void    LocalGetQuotes(
             LocalQuotes *       quotes);
 
@@ -2633,7 +2633,7 @@ This routine returns the user's preferred quote marks.
 **Include:** localize.h
 
 ----------
-#### LocalIsAlpha()
+### LocalIsAlpha()
     Boolean LocalIsAlpha(
             word    ch);
 
@@ -2642,7 +2642,7 @@ This routine returns *true* if the passed character is alphabetic.
 **Include:** localize.h
 
 ----------
-#### LocalIsAlphaNumeric()
+### LocalIsAlphaNumeric()
     Boolean LocalIsAlphaNumeric(
             word    ch);
 
@@ -2651,7 +2651,7 @@ This routine returns *true* if the passed character is alphanumeric.
 **Include:** localize.h
 
 ----------
-#### LocalIsControl()
+### LocalIsControl()
     Boolean LocalIsControl(
             word    ch);
 
@@ -2660,7 +2660,7 @@ This routine returns *true* if the passed character is a control character.
 **Include:** localize.h
 
 ----------
-#### LocalIsDateChar()
+### LocalIsDateChar()
     Boolean LocalIsDateChar(
             word    ch);
 
@@ -2670,7 +2670,7 @@ time.
 **Include:** localize.h
 
 ----------
-#### LocalIsDigit()
+### LocalIsDigit()
     Boolean LocalIsDigit(
             word    ch);
 
@@ -2679,7 +2679,7 @@ This routine returns *true* if the passed character is a decimal digit.
 **Include:** localize.h
 
 ----------
-#### LocalIsDosChar()
+### LocalIsDosChar()
     Boolean LocalIsDosChar(
             word    ch);
 
@@ -2689,7 +2689,7 @@ set.
 **Include:** localize.h
 
 ----------
-#### LocalIsGraphic()
+### LocalIsGraphic()
     Boolean LocalIsGraphic(
             word    ch);
 
@@ -2698,7 +2698,7 @@ This routine returns true if the passed character is displayable.
 **Include:** localize.h
 
 ----------
-#### LocalIsHexDigit()
+### LocalIsHexDigit()
     Boolean LocalIsHexDigit(
             word    ch);
 
@@ -2707,7 +2707,7 @@ This routine returns *true* if the passed character is a hexadecimal digit.
 **Include:** localize.h
 
 ----------
-#### LocalIsLower()
+### LocalIsLower()
     Boolean LocalIsLower(
             word    ch);
 
@@ -2727,7 +2727,7 @@ number format.
 **Include:** localize.h
 
 ----------
-#### LocalIsPrintable()
+### LocalIsPrintable()
     Boolean LocalIsPrintable(
             word    ch);
 
@@ -2737,7 +2737,7 @@ space when printing).
 **Include:** localize.h
 
 ----------
-#### LocalIsPunctuation()
+### LocalIsPunctuation()
     Boolean LocalIsPunctuation(
             word    ch);
 
@@ -2746,7 +2746,7 @@ This routine returns *true* if the passed character is a punctuation mark.
 **Include:** localize.h
 
 ----------
-#### LocalIsSpace()
+### LocalIsSpace()
     Boolean LocalIsSpace(
             word    ch);
 
@@ -2755,7 +2755,7 @@ This routine returns *true* if the passed character is whitespace.
 **Include:** localize.h
 
 ----------
-#### LocalIsSymbol()
+### LocalIsSymbol()
     Boolean LocalIsSymbol(
             word    ch);
 
@@ -2764,7 +2764,7 @@ This routine returns *true* if the passed character is a symbol.
 **Include:** localize.h
 
 ----------
-#### LocalIsTimeChar()
+### LocalIsTimeChar()
     Boolean LocalIsTimeChar(
             word    ch);
 
@@ -2774,7 +2774,7 @@ user's time format.
 **Include:** localize.h
 
 ----------
-#### LocalIsUpper()
+### LocalIsUpper()
     Boolean LocalIsUpper(
             word    ch);
 
@@ -2784,7 +2784,7 @@ character.
 **Include:** localize.h
 
 ----------
-#### LocalLexicalValue()
+### LocalLexicalValue()
     word    LocalLexicalValue(
             word    ch);
 
@@ -2794,7 +2794,7 @@ to sort strings alphabetically.
 **Include:** localize.h
 
 ----------
-#### LocalLexicalValueNoCase()
+### LocalLexicalValueNoCase()
     word    LocalLexicalValueNoCase(
             word    ch);
 
@@ -2804,7 +2804,7 @@ useful when trying to sort strings alphabetically.
 **Include:** localize.h
 
 ----------
-#### LocalParseDateTime()
+### LocalParseDateTime()
     Boolean LocalParseDateTime(
             const char *            str,
             DateTimeFormat          format,
@@ -2816,7 +2816,7 @@ it using the passed format.
 **Include:** localize.h
 
 ----------
-#### LocalSetCurrencyFormat()
+### LocalSetCurrencyFormat()
     void    LocalSetCurrencyFormat(
             const LocalCurrencyFormat *     buf,
             const char *                    symbol);
@@ -2826,7 +2826,7 @@ This routine changes the stored preferred currency format.
 **Include:** localize.h
 
 ----------
-#### LocalSetDateTimeFormat()
+### LocalSetDateTimeFormat()
     void    LocalSetDateTimeFormat(
             const char *        str,
             DateTimeFormat      format);
@@ -2836,7 +2836,7 @@ This routine changes the stored preferred time and date format.
 **Include:** localize.h
 
 ----------
-#### LocalSetDefaultPrintSizes()
+### LocalSetDefaultPrintSizes()
     void    LocalSetDefaultPrintSizes(
             const DefaultPrintSizes *           sizes);
 
@@ -2845,7 +2845,7 @@ This routine changes the stored preferred default page and document sizes.
 **Include:** localize.h
 
 ----------
-#### LocalSetMeasurementType()
+### LocalSetMeasurementType()
     void    LocalSetMeasurementType(
             MeasurementTypes meas);
 
@@ -2854,7 +2854,7 @@ This routine changes the stored preferred measurement type.
 **Include:** localize.h
 
 ----------
-#### LocalSetNumericFormat()
+### LocalSetNumericFormat()
     void    LocalSetNumericFormat(
             const LocalNumericFormat *          buf);
 
@@ -2863,7 +2863,7 @@ This routine changes the stored preferred number format.
 **Include:** localize.h
 
 ----------
-#### LocalSetQuotes()
+### LocalSetQuotes()
     void    LocalSetQuotes(
             const LocalQuotes *     quotes);
 
@@ -2872,7 +2872,7 @@ This routine changes the stored preferred quote marks.
 **Include:** localize.h
 
 ----------
-#### LocalStringLength()
+### LocalStringLength()
     word    LocalStringLength(
             const char *        str);
 
@@ -2882,7 +2882,7 @@ This routine returns the length (in characters) of a null-terminated string
 **Include:** localize.h
 
 ----------
-#### LocalStringSize()
+### LocalStringSize()
     word    LocalStringSize(
             const char *        str);
 
@@ -2891,7 +2891,7 @@ This routine returns the size (in bytes) of a null-terminated string.
 **Include:** localize.h
 
 ----------
-#### LocalUpcaseChar()
+### LocalUpcaseChar()
     word    LocalUpcaseChar(
             word    ch);
 
@@ -2901,7 +2901,7 @@ character.
 **Include:** localize.h
 
 ----------
-#### LocalUpcaseString()
+### LocalUpcaseString()
     void    LocalUpcaseString(
             char *  str,
             word    size);

--- a/TechDocs/Markdown/Routines/rroutm_p.md
+++ b/TechDocs/Markdown/Routines/rroutm_p.md
@@ -1,6 +1,6 @@
 ## 3.5 Routines M-P
 ----------
-#### MakeWWFixed()
+### MakeWWFixed()
     WWFixedAsDWord MakeWWFixed(number);
 
 This macro casts a floating-point or integer number to a WWFixedAsDWord value.
@@ -8,7 +8,7 @@ This macro casts a floating-point or integer number to a WWFixedAsDWord value.
 **Include:** geos.h
 
 ----------
-#### malloc()
+### malloc()
     void    * malloc(
             size_t      blockSize);         /* # of bytes to allocate*/
 
@@ -45,7 +45,7 @@ free the memory as quickly as possible.
 **See Also:** calloc(), free(), GeoMalloc(), realloc()
 
 ----------
-#### ManufacturerFromFormatID
+### ManufacturerFromFormatID
     word    ManufacturerFromFormatID(id);
             ClipboardItemFormatID id;
 
@@ -53,7 +53,7 @@ This macro extracts the word-sized manufacturer ID (of type
 **ManufacturerIDs**) from a **ClipboardInfoFormatID** argument.
 
 ----------
-#### MemAlloc()
+### MemAlloc()
     MemHandle MemAlloc(
             word            byteSize,       /* Size of block in bytes */
             HeapFlags       hfFlags,        /* Type of block */
@@ -146,7 +146,7 @@ accessed or altered by a less privileged entity.
 **See Also:** MemAllocSetOwner(), MemReAlloc(), MemDeref()
 
 ----------
-#### MemAllocLMem()
+### MemAllocLMem()
         MemHandle MemAllocLMem(
             LMemType    type,               /* type of LMem block */
             word        headerSize);        /* size of header structure */
@@ -166,7 +166,7 @@ heap.
 **See Also:** LMemInitHeap()
 
 ----------
-#### MemAllocSetOwner()
+### MemAllocSetOwner()
     MemHandle MemAllocSetOwner(
             GeodeHandle     owner,              /* Handle of block's owner */
             word            byteSize,           /* Size of block in bytes */
@@ -181,7 +181,7 @@ owner of the global memory block created.
 **See Also:** MemAlloc()
 
 ----------
-#### MemDecRefCount()
+### MemDecRefCount()
     void    MemDecRefCount(
             MemHandle       mh);            /* handle of affected block */
 
@@ -196,7 +196,7 @@ may only use this routine if the block has had a reference count set up with
 **Include:** heap.h
 
 ----------
-#### MemDeref()
+### MemDeref()
     void    * MemDeref(
             MemHandle   mh);    /* Handle of locked block to dereference */
 
@@ -221,7 +221,7 @@ without a warning, even though that block may move at any time.
 **See Also:** MemGetInfo(), MemModifyFlags()
 
 ----------
-#### MemDowngradeExclLock()
+### MemDowngradeExclLock()
     void    MemDowngradeExclLock(
             MemHandle       mh);        /* handle of affected block */
 
@@ -231,7 +231,7 @@ shared lock with this routine. It does not otherwise affect the block.
 **Include:** heap.h
 
 ----------
-#### MemFree()
+### MemFree()
     void    MemFree(
             MemHandle       mh);        /* handle of block to be freed */
 
@@ -244,7 +244,7 @@ unlocked.
 try to free a bad handle, routine may fatal-error.
 
 ----------
-#### MemGetInfo()
+### MemGetInfo()
     word    MemGetInfo( /* return value depends on flag passed */
             MemHandle       mh,     /* Handle of block to get info about */
             MemGetInfoType  info);  /* Type of information to get */
@@ -293,7 +293,7 @@ if any.
 HandleModifyOwner()
 
 ----------
-#### MemIncRefCount()
+### MemIncRefCount()
     void    MemIncRefCount(
             MemHandle       mh);        /* handle of affected block */
 
@@ -307,7 +307,7 @@ may only use this routine if the block has had a reference count set up with
 **Include:** heap.h
 
 ----------
-#### MemInitRefCount()
+### MemInitRefCount()
     void    MemInitRefCount(
             MemHandle   mh,             /* handle of affected block */
             word        count);         /* initial reference count */
@@ -324,7 +324,7 @@ count routines on the same block.
 **Include:** heap.h
 
 ----------
-#### MemLock()
+### MemLock()
     void    * MemLock(
             MemHandle       mh);        /* Handle of block to lock */
 
@@ -346,7 +346,7 @@ threads, you should use the synchronization routines.
 **See Also:** MemDeref()
 
 ----------
-#### MemLockExcl()
+### MemLockExcl()
     void    * MemLockExcl(
             MemHandle       mh);        /* Handle of block to grab */
 
@@ -399,7 +399,7 @@ attempt to lock the block, and fixed blocks cannot be locked. Instead, use the
 **See Also:** MemLockShared(), MemUnlockExcl(), MemUnlockShared()
 
 ----------
-#### MemLockFixedOrMovable()
+### MemLockFixedOrMovable()
     void    * MemLockFixedOrMovable(
             void    * ptr);     /* virtual segment */
 
@@ -411,7 +411,7 @@ will designate them as virtual segments.
 **Include:** heap.h
 
 ----------
-#### MemLockShared()
+### MemLockShared()
     void    * MemLockShared(
             MemHandle       mh);            /* Handle of block to grab */
 
@@ -442,7 +442,7 @@ attempt to lock the block, and fixed blocks cannot be locked. Instead, use the
 **See Also:** MemLockExcl(), MemUnlockExcl(), MemUnlockShared()
 
 ----------
-#### MemModifyFlags()
+### MemModifyFlags()
     void    MemModifyFlags(
             MemHandle       mh,             /* Handle of block to modify */
             HeapFlags       bitsToSet,      /* HeapFlags to turn on */
@@ -465,7 +465,7 @@ routine will change inappropriate bits of the handle table entry.
 **See Also:** MemGetInfo(), HandleModifyOwner(), MemModifyOtherInfo()
 
 ----------
-#### MemModifyOtherInfo()
+### MemModifyOtherInfo()
     void    MemModifyOtherInfo(
             MemHandle   mh,             /* Handle of block to modify */
             word        otherInfo);     /* New value of HM_otherInfo word */
@@ -479,7 +479,7 @@ data-access synchronization routines use this word.
 **See Also:** MemGetInfo(), MemModifyFlags(), HandleModifyOwner()
 
 ----------
-#### MemOwner()
+### MemOwner()
 
 GeodeHandle MemOwner(
 
@@ -492,7 +492,7 @@ belongs to a VM file, the owner of the VM file will be returned (unlike
 **Include:** heap.h
 
 ----------
-#### MemPLock()
+### MemPLock()
     void    * MemPLock(
             MemHandle       mh);        /* Handle of block to lock */
 
@@ -530,7 +530,7 @@ fixed blocks cannot be locked. Instead, use **HandleP()**.
 **See Also:** HandleP(), MemUnlockV(), HandleV()
 
 ----------
-#### MemPtrToHandle()
+### MemPtrToHandle()
     MemHandle MemPtrToHandle(
             void    * ptr);     /* pointer to locked block */
 
@@ -539,7 +539,7 @@ This routine returns the global handle of the locked block.
 **Include:** heap.h
 
 ----------
-#### MemReAlloc()
+### MemReAlloc()
     MemHandle   MemReAlloc(
             MemHandle       mh,                 /* Handle of block */
             word            byteSize,           /* New size of the block */
@@ -568,7 +568,7 @@ the synchronization routines.
 **See Also:** MemAlloc(), MemDeref()
 
 ----------
-#### MemThreadGrab()
+### MemThreadGrab()
     void    * MemThreadGrab(
             MemHandle       mh);        /* Handle of block to grab */
 
@@ -605,7 +605,7 @@ routines.
 **See Also:** MemThreadGrabNB(), MemThreadRelease()
 
 ----------
-#### MemThreadGrabNB()
+### MemThreadGrabNB()
     void    * MemThreadGrabNB(
             MemHandle       mh);    /* handle of block to grab */
 
@@ -643,7 +643,7 @@ fixed block, use the **HandleP()** and **HandleV()** routines.
 **See Also:** MemThreadGrab(), MemThreadRelease()
 
 ----------
-#### MemThreadRelease()
+### MemThreadRelease()
     void    MemThreadRelease(
             MemHandle       mh);    /* handle of locked block to release */
 
@@ -671,7 +671,7 @@ routine will fatal-error.
 **See Also:** MemThreadGrab(), MemThreadGrabNB()
 
 ----------
-#### MemUnlock()
+### MemUnlock()
     void    MemUnlock(
             MemHandle       mh);        /* Handle of block to unlock */
 
@@ -682,7 +682,7 @@ or discarded). Do not try to unlock a block that has not been locked.
 **Include:** heap.h
 
 ----------
-#### MemUnlockExcl()
+### MemUnlockExcl()
     void    MemUnlockExcl(
             memHandle       mh);        /* Handle of block to release */
 
@@ -711,7 +711,7 @@ fatal-error.
 **See Also:** MemLockExcl(), MemLockShared(), MemUnlockShared()
 
 ----------
-#### MemUnlockFixedOrMovable()
+### MemUnlockFixedOrMovable()
     void    MemUnlockFixedOrMovable(
             void    * ptr);     /* virtual segment */
 
@@ -722,7 +722,7 @@ blocks locked with **MemLockFixedOrMovable()**.
 **Include:** heap.h
 
 ----------
-#### MemUnlockShared()
+### MemUnlockShared()
     void    MemUnlockShared(
             MemHandle       mh);        /* Handle of block to release */
 
@@ -752,7 +752,7 @@ fatal-error.
 **See Also:** MemLockExcl(), MemLockShared(), MemUnlockExcl()
 
 ----------
-#### MemUnlockV()
+### MemUnlockV()
     void    MemUnlockV(
             MemHandle       mh);        /* Handle of block to release */
 
@@ -782,7 +782,7 @@ fixed blocks cannot be locked or unlocked. Instead, call **HandleV()** directly.
 **See Also:** MemPLock(), HandleP(), HandleV()
 
 ----------
-#### MemUpgradeSharedLock()
+### MemUpgradeSharedLock()
     void    * MemUpgradeSharedLock(
             MemHandle       mh);        /* handle of locked block */
 
@@ -799,7 +799,7 @@ granting of access.
 **See Also:** MemLockExcl(), MemLockShared(), MemDowngradeExclLock()
 
 ----------
-#### MessageSetDestination()
+### MessageSetDestination()
     void    MessageSetDestination(
             EventHandle     event,      /* handle of the event to be modified */
             optr            dest);      /* new destination for the event */
@@ -809,7 +809,7 @@ This routine sets the destination of an event to the optr passed.
 **Include:** object.h
 
 ----------
-#### NameArrayAdd()
+### NameArrayAdd()
     word    NameArrayAdd(
             optr                arr,        /* optr of name array */
             const char          * nameToAdd,/* Name of new element */
@@ -851,7 +851,7 @@ heap are invalidated.
 **Include:** chunkarr.h
 
 ----------
-#### NameArrayAddHandles()
+### NameArrayAddHandles()
     dword   NameArrayAddHandles(
             MemHandle           mh,         /* Handle of LMem heap */
             ChunkHandle         arr,        /* Chunk handle of name array */
@@ -870,7 +870,7 @@ LMem heap are invalidated.
 **Include:** chunkarr.h
 
 ----------
-#### NameArrayChangeName()
+### NameArrayChangeName()
     void    NameArrayChangeName(
             optr        array,          /* optr of name array */
             word        token,          /* Token of element to be changed */
@@ -887,7 +887,7 @@ all pointers to within the LMem heap.
 **Include:** chunkarr.h
 
 ----------
-#### NameArrayChangeNameHandles()
+### NameArrayChangeNameHandles()
     dword   NameArrayChangeNameHandles(
             MemHandle       mh,             /* Handle of LMem heap */
             ChunkHandle     array,          /* Chunk handle of name array */
@@ -907,7 +907,7 @@ all pointers to within the LMem heap.
 **Include:** chunkarr.h
 
 ----------
-#### NameArrayCreate()
+### NameArrayCreate()
     ChunkHandle     NameArrayCreate(
             MemHandle   mh,             /* Global handle of LMem heap */
             word        dataSize,       /* Size of data section for
@@ -938,7 +938,7 @@ fixed). If you pass a header size, make sure it is larger than
 **Include:** chunkarr.h
 
 ----------
-#### NameArrayCreateAt()
+### NameArrayCreateAt()
     ChunkHandle     NameArrayCreateAt(
             optr    array,      /* Turn this chunk into a name array */
             word    dataSize,   /* Size of data section of each element */
@@ -956,7 +956,7 @@ pointers to chunks in that block.
 **Include:** chunkarr.h
 
 ----------
-#### NameArrayCreateAtHandles()
+### NameArrayCreateAtHandles()
     ChunkHandle     NameArrayCreateAtHandles(
             MemHandle       mh,         /* Global handle of LMem heap */
             ChunkHandle     chunk,      /* the chunk for the array */
@@ -976,7 +976,7 @@ pointers to chunks in that block.
 **Include:** chunkarr.h
 
 ----------
-#### NameArrayFind()
+### NameArrayFind()
     word    NameArrayFind(
             optr        array,          /* optr to name array */
             const char  * nameToFind,   /* Find element with this name */
@@ -1005,7 +1005,7 @@ CA_NULL_ELEMENT. The routine takes the following arguments:
 element's data portion; otherwise, data after the buffer will be overwritten.
 
 ----------
-#### NameArrayFindHandles()
+### NameArrayFindHandles()
     word    NameArrayFindHandles(
             MemHandle       mh,             /* Handle of LMem heap */
             ChunkHandle     array,          /* Handle of name array */
@@ -1021,7 +1021,7 @@ array is specified by its global and chunk handles (instead of with an optr).
 **Include:** chunkarr.h
 
 ----------
-#### NEC()
+### NEC()
     NEC(line)
 
 This macro defines a line of code that will only be compiled into the 
@@ -1033,7 +1033,7 @@ compiled, the line will be ignored.
 **Include:** ec.h
 
 ----------
-#### ObjBlockGetOutput()
+### ObjBlockGetOutput()
     optr    ObjBlockGetOutput(
             MemHandle   mh);        /* handle of the subject object block */
 
@@ -1047,7 +1047,7 @@ returned.
 **See Also:** ObjLMemBlockHeader
 
 ----------
-#### ObjBlockSetOutput()
+### ObjBlockSetOutput()
     void    ObjBlockSetOutput(
             MemHandle   mh,         /* handle of the subject object block */
             optr        o);         /* optr of the new output object */
@@ -1060,7 +1060,7 @@ header. The optr passed in *o* will be set as the block's output.
 **See Also:** ObjLMemBlockHeader
 
 ----------
-#### ObjCompAddChild()
+### ObjCompAddChild()
     void    ObjCompAddChild(
             optr    obj,            /* optr of parent composite */
             optr    objToAdd,       /* optr of new child */
@@ -1102,7 +1102,7 @@ thereby invalidating all segment addresses and pointers.
 **See Also:** MSG_VIS_ADD_CHILD, MSG_GEN_ADD_CHILD
 
 ----------
-#### ObjCompFindChildByNumber()
+### ObjCompFindChildByNumber()
     optr    ObjCompFindChildByNumber(
             optr    obj,            /* parent's optr */
             word    childToFind,    /* zero-based child number */
@@ -1135,7 +1135,7 @@ field.
 **See Also:** MSG_GEN_FIND_CHILD, MSG_VIS_FIND_CHILD
 
 ----------
-#### ObjCompFindChildByOptr()
+### ObjCompFindChildByOptr()
     word    ObjCompFindChildByOptr(
             optr    obj,            /* parent's optr */
             optr    childToFind,    /* optr of child to find */
@@ -1170,7 +1170,7 @@ field.
 **See Also:** MSG_GEN_FIND_CHILD, MSG_VIS_FIND_CHILD
 
 ----------
-#### ObjCompMoveChild()
+### ObjCompMoveChild()
     void    ObjCompMoveChild(
             optr    obj,            /* parent's optr */
             optr    objToMove,      /* optr of child to move */
@@ -1211,7 +1211,7 @@ their chunks, thereby invalidating any segment addresses or pointers.
 **See Also:** MSG_GEN_MOVE_CHILD, MSG_VIS_MOVE_CHILD
 
 ----------
-#### ObjCompProcessChildren()
+### ObjCompProcessChildren()
     Boolean ObjCompProcessChildren(
             optr            obj,            /* parent's optr */
             optr            firstChild,     /* optr of first child to process */
@@ -1317,7 +1317,7 @@ Counts the number of children rather than calling each.
 **See Also:** @send, @call, MSG_META_SEND_CLASSED_EVENT
 
 ----------
-#### ObjCompRemoveChild()
+### ObjCompRemoveChild()
     void    ObjCompRemoveChild(
             optr    obj,            /* parent's optr */
             optr    objToRemove     /* optr of child to be removed */
@@ -1349,7 +1349,7 @@ field.
 **Include:** metaC.goh
 
 ----------
-#### ObjDecInteractibleCount()
+### ObjDecInteractibleCount()
     void    ObjDecInteractibleCount(
             MemHandle mh);          /* subject object block */
 
@@ -1363,7 +1363,7 @@ interactable count in their MSG_VIS_CLOSE handlers.
 **See Also:** ObjIncInteractibleCount(), MSG_VIS_CLOSE, ObjLMemBlockHeader
 
 ----------
-#### ObjDecInUseCount()
+### ObjDecInUseCount()
     void    ObjDecInUseCount(
             MemHandle mh);      /* subject object block */
 
@@ -1380,7 +1380,7 @@ result.
 **See Also:** ObjIncInUseCount(), ObjDecInteractibleCount(), ObjLMemBlockHeader
 
 ----------
-#### ObjDeref()
+### ObjDeref()
     void    * ObjDeref(
             optr    obj             /* optr to dereference */
             word    masterLevel);   /* specific master level to dereference */
@@ -1413,7 +1413,7 @@ the Gen master part.
 **See Also:** ObjDeref1(), ObjDeref2()
 
 ----------
-#### ObjDerefHandles()
+### ObjDerefHandles()
     void    * ObjDerefHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -1425,7 +1425,7 @@ is specified as its separate handles.
 **Include:** object.h
 
 ----------
-#### ObjDeref1()
+### ObjDeref1()
     void    * ObjDeref1(
             optr obj);          /* optr of object to be dereferenced */
 
@@ -1438,7 +1438,7 @@ master part of an object. Visible objects should use this routine or
 **See Also:** ObjDeref(), ObjDeref2()
 
 ----------
-#### ObjDeref1Handles()
+### ObjDeref1Handles()
     void    *ObjDeref1Handles(
             MemHandle       mh,         /* handle portion of optr */
             ChunkHandle     ch,);       /* chunk handle portion of optr */
@@ -1449,7 +1449,7 @@ specified as its separate handles.
 **Include:** object.h
 
 ----------
-#### ObjDeref2()
+### ObjDeref2()
     void    * ObjDeref2(
             optr    obj);       /* optr of object to be dereferenced */
 
@@ -1462,7 +1462,7 @@ second master part of an object. Generic objects should use this routine or
 **See Also:** ObjDeref(), ObjDeref1()
 
 ----------
-#### ObjDeref2Handles()
+### ObjDeref2Handles()
     void    * ObjDeref2Handles(
             MemHandle       mh,/            /* handle portion of optr */
             ChunkHandle     ch);            /* chunk portion of optr */
@@ -1473,7 +1473,7 @@ specified as its separate handles.
 **Include:** object.h
 
 ----------
-#### ObjDerefGen()
+### ObjDerefGen()
     void    * ObjDerefGen(
             optr    obj);           /* generic object to be dereferenced */
 
@@ -1485,7 +1485,7 @@ master part of a generic object.
 **See Also:** ObjDeref(), ObjDeref2()
 
 ----------
-#### ObjDerefVis()
+### ObjDerefVis()
     void    * ObjDerefVis(
             optr    obj);           /* visible object to be dereferenced */
 
@@ -1497,7 +1497,7 @@ master part of a visible object or a visibly-realized generic object.
 **See Also:** ObjDeref(), ObjDeref1()
 
 ----------
-#### ObjDoRelocation()
+### ObjDoRelocation()
     Boolean ObjDoRelocation( /* returns true if error */
             ObjRelocationType   type,           /* type of relocation */
             MemHandle           block,          /* handle of info block */
@@ -1552,7 +1552,7 @@ The relocation done by this routine can be undone with
 **Include:** object.h
 
 ----------
-#### ObjDoUnRelocation()
+### ObjDoUnRelocation()
     Boolean ObjDoUnRelocation( /* returns true if error */
             ObjRelocationType   type,           /* type of relocation */
             MemHandle           block,          /* handle of info block */
@@ -1573,7 +1573,7 @@ will be returned pointed to by the *destData* pointer.
 **See Also:** ObjDoRelocation()
 
 ----------
-#### ObjDuplicateMessage()
+### ObjDuplicateMessage()
     EventHandle ObjDuplicateMessage(
             EventHandle msg);               /* event to duplicate */
 
@@ -1586,7 +1586,7 @@ change information about the event with **ObjSetMessageDestination()**.
 **See Also:** ObjSetEventInfo()
 
 ----------
-#### ObjDuplicateResource()
+### ObjDuplicateResource()
     MemHandle ObjDuplicateResource(
             MemHandle       blockToDup,     /* handle of resource; must
                                              * not be loaded */
@@ -1623,7 +1623,7 @@ which will be unlocked and may or may not be resident in memory.
 **See Also:** ObjFreeDuplicate(), MSG_META_BLOCK_FREE, ObjLockObjBlock()
 
 ----------
-#### ObjEnableDetach()
+### ObjEnableDetach()
     void    ObjEnableDetach(
             optr    obj);       /* object calling this routine */
 
@@ -1644,7 +1644,7 @@ invalidating all pointers and segment addresses.
 **See Also:** MSG_META_DETACH, ObjInitDetach(), ObjIncDetach(), MSG_META_ACK
 
 ----------
-#### ObjFreeChunk()
+### ObjFreeChunk()
     void    ObjFreeChunk(
             optr    o);     /* optr of chunk to be freed */
 
@@ -1661,7 +1661,7 @@ MSG_META_OBJ_FREE.
 **See Also:** MSG_META_DETACH, MSG_META_OBJ_FREE, ObjInstantiate()
 
 ----------
-#### ObjFreeChunkHandles()
+### ObjFreeChunkHandles()
     void    ObjFreeChunkHandles(
             MemHandle       mh,         /* handle portion of optr */
             ChunkHandle     ch);        /* chunk portion of optr */
@@ -1672,7 +1672,7 @@ handles rather than by an optr.
 **Include:** object.h
 
 ----------
-#### ObjFreeDuplicate()
+### ObjFreeDuplicate()
     void    ObjFreeDuplicate(
             MemHandle mh);      /* handle of duplicate block to be freed */
 
@@ -1689,7 +1689,7 @@ the block's in-use count and interactable count should be zero.
 **See Also:** ObjDuplicateResource(), ObjSaveBlock(), ObjLMemBlockHeader
 
 ----------
-#### ObjFreeMessage()
+### ObjFreeMessage()
     void    ObjFreeMessage(
             EventHandle event);         /* event to be freed */
 
@@ -1700,7 +1700,7 @@ free events after they have been handled.
 **Include:** object.h
 
 ----------
-#### ObjFreeObjBlock()
+### ObjFreeObjBlock()
     void    ObjFreeObjBlock(
             MemHandle block);   /* handle of the object block to be freed */
 
@@ -1719,7 +1719,7 @@ be handled by a remote call in the object block's thread.
 **See Also:** ObjFreeDuplicate(), MSG_META_BLOCK_FREE
 
 ----------
-#### ObjGetFlags()
+### ObjGetFlags()
     ObjChunkFlags ObjGetFlags(
             optr    o);     /* optr of subject object */
 
@@ -1732,7 +1732,7 @@ is specified by the passed optr, and the flags are stored in the object's
 **See Also:** ObjSetFlags(), ObjChunkFlags
 
 ----------
-#### ObjGetFlagsHandles()
+### ObjGetFlagsHandles()
     ObjChunkFlags ObjGetFlagsHandles(
             Memhandle       mh,         /* handle portion of optr */
             ChunkHandle     ch);        /* chunk portion of optr */
@@ -1743,7 +1743,7 @@ its handles rather than with its optr.
 **Include:** object.h
 
 ----------
-#### ObjGetMessageInfo()
+### ObjGetMessageInfo()
     Message ObjGetMessageInfo(
             EventHandle     event,      /* event to be queried */
             optr            * dest);    /* buffer for destination optr */
@@ -1756,7 +1756,7 @@ object.
 **Include:** object.h
 
 ----------
-#### ObjIncDetach()
+### ObjIncDetach()
     void    ObjIncDetach(
             optr    obj);       /* optr of calling object */
 
@@ -1776,7 +1776,7 @@ the optr of the calling object.
 **See Also:** MSG_META_DETACH, ObjInitDetach(), ObjEnableDetach(), MSG_META_ACK
 
 ----------
-#### ObjIncInteractibleCount()
+### ObjIncInteractibleCount()
     void    ObjIncInteractibleCount(
             MemHandle mh);          /* handle of object block */
 
@@ -1797,7 +1797,7 @@ into **VisClass**.
 ObjLMemBlockHeader
 
 ----------
-#### ObjIncInUseCount()
+### ObjIncInUseCount()
     void    ObjIncInUseCount(
             MemHandle mh);          /* handle of object block */
 
@@ -1815,7 +1815,7 @@ decremented with **ObjDecInUseCount()**.
 **See Also:** ObjDecInUseCount(), ObjIncInteractibleCount(), ObjLMemBlockHeader
 
 ----------
-#### ObjInitDetach()
+### ObjInitDetach()
     void    ObjInitDetach(
             MetaMessages    msg,
             optr            obj         /* object being detached */
@@ -1844,7 +1844,7 @@ acknowledgment notification of the detach.
 ObjIncDetach(), ObjEnableDetach(), MSG_META_ACK
 
 ----------
-#### ObjInitializeMaster()
+### ObjInitializeMaster()
     void    ObjInitializeMaster(
             optr            obj,        /* object to be initialized */
             ClassStruct     * class);   /* class in master group */
@@ -1866,7 +1866,7 @@ invalidating pointers and segment addresses.
 **See Also:** ObjResizeMaster(), ObjInitializePart(), ClassStruct
 
 ----------
-#### ObjInitializeMasterHandles()
+### ObjInitializeMasterHandles()
     void    ObjInitializeMasterHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -1878,7 +1878,7 @@ object via its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjInitializePart()
+### ObjInitializePart()
     void    ObjInitializePart(
             optr    obj,            /* object to have a part initialized */
             word    masterOffset);  /* offset to master offset in chunk */
@@ -1903,7 +1903,7 @@ invalidating pointers and segment addresses.
 MSG_META_RESOLVE_VARIANT_SUPERCLASS
 
 ----------
-#### ObjInitializePartHandles()
+### ObjInitializePartHandles()
     void    ObjInitializePartHandles(
             Memhandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -1915,7 +1915,7 @@ object via its handles rather than an optr.
 **Include:** object.h
 
 ----------
-#### ObjInstantiate()
+### ObjInstantiate()
     optr    ObjInstantiate(
             MemHandle       block,      /* block in which new object
                                          * will be instantiated */
@@ -1951,7 +1951,7 @@ addresses. Be sure to dereference pointers after calls to this routine.
 **Include:** metaC.goh
 
 ----------
-#### ObjIsClassADescendant()
+### ObjIsClassADescendant()
     Boolean ObjIsClassADescendant(
             ClassStruct     * class1,           /* proposed ancestor */
             ClassStruct     * class2);          /* proposed descendant */
@@ -1961,7 +1961,7 @@ This routine checks if *class2* is a descendant of *class1* and returns *true* i
 **Include:** object.h
 
 ----------
-#### ObjIsObjectInClass()
+### ObjIsObjectInClass()
     Boolean ObjIsObjectInClass(
             optr            obj,            /* object to check */
             ClassStruct     * class);       /* proposed class */
@@ -1982,7 +1982,7 @@ it is not.
 **Include:** object.h
 
 ----------
-#### ObjIsObjectInClassHandles()
+### ObjIsObjectInClassHandles()
     Boolean ObjIsObjectInClassHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -1994,7 +1994,7 @@ via its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjLinkFindParent()
+### ObjLinkFindParent()
     optr    ObjLinkFindParent(
             optr    obj,            /* child's optr */
             word    masterOffset,   /* offset to master part with link field */
@@ -2016,7 +2016,7 @@ group's offset (the value that would appear in the
 **See Also:** MSG_VIS_FIND_PARENT, MSG_GEN_FIND_PARENT
 
 ----------
-#### ObjLockObjBlock()
+### ObjLockObjBlock()
     void    * ObjLockObjBlock(
             MemHandle mh);          /* handle of object block */
 
@@ -2032,7 +2032,7 @@ address. When the caller is done using the block, it should unlock it with
 **See Also:** MemLock(), MemUnlock()
 
 ----------
-#### ObjMapSavedToState()
+### ObjMapSavedToState()
     VMBlockHandle ObjMapSavedToState(
         MemHandle mh);          /* handle of object block */
 
@@ -2043,7 +2043,7 @@ equivalent, a null handle is returned.
 **Include:** object.h
 
 ----------
-#### ObjMapStateToSaved()
+### ObjMapStateToSaved()
     MemHandle ObjMapStateToSaved(
             VMBlockHandle   vmbh,   /* VM block handle of state block */
             GeodeHandle     gh);    /* handle of geode owning block */
@@ -2062,7 +2062,7 @@ block is not found, it returns a null handle.
 **Include:** object.h
 
 ----------
-#### ObjMarkDirty()
+### ObjMarkDirty()
     void    ObjMarkDirty(
             optr    o);         /* object to be marked dirty */
 
@@ -2079,7 +2079,7 @@ you should use this routine.
 **See Also:** ObjChunkFlags, ObjSetFlags()
 
 ----------
-#### ObjMarkDirtyHandles()
+### ObjMarkDirtyHandles()
     void    ObjMarkDirtyHandles(
             MemHandle       mh,         /* handle portion of optr */
             ChunkHandle     ch);        /* chunk portion of optr */
@@ -2088,7 +2088,7 @@ This routine is the same as **ObjMarkDirty()** except that it specifies the
 object via handles rather than an optr.
 
 ----------
-#### ObjProcBroadcastMessage()
+### ObjProcBroadcastMessage()
     void    ObjProcBroadcastMessage(
             EventHandle event);         /* the event to be broadcast */
 
@@ -2100,12 +2100,12 @@ purposes.
 **Include:** metaC.goh
 
 ----------
-#### ObjRelocateEntryPoint()
+### ObjRelocateEntryPoint()
     void *  ObjRelocateEntryPoint(
             EntryPointRelocation *          relocData);
 
 ----------
-#### ObjRelocOrUnRelocSuper()
+### ObjRelocOrUnRelocSuper()
     void    ObjRelocOrUnRelocSuper(
             optr            oself,
             ClassStruct     *class,
@@ -2116,7 +2116,7 @@ Call this routine to relocate an object's superclass.
 **Include:** object.h
 
 ----------
-#### ObjResizeMaster()
+### ObjResizeMaster()
     void    ObjResizeMaster(
             optr    obj,            /* object to have its master part resized */
             word    masterOffset,   /* master offset of proper master part */
@@ -2144,7 +2144,7 @@ invalidating stored segment addresses and pointers.
 **See Also:** ClassStruct, ObjInitializeMaster(), ObjInitializePart()
 
 ----------
-#### ObjResizeMasterHandles()
+### ObjResizeMasterHandles()
     void    ObjResizeMasterHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -2157,7 +2157,7 @@ specified with its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjSaveBlock()
+### ObjSaveBlock()
     void    ObjSaveBlock(
             MemHandle   mh);    /*handle of block to be marked for saving */
 
@@ -2170,7 +2170,7 @@ block.
 **See Also:** ObjMapSavedToState(), ObjMapStateToSaved()
 
 ----------
-#### ObjSetEventInfo()
+### ObjSetEventInfo()
     void    ObjSetEventInfo(
             EventHandle     event,      /* handle of the event to be modified */
             Message         msg,        /* the new message for the event */
@@ -2194,7 +2194,7 @@ same destination object, you must first retrieve it with
 **See Also:** ObjGetEventInfo()
 
 ----------
-#### ObjSetFlags()
+### ObjSetFlags()
     void    ObjSetFlags(
             optr            o,              /* object whose flags will be set */
             ObjChunkFlags   bitsToSet,      /* flags to set */
@@ -2210,7 +2210,7 @@ let the kernel maintain the object's flags.
 **See Also:** ObjGetFlags(), ObjChunkFlags
 
 ----------
-#### ObjSetFlagsHandles()
+### ObjSetFlagsHandles()
     void    ObjSetFlagsHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -2223,7 +2223,7 @@ via its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjTestIfObjBlockRunByCurThread()
+### ObjTestIfObjBlockRunByCurThread()
     Boolean ObjTestIfObjBlockRunByCurThread(
             MemHandle   mh);        /* handle of object block */
 
@@ -2239,13 +2239,13 @@ thread runs the block, the return is *false* (zero).
 **Include:** object.h
 
 ----------
-#### ObjUnrelocateEntryPoint()
+### ObjUnrelocateEntryPoint()
     void    ObjUnrelocateEntryPoint(
             EntryPointRelocation *      relocData,
             void *                      entryPoint);
 
 ----------
-#### ObjVarAddData()
+### ObjVarAddData()
     void    * ObjVarAddData(
             optr        obj,            /* object to add vardata to */
             VardataKey  dataType,       /* vardata type */
@@ -2282,7 +2282,7 @@ operate on other objects' vardata remotely, use messages provided by
 **See Also:** MSG_META_ADD_VAR_DATA, ObjVarDeleteDataAt()
 
 ----------
-#### ObjVarAddDataHandles()
+### ObjVarAddDataHandles()
     void    * ObjVarAddDataHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -2295,7 +2295,7 @@ specified via its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjVarCopyDataRange()
+### ObjVarCopyDataRange()
     void    ObjVarCopyDataRange(
             optr    source,     /* the optr of the source object */
             optr    dest,       /* the optr of the destination (calling) object */
@@ -2313,7 +2313,7 @@ doctrine for one object to alter another's instance data.
 **Include:** object.h
 
 ----------
-#### ObjVarDeleteData()
+### ObjVarDeleteData()
     Boolean ObjVarDeleteData(
             optr        obj,            /* object to delete from */
             VardataKey  dataType);      /* data type to delete */
@@ -2341,7 +2341,7 @@ operate on other objects' vardata remotely, use messages provided by
 **See Also:** MSG_META_DELETE_VAR_DATA, ObjVarDeleteDataAt()
 
 ----------
-#### ObjVarDeleteDataHandles()
+### ObjVarDeleteDataHandles()
     Boolean ObjVarDeleteDataHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -2353,7 +2353,7 @@ specified via its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjVarDeleteDataAt()
+### ObjVarDeleteDataAt()
     void    ObjVarDeleteDataAt(
             optr    obj,                /* object to delete from */
             word    extraDataOffset);   /* offset to extra data to delete */
@@ -2372,7 +2372,7 @@ operate on other objects' vardata remotely, use messages provided by
 **See Also:** MSG_META_DELETE_VAR_DATA, ObjVarDeleteData()
 
 ----------
-#### ObjVarDeleteDataAtHandles()
+### ObjVarDeleteDataAtHandles()
     void    ObjVarDeleteDataAtHandles(
             MemHandle       mh,         /* handle portion of optr */
             ChunkHandle     ch,         /* chunk portion of optr */
@@ -2384,7 +2384,7 @@ specified via its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjVarDeleteDataRange()
+### ObjVarDeleteDataRange()
     void    ObjVarDeleteDataRange(
             optr        obj,                /* object to delete from */
             word        rangeStart,         /* start of range */
@@ -2419,7 +2419,7 @@ operate on other objects' vardata remotely, use messages provided by
 **See Also:** MSG_META_DELETE_VAR_DATA
 
 ----------
-#### ObjVarDeleteDataRangeHandles()
+### ObjVarDeleteDataRangeHandles()
     void    ObjVarDeleteDataRangeHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -2433,7 +2433,7 @@ object is specified via its handles rather than its optr.
 **Include:** object.h
 
 ----------
-#### ObjVarDerefData()
+### ObjVarDerefData()
     void    * ObjVarDerefData(
             optr            obj,            /* object having data type */
             VardataKey      dataType);      /* data type to dereference */
@@ -2448,7 +2448,7 @@ results are unpredictable.
 **See Also:** ObjVarFindData()
 
 ----------
-#### ObjVarDerefDataHandles()
+### ObjVarDerefDataHandles()
     void    * ObjVarDerefDataHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -2460,7 +2460,7 @@ specified via its handles rather than its optr.
 **Include:** object.h 
 
 ----------
-#### ObjVarFindData()
+### ObjVarFindData()
     void    * ObjVarFindData(
             optr            obj,            /* object to be checked */
             VardataKey      dataType);      /* data type to find */
@@ -2490,7 +2490,7 @@ operate on other objects' vardata remotely, use messages provided by
 **See Also:** MSG_META_FIND_VAR_DATA
 
 ----------
-#### ObjVarFindDataHandles()
+### ObjVarFindDataHandles()
     void    * ObjVarFindDataHandles(
             MemHandle       mh,             /* handle portion of optr */
             ChunkHandle     ch,             /* chunk portion of optr */
@@ -2502,7 +2502,7 @@ specified via its handles rather than its optr.
 **Include:** object.h 
 
 ----------
-#### ObjVarScanData()
+### ObjVarScanData()
     void    ObjVarScanData(
             optr                obj,            /* object to be scanned */
             word                numHandlers,    /* number of handlers in table */
@@ -2569,7 +2569,7 @@ the type.
 **Include:** object.h 
 
 ----------
-#### ObjVarScanDataHandles()
+### ObjVarScanDataHandles()
     void    ObjVarScanDataHandles(
             MemHandle           mh,             /* handle portion of optr */
             ChunkHandle         ch,             /* chunk portion of optr */
@@ -2583,14 +2583,14 @@ specified via its handles rather than its optr.
 **Include:** object.h 
 
 ----------
-#### offsetof()
+### offsetof()
     word    offsetof(struc, field);
 
 This macro returns the offset of the specified field within the specified 
 structure.
 
 ----------
-#### OptrToChunk()
+### OptrToChunk()
     ChunkHandle OptrToChunk(op);
             optr    op;
 
@@ -2599,7 +2599,7 @@ This macro extracts the chunk handle portion of the given optr.
 **See Also:** ConstructOptr(), OptrToHandle()
 
 ----------
-#### OptrToHandle()
+### OptrToHandle()
     MemHandle OptrToHandle(op);
             optr    op;
 
@@ -2608,7 +2608,7 @@ This macro extracts the MemHandle portion of the given optr.
 **See Also:** ConstructOptr(), OptrToChunk()
 
 ----------
-#### ParallelClose()
+### ParallelClose()
     StreamError ParallelClose(
             GeodeHandle         driver,
             ParallelUnit        unit,
@@ -2619,7 +2619,7 @@ Close the stream to a parallel port.
 **Include:** streamC.h 
 
 ----------
-#### ParallelOpen()
+### ParallelOpen()
     StreamError ParallelOpen(
             GeodeHandle         driver,
             ParallelUnit        unit,
@@ -2650,7 +2650,7 @@ member of the **StreamError** enumerated type.
 **Include:** streamC.h 
 
 ----------
-#### ParallelWrite()
+### ParallelWrite()
     StreamError ParallelWrite(
             GeodeHandle         driver,
             ParallelUnit        unit,
@@ -2664,7 +2664,7 @@ Write data to a parallel port.
 **Include:** streamC.h 
 
 ----------
-#### ParallelWriteByte()
+### ParallelWriteByte()
     StreamError ParallelWrite(
             GeodeHandle         driver,
             ParallelUnit        unit,
@@ -2677,7 +2677,7 @@ Write one byte of data to a parallel port.
 **Include:** streamC.h 
 
 ----------
-#### PCB()
+### PCB()
     #define PCB(return_type, pointer_name, args) \
             return_type _pascal (*pointer_name) args
 
@@ -2694,7 +2694,7 @@ which would be expanded to
 **See Also:** CCB()
 
 ----------
-#### PCCOMABORT()
+### PCCOMABORT()
     void PCCOMABORT(void);
 
 This routine aborts the current file transfer operation being carried out by 
@@ -2703,7 +2703,7 @@ the PCCom library. It is the third entry point in the PCCom library.
 **Include:** pccom.goh 
 
 ----------
-#### PCCOMEXIT()
+### PCCOMEXIT()
     PCComReturnType PCCOMEXIT();
 
 This routine kills a pccom thread such as those started by PCCOMINIT(). It is 
@@ -2721,7 +2721,7 @@ the second entry point in the PCCom library.
 **Include:** pccom.goh 
 
 ----------
-#### PCCOMINIT()
+### PCCOMINIT()
     PCComReturnType PCCOMINIT(
             SerialPortNum       port,
             SerialBaud          baud,
@@ -2771,7 +2771,7 @@ determine what sort of notifications will be sent.
 **Include:** pccom.goh 
 
 ----------
-#### ProcCallFixedOrMovable_cdecl()
+### ProcCallFixedOrMovable_cdecl()
     dword   ProcCallFixedOrMovable_cdecl(
             void    (*routine),
             ...)
@@ -2783,7 +2783,7 @@ conventions.
 **Include:** resource.h 
 
 ----------
-#### ProcCallFixedOrMovable_pascal()
+### ProcCallFixedOrMovable_pascal()
     dword   ProcCallFixedOrMovable_pascal(
             ...,
             void    (*routine))
@@ -2795,7 +2795,7 @@ conventions.
 **Include:** resource.h 
 
 ----------
-#### ProcGetLibraryEntry()
+### ProcGetLibraryEntry()
     void *  ProcGetLibraryEntry(
             GeodeHandle     library,
             word            entryNumber)
@@ -2805,7 +2805,7 @@ This routine returns the pointer to a library's entry-point.
 **Include:** resource.h 
 
 ----------
-#### ProcInfo()
+### ProcInfo()
     ThreadHandle ProcInfo(
             GeodeHandle gh);        /* handle of geode to check */
 
@@ -2815,7 +2815,7 @@ geode is not a process, the routine will return a null handle.
 **Include:** geode.h 
 
 ----------
-#### PtrToOffset()
+### PtrToOffset()
     word    PtrToOffset(ptr);
             dword   ptr;
 
@@ -2823,7 +2823,7 @@ This macro returns just the lower 16 bits of the given dword. It is most useful
 for extracting the offset portion of a far pointer.
 
 ----------
-#### PtrToSegment()
+### PtrToSegment()
     word    PtrToSegment(ptr);
             dword   ptr;
 

--- a/TechDocs/Markdown/Routines/rroutq_t.md
+++ b/TechDocs/Markdown/Routines/rroutq_t.md
@@ -1,6 +1,6 @@
 ## 3.6 Routines Q-T
 ----------
-#### qsort
+### qsort
     extern void _pascal qsort(
             void *array, 
             word count, 
@@ -11,7 +11,7 @@ This is a standard quicksort routine. The callback routine must be decared
 _pascal.
 
 ----------
-#### QueueGetInfo()
+### QueueGetInfo()
     word    QueueGetInfo(
             QueueHandle qh);            /* queue to query */
 
@@ -23,7 +23,7 @@ currently in the queue.
 **Include:** geode.h
 
 ----------
-#### QueueGetMessage()
+### QueueGetMessage()
     EventHandle QueueGetMessage(
             QueueHandle qh);            /* queue to query */
 
@@ -35,7 +35,7 @@ almost exclusively by the kernel.
 **Include:** geode.h
 
 ----------
-#### QueuePostMessage()
+### QueuePostMessage()
     void    QueuePostMessage(
             QueueHandle     qh,         /* queue to add event to */
             EventHandle     event,      /* event to be added to queue */
@@ -48,7 +48,7 @@ first spot of the queue.
 **Include:** geode.h
 
 ----------
-#### RangeEnum()
+### RangeEnum()
     Boolean RangeEnum(
             CellFunctionParameters  * cfp,      /* cell function parameters */
             RangeEnumParams         * params);  /* special other parameters */
@@ -94,7 +94,7 @@ wants to abort the **RangeEnum()**, it should return *true*.
 **Include:** cell.h
 
 ----------
-#### RangeExists()
+### RangeExists()
     Boolean RangeExists( /* returns non-zero if there are cells in range */
             CellFunctionParameters  * cfp,          /* see RangeEnum() */
             word                    firstRow,       /* range delimiters */
@@ -110,7 +110,7 @@ of the range to check.
 **Include:** cell.h
 
 ----------
-#### RangeInsert()
+### RangeInsert()
     void    RangeInsert(
             CellFunctionParameters  * cfp,      /* see RangeEnum() */
             RangeInsertParams       * rep);     /* parameters structure */
@@ -150,7 +150,7 @@ an explanation of the "visible" and "scratch-pad" portions of a cell file, see
 Section 19.4.1 of the Concepts book.
 
 ----------
-#### realloc()
+### realloc()
     void *  realloc(
             void *      blockPtr,       /* address of memory to resize */
             size_t      newSize);       /* New size of memory in bytes */
@@ -189,7 +189,7 @@ the memory. If you pass a different address, the results are undefined.
 **See Also:** calloc(), free(), malloc(), GeoReAlloc()
 
 ----------
-#### SerialClose()
+### SerialClose()
     StreamError SerialClose(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -198,7 +198,7 @@ the memory. If you pass a different address, the results are undefined.
 Close the stream to a serial port.
 
 ----------
-#### SerialCloseWithoutReset()
+### SerialCloseWithoutReset()
     StreamError SerialClose(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -207,7 +207,7 @@ Close the stream to a serial port.
 Close the stream to a serial port, without actually resetting the port.
 
 ----------
-#### SerialFlush()
+### SerialFlush()
     StreamError SerialFlush(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -217,7 +217,7 @@ Flush all data pending in a serial port's input or output buffer (depending on
 the value of *roles*).
 
 ----------
-#### SerialGetFormat()
+### SerialGetFormat()
     StreamError SerialGetFormat(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -228,7 +228,7 @@ the value of *roles*).
 Get the format of a stream to a specified serial port.
 
 ----------
-#### SerialGetModem()
+### SerialGetModem()
     StreamError SerialGetModem(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -237,7 +237,7 @@ Get the format of a stream to a specified serial port.
 Read a modem's hardware flow control bits.
 
 ----------
-#### SerialOpen()
+### SerialOpen()
     StreamError SerialOpen(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -268,7 +268,7 @@ If the routine is successful, it returns zero. If it is unsuccessful, it returns
 member of the **StreamError** enumerated type.
 
 ----------
-#### SerialQuery()
+### SerialQuery()
     StreamError SerialQuery(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -279,7 +279,7 @@ Find out how much space is available in a serial buffer, or how much data is
 waiting to be read.
 
 ----------
-#### SerialRead()
+### SerialRead()
     StreamError SerialRead (
             GeodeHandle     driver,
             SerialUnit      unit,
@@ -291,7 +291,7 @@ waiting to be read.
 Read data from a serial port and write it to a passed buffer.
 
 ----------
-#### SerialReadByte()
+### SerialReadByte()
     StreamError SerialReadByte (
             GeodeHandle     driver,
             SerialUnit      unit,
@@ -302,7 +302,7 @@ Read data from a serial port and write it to a passed buffer.
 Read a byte of data from a serial port and write it to a passed variable.
 
 ----------
-#### SerialSetFormat()
+### SerialSetFormat()
     StreamError SerialSetFormat(
             GeodeHandle         driver,
             SerialUnit      unit,
@@ -313,7 +313,7 @@ Read a byte of data from a serial port and write it to a passed variable.
 Set the format for a stream to a specified serial port.
 
 ----------
-#### SerialSetModem()
+### SerialSetModem()
     StreamError SerialSetModem(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -322,7 +322,7 @@ Set the format for a stream to a specified serial port.
 Set a modem's hardware flow control bits.
 
 ----------
-#### SerialWrite()
+### SerialWrite()
     StreamError SerialWrite(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -334,7 +334,7 @@ Set a modem's hardware flow control bits.
 Write data to a serial port.
 
 ----------
-#### SerialWriteByte()
+### SerialWriteByte()
     StreamError SerialWrite(
             GeodeHandle         driver,
             SerialUnit          unit,
@@ -345,7 +345,7 @@ Write data to a serial port.
 Write one byte of data to a serial port.
 
 ----------
-#### SGC_MACHINE
+### SGC_MACHINE
     byte    SGC_MACHINE(val);
             dword   val;
 
@@ -355,7 +355,7 @@ return value.
 **Include:** system.goh
 
 ----------
-#### SGC_PROCESSOR
+### SGC_PROCESSOR
     byte    SGC_PROCESSOR(val);
             dword   val;
 
@@ -365,7 +365,7 @@ return value.
 **Include:** system.goh
 
 ----------
-#### SoundAllocMusic()
+### SoundAllocMusic()
     MemHandle   SoundAllocMusic(
             const word      *song, 
             word            voices );
@@ -378,7 +378,7 @@ set up one of these buffers of music, see "Sound Library," Chapter 13 of the
 Concepts book. The *voices* argument is the number of voices in the buffer. 
 
 ----------
-#### SoundAllocMusicNote()
+### SoundAllocMusicNote()
     MemHandle SoundAllocMusicNote(
             word _far       instrument, 
             word            frequency, 
@@ -403,7 +403,7 @@ delta type is SSDTT_TICKS and *duration* is 30, then the note will sound for
 half a second.
 
 ----------
-#### SoundAllocMusicStream()
+### SoundAllocMusicStream()
     MemHandle   SoundAllocMusicStream(
             word        streamType,
             word        priority,
@@ -420,7 +420,7 @@ done. You must specify how many voices there are in the music buffer. You
 must also pass a starting *tempo* for the music stream.
 
 ----------
-#### SoundAllocSampleStream()
+### SoundAllocSampleStream()
     MemHandle SoundAllocSampleStream(void);
 
 This routine allocates a sample stream handle. If the returned handle is *null*, 
@@ -428,7 +428,7 @@ the library was unavailable (i.e. some other thread has grabbed exclusive
 access).
 
 ----------
-#### SoundDisableSampleStream()
+### SoundDisableSampleStream()
     void    SoundDisableSampleStream(
             MemHandle       mh);
 
@@ -437,7 +437,7 @@ Before you play more sounds using the handle, you will have to call
 **SoundEnableSampleStream()** again. 
 
 ----------
-#### SoundEnableSampleStream()
+### SoundEnableSampleStream()
     Boolean     SoundEnableSampleStream(
             MemHandle       mh,
             word            priority,
@@ -453,7 +453,7 @@ playing on the DAC device: the *priority* with which to grab the DAC player
 identified by a *manufacturerID* and a **DACSampleFormat** value).
 
 ----------
-#### SoundFreeMusic()
+### SoundFreeMusic()
     void    SoundFreeMusic(
             MemHandle       mh);
 
@@ -462,7 +462,7 @@ This routine frees up a music handle. The music must not be playing; call
 after calling this routine on it.
 
 ----------
-#### SoundFreeMusicNote()
+### SoundFreeMusicNote()
     void SoundFreeMusicNote(
             MemHandle       mh);
 
@@ -471,7 +471,7 @@ when you call this routine; call **SoundStopMusicNote()** if you are not sure.
 You should not try to use the note's handle after freeing it.
 
 ----------
-#### SoundFreeMusicStream()
+### SoundFreeMusicStream()
     void SoundFreeMusicStream(
             MemHandle       mh);
 
@@ -480,7 +480,7 @@ the stream; call **SoundDisableMusicStream()** if you are not sure. Do not
 try to use the stream after calling this routine on it.
 
 ----------
-#### SoundFreeSampleStream()
+### SoundFreeSampleStream()
     void    SoundFreeSampleStream(
             MemHandle       mh);
 
@@ -488,7 +488,7 @@ This routine frees the passed sampled sound handle. You must not try to use
 this handle after calling this routine on it.
 
 ----------
-#### SoundGetExclusive()
+### SoundGetExclusive()
     void    SoundGetExclusive(void);
 
 This routine grabs the exclusive semaphore for the sound library; if another 
@@ -499,7 +499,7 @@ to play new sounds. When done with the sound library exclusive, call
 **SoundReleaseExclusive()**.
 
 ----------
-#### SoundGetExclusiveNB()
+### SoundGetExclusiveNB()
     Boolean SoundGetExclusiveNB(void);
 
 This routine grabs the exclusive semaphore for the sound library, doing so 
@@ -512,7 +512,7 @@ When done with the sound library exclusive, call
 **SoundReleaseExclusive()**. 
 
 ----------
-#### SoundInitMusic()
+### SoundInitMusic()
     void SoundInitMusic(
             MemHandle       mh, 
             byte            voices);
@@ -523,7 +523,7 @@ instead. This allows a music buffer stored in a block referenced by a pointer
 to be playable using **SoundPlayMusic()**.
 
 ----------
-#### SoundPlayMusic()
+### SoundPlayMusic()
     Boolean     SoundPlayMusic(
             MemHandle       mh, 
             word            priority,
@@ -547,7 +547,7 @@ handle before you may use it to play music.
 **Include:** sound.h
 
 ----------
-#### SoundPlayMusicNote()
+### SoundPlayMusicNote()
     Boolean     SoundPlayMusicNote(
             MemHandle       mh,             /* handle of note */
             word            priority, 
@@ -570,7 +570,7 @@ thread had grabbed the sound exclusive).
 **Include:** sound.h
 
 ----------
-#### SoundPlayToMusicStream()
+### SoundPlayToMusicStream()
     Boolean     SoundPlayToMusicStream(
             MemHandle                   mh,
             const word                  * sample,
@@ -589,7 +589,7 @@ If you don't know the size of the buffer, it may be all right - any data in the
 buffer after the GE_END_OF_SONG will be ignored.
 
 ----------
-#### SoundPlayToSampleStream()
+### SoundPlayToSampleStream()
     Boolean SoundPlayToSampleStream(
             MemHandle                   mh,
             word _far                   * sample,
@@ -606,7 +606,7 @@ the *format* information which will determine how the DAC player handles the
 data.
 
 ----------
-#### SoundReallocMusic()
+### SoundReallocMusic()
     Boolean     SoundReallocMusic(
             MemHandle       mh,
             word _far       * song);
@@ -619,7 +619,7 @@ handle if you are not sure. See "Sound Library," Chapter 13 of the Concepts
 book to find out how to set up the buffer of music.
 
 ----------
-#### SoundReallocMusicNote()
+### SoundReallocMusicNote()
     Boolean     SoundReallocMusicNote(
             MemHandle       mh,
             word            freq,
@@ -633,7 +633,7 @@ handle. Do not call this routine with the handle of a note that may be playing;
 call **SoundStopMusicNote()** on the handle if you are not sure. 
 
 ----------
-#### SoundReleaseExclusive()
+### SoundReleaseExclusive()
     void    SoundReleaseExclusive(void);
 
 This routine releases the sound library exclusive semaphore. You will not 
@@ -643,7 +643,7 @@ sounds. If another thread called **SoundGrabExclusive()** while your thread
 had the exclusive, it will now grab the exclusive.
 
 ----------
-#### SoundStopMusic()
+### SoundStopMusic()
     Boolean     SoundStopMusic(
             MemHandle       mh);        /* Handle of music buffer */
 
@@ -651,7 +651,7 @@ This routine stops the playing of a simple music buffer. It returns *true* if th
 library was unavailable (i.e. some other thread has grabbed the exclusive).
 
 ----------
-#### SoundStopMusicNote()
+### SoundStopMusicNote()
     Boolean     SoundStopMusicNote(
             MemHandle       mh);
 
@@ -661,7 +661,7 @@ sound library was unavailable (i.e. some other thread has grabbed the
 exclusive). 
 
 ----------
-#### SoundStopMusicStream()
+### SoundStopMusicStream()
     Boolean     SoundStopMusicStream(
             MemHandle       mh);
 
@@ -670,7 +670,7 @@ flushed from the stream. It takes one argument, the token of the sound
 stream, as returned by **SoundAllocMusicStream()**.
 
 ----------
-#### SoundStopSampleStream()
+### SoundStopSampleStream()
     void    SoundStopSampleStream(
             MemHandle       mh);
 
@@ -678,7 +678,7 @@ This routine stops a sound playing through a previously allocated sampled
 sound stream.
 
 ----------
-#### SpoolConvertPaperSize()
+### SpoolConvertPaperSize()
     word    SpoolConvertPaperSize(
             int         width,          /* width of paper */
             int         height,         /* height of paper */
@@ -689,7 +689,7 @@ This routine converts a width and height into a page size number.
 **Include:** spool.goh
 
 ----------
-#### SpoolCreatePaperSize()
+### SpoolCreatePaperSize()
     Boolean     SpoolCreatePaperSize( /* Returns true if failed */
             word        * retValue, /* returns paper size value */
             char        * name,     /* name of paper size */
@@ -702,7 +702,7 @@ This routine defines and stores a new paper size for later use by the user.
 **Include:** spool.goh
 
 ----------
-#### SpoolCreatePrinter()
+### SpoolCreatePrinter()
     Boolean SpoolCreatePrinter(     /* Returns true if error 
                                        (printer already exists) */
             char                *name,      /* name of printer */
@@ -716,7 +716,7 @@ Preferences manager. Returns *true* if the printer already exists.
 **Include:** spool.goh
 
 ----------
-#### SpoolDeletePaperSize()
+### SpoolDeletePaperSize()
     Boolean     SpoolDeletePaperSize(
             word    size);      /* size number to delete */
 
@@ -725,7 +725,7 @@ This routine deletes a user-defined paper size.
 **Include:** spool.goh
 
 ----------
-#### SpoolDeletePrinter()
+### SpoolDeletePrinter()
     void    SpoolDeletePrinter(
             int     prtrNum);       /* printer number to delete */
 
@@ -734,7 +734,7 @@ Deletes the requested printer from the system.
 **Include:** spool.goh
 
 ----------
-#### SpoolGetDefaultPrinter()
+### SpoolGetDefaultPrinter()
     int     SpoolGetDefaultPrinter(); /* Returns printer number */
 
 Returns the system-default printer, which is used (for example) by the 
@@ -743,7 +743,7 @@ Returns the system-default printer, which is used (for example) by the
 **Include:** spool.goh
 
 ----------
-#### SpoolGetNumPaperSizes()
+### SpoolGetNumPaperSizes()
     int     SpoolGetNumPaperSizes(
             PageType    type);      /* type of page */
 
@@ -753,7 +753,7 @@ user-defined, that should appear in a paper size list.
 **Include:** spool.goh
 
 ----------
-#### SpoolGetNumPrinters()
+### SpoolGetNumPrinters()
     int     SpoolGetNumPrinters(
             PrinterDriverType       type);          /* driver type */
 
@@ -773,7 +773,7 @@ This routine returns the number of installed printers with the given type.
 **Include:** spool.goh
 
 ----------
-#### SpoolGetPaperSize()
+### SpoolGetPaperSize()
     XYSizeAsDWord SpoolGetPaperSize(
             int         size,       /* This must be between 0 and the return 
                                      * value of SpoolGetNumPaperSizes() */
@@ -785,7 +785,7 @@ Use this routine to determine the dimensions of a paper size.
 **Include:** spool.goh
 
 ----------
-#### SpoolGetPaperSizeOrder()
+### SpoolGetPaperSizeOrder()
     dword   SpoolGetPaperSizeOrder( /* High byte is number of unused sizes;
                                      * Low byte is # of ordered sizes */
             PageType    type,
@@ -799,7 +799,7 @@ Use this routine to determine the dimensions of a paper size.
                                      * array of user paper sizes. */
 
 ----------
-#### SpoolGetPaperSizeString()
+### SpoolGetPaperSizeString()
     Boolean     SpoolGetPaperSizeString( /* true if error*/
             char        * retValue, /* buffer for returned value */
             int         size,       /* Must be between 0 and the return
@@ -814,7 +814,7 @@ couldn't be found, the returned value will be *true*.
 **Include:** spool.goh
 
 ----------
-#### SpoolGetPrinterString()
+### SpoolGetPrinterString()
     Boolean SpoolGetPrinterString( /* Returns true if error */
             int     *retValue,  /* On return, will point to length of string */
             char    *string,    /* returned name string */
@@ -827,7 +827,7 @@ error).
 **Include:** spool.goh
 
 ----------
-#### SpoolSetDefaultPrinter()
+### SpoolSetDefaultPrinter()
     void    SpoolSetDefaultPrinter(
             int prtrNum);       /* printer number */
 
@@ -838,7 +838,7 @@ Preferences manager.
 **Include:** spool.goh
 
 ----------
-#### SpoolSetDocSize()
+### SpoolSetDocSize()
     void    SpoolSetDocSize(
             Boolean         open;           /* false if document is closed */
             PageSizeInfo    * psr);         /* NULL if document is closed */
@@ -849,7 +849,7 @@ size.
 **Include:** spool.goh
 
 ----------
-#### SpoolSetPaperSizeOrder()
+### SpoolSetPaperSizeOrder()
     void    SpoolSetPaperSizeOrder(
             void    * ptr,      /* Array of PageSizeOrder entries */
             word    number);    /* number of entries in array */
@@ -859,7 +859,7 @@ This routine resets the order in which paper sizes are displayed to the user.
 **Include:** spool.goh
 
 ----------
-#### SpreadsheetInitFile()
+### SpreadsheetInitFile()
     VMBlockHandle SpreadsheetInitFile(
             const SpreadsheetInitFileData           * ifd);
 
@@ -889,7 +889,7 @@ containing the file handle and the number of rows and columns to allocate.
 **Include:** ssheet.goh
 
 ----------
-#### StreamClose()
+### StreamClose()
     StreamError StreamClose (
             GeodeHandle         driver,
             StreamToken         stream,
@@ -909,7 +909,7 @@ If the routine is successful, it returns zero. If it is unsuccessful, it returns
 member of the **StreamError** enumerated type.
 
 ----------
-#### StreamFlush()
+### StreamFlush()
     StreamError StreamFlush (
             GeodeHandle         driver,
             StreamToken         stream);
@@ -925,7 +925,7 @@ If the routine is successful, it returns zero. If it is unsuccessful, it returns
 member of the **StreamError** enumerated type.
 
 ----------
-#### StreamOpen()
+### StreamOpen()
     StreamError  StreamOpen (
             GeodeHandle         driver,
             word                buffSize,
@@ -950,7 +950,7 @@ to **stream*. If it is unsuccessful, it returns a member of the **StreamError**
 enumerated type.
 
 ----------
-#### StreamQuery()
+### StreamQuery()
     StreamError StreamQuery (
             GeodeHandle         driver,
             StreamToken         stream,
@@ -977,7 +977,7 @@ If the routine is successful, it returns zero. If it is unsuccessful, it returns
 member of the **StreamError** enumerated type.
 
 ----------
-#### StreamRead()
+### StreamRead()
     StreamError StreamRead (
             GeodeHandle         driver,
             StreamToken         stream,
@@ -1008,7 +1008,7 @@ not read all the data requested from the stream, it returns a member of the
 *StreamError* enumerated type.
 
 ----------
-#### StreamReadByte()
+### StreamReadByte()
     StreamError StreamWriteByte (
             GeodeHandle         driver,
             StreamToken         stream,
@@ -1031,7 +1031,7 @@ If the routine is successful, it returns zero. If it is unsuccessful, it returns
 member of the **StreamError** enumerated type.
 
 ----------
-#### StreamWrite()
+### StreamWrite()
     StreamError StreamWrite (
             GeodeHandle         driver,
             StreamToken         stream,
@@ -1063,7 +1063,7 @@ not write all the data to the stream, it returns a member of the **StreamError**
 enumerated type.
 
 ----------
-#### StreamWriteByte()
+### StreamWriteByte()
     StreamError StreamWriteByte (
             GeodeHandle         driver,
             StreamToken         stream,
@@ -1086,7 +1086,7 @@ If the routine is successful, it returns zero. If it is unsuccessful, it returns
 member of the **StreamError** enumerated type.
 
 ----------
-#### SysGetConfig()
+### SysGetConfig()
     dword   SysGetConfig();
 
 This routine returns a set of values defining the system configuration. The 
@@ -1122,7 +1122,7 @@ from the returned dword.
 **Include:** system.h
 
 ----------
-#### SysGetDosEnvironment()
+### SysGetDosEnvironment()
     Boolean SysGetDosEnvironment( /* true if error (not found) */
             const char      * variable,     /* environment variable */
             char            * buffer,       /* buffer for return value */
@@ -1146,7 +1146,7 @@ If the variable is not found, the error flag returned will be true.
 **Include:** system.h
 
 ----------
-#### SysGetECLevel()
+### SysGetECLevel()
     ErrorCheckingFlags SysGetECLevel(
             MemHandle * checksumBlock);
 
@@ -1159,7 +1159,7 @@ which the checksum will be done.
 **Include:** ec.h
 
 ----------
-#### SysGetInfo()
+### SysGetInfo()
     dword   SysGetInfo(
             SysGetInfoType info);       /* type of information to retrieve */
 
@@ -1217,7 +1217,7 @@ SGIT_UI_PROCESS
 **Include:** sysstats.h
 
 ----------
-#### SysGetPenMode()
+### SysGetPenMode()
     Boolean SysGetPenMode();
 
 This routine returns true if GEOS is running on a pen-based system, false if 
@@ -1226,7 +1226,7 @@ it is not.
 **Include:** system.h
 
 ----------
-#### SysLocateFileInDosPath()
+### SysLocateFileInDosPath()
     DiskHandle SysLocateFileInDosPath( /* sets thread's error value */
             const char      * fname,        /* file name */
             char            * buffer);      /* returned path of file */
@@ -1248,7 +1248,7 @@ with **ThreadGetError()**.
 **Include:** system.h
 
 ----------
-#### SysNotify()
+### SysNotify()
     word    SysNotify(
             SysNotifyFlags      flags,          /* options to offer user */
             const char          * string1,      /* first string to display */
@@ -1300,13 +1300,13 @@ user selects this option, the routine will not return.
 **Include:** system.h
 
 ----------
-#### SysRegisterScreen()
+### SysRegisterScreen()
     void    SysRegisterScreen(
             GeodeHandle     driver,
             WindowHandle        root);
 
 ----------
-#### SysSetECLevel()
+### SysSetECLevel()
     void    SysSetECLevel(
             ErrorCheckingFlags  flags,          /* level of error checking */
             MemHandle           checksumBlock); /* block to check, if any */
@@ -1319,13 +1319,13 @@ also pass the handle of a block on which the checksum will be performed.
 **Include:** ec.h
 
 ----------
-#### SysSetExitFlags()
+### SysSetExitFlags()
     word    SysGetExitFlags(
             ExitFlags       bitsToSet,
             ExitFlags       bitsToClear);
 
 ----------
-#### SysShutdown()
+### SysShutdown()
     Boolean SysShutdown(
             SysShutdownType     type,
             ...);
@@ -1461,7 +1461,7 @@ continued, FALSE if the shutdown should be aborted.
 with extreme care.
 
 ----------
-#### SysStatistics()
+### SysStatistics()
     void    SysStatistics(
             SysStats * stats);          /* returned statistics */
 
@@ -1481,11 +1481,11 @@ empty **SysStats** structure; the routine will fill in the appropriate fields.
 **Include:** sysstats.h
 
 ----------
-#### SysUnlockBIOS()
+### SysUnlockBIOS()
     void    SysUnlockBIOS(void);
 
 ----------
-#### TextSearchInString()
+### TextSearchInString()
     char *  TextSearchInSTring(
             const char      *str1,
             conat char      *startPtr,
@@ -1520,7 +1520,7 @@ word itself is returned by the routine.)
 **Include:** Objects/vTextC.goh
 
 ----------
-#### TextSearchInHugeArray()
+### TextSearchInHugeArray()
     dword   TextSearchInSTring(
             char            *str2,
             word            str2Size,
@@ -1559,7 +1559,7 @@ word itself is returned by the routine.)
 **Include:** Objects/vTextC.goh
 
 ----------
-#### TGI_PRIORITY()
+### TGI_PRIORITY()
     byte    TGI_PRIORITY(val);
             word    val;
 
@@ -1567,7 +1567,7 @@ This macro extracts the thread priority from the value returned by
 **ThreadGetInfo()**.
 
 ----------
-#### TGI_RECENT_CPU_USAGE()
+### TGI_RECENT_CPU_USAGE()
     byte    TGI_RECENT_CPU_USAGE(val);
             word    val;
 
@@ -1575,7 +1575,7 @@ This macro extracts the recent CPU usage from the value returned by
 **ThreadGetInfo()**.
 
 ----------
-#### ThreadAllocSem()
+### ThreadAllocSem()
     SemaphoreHandle ThreadAllocSem(
             word    value);         /* allowable locks on the semaphore */
 
@@ -1588,7 +1588,7 @@ will be one. The routine returns the handle of the new semaphore.
 **Include:** sem.h
 
 ----------
-#### ThreadAllocThreadLock()
+### ThreadAllocThreadLock()
     ThreadLockHandle ThreadAllocThreadLock();
 
 This routine allocates a special semaphore called a thread lock. With a 
@@ -1603,7 +1603,7 @@ In all other aspects, however, the thread lock resembles a normal semaphore.
 **Include:** sem.h
 
 ----------
-#### ThreadAttachToQueue()
+### ThreadAttachToQueue()
     void    ThreadAttachToQueue(
             QueueHandle     qh,             /* queue to attach */
             ClassStruct     * class);       /* primary class of thread */
@@ -1625,7 +1625,7 @@ threads, and it is nearly always taken care of automatically by
 **Include:** thread.h
 
 ----------
-#### ThreadCreate()
+### ThreadCreate()
     ThreadHandle ThreadCreate(
             word    priority,       /* Initial base priority of new thread */
             word    valueToPass,    /* Optional data to pass to new thread */
@@ -1706,7 +1706,7 @@ take any amount of time to complete.
 **Include:** thread.h
 
 ----------
-#### ThreadDestroy()
+### ThreadDestroy()
     void    ThreadDestroy(
             word    errorCode,  /* Error code to indicate cause of destruction */
             optr    ackObject,  /* Object to receive destruction acknowledgment */
@@ -1734,7 +1734,7 @@ clean up after itself.
 **Include:** thread.h
 
 ----------
-#### ThreadFreeSem()
+### ThreadFreeSem()
     void    ThreadFreeSem(
             SemaphoreHandle sem);           /* semaphore to be freed */
 
@@ -1746,7 +1746,7 @@ could cause illegal handle errors or worse.
 **Include:** sem.h
 
 ----------
-#### ThreadFreeThreadLock()
+### ThreadFreeThreadLock()
     void    ThreadFreeThreadLock(
             ThreadLockHandle sem);              /* thread lock to be freed */
 
@@ -1758,13 +1758,13 @@ or release the thread lock could cause illegal handle errors.
 **Include:** sem.h
 
 ----------
-#### ThreadGetError()
+### ThreadGetError()
     word    ThreadGetError(void)
 
 This routine returns the thread's current error value.
 
 ----------
-#### ThreadGetInfo()
+### ThreadGetInfo()
     word    ThreadGetInfo(
             ThreadHandle        th,     /* thread to get information about */
             ThreadGetInfoType   info);  /* type of information to get */
@@ -1796,7 +1796,7 @@ event-driven, a null queue handle will be returned.
 **Include:** thread.h
 
 ----------
-#### ThreadGrabThreadLock()
+### ThreadGrabThreadLock()
     void    ThreadGrabThreadLock(
             ThreadLockHandle sem);              /* thread lock to grab */
 
@@ -1815,7 +1815,7 @@ grabbed in the same order to minimize the potential for deadlock.
 **Include:** sem.h
 
 ----------
-#### ThreadHandleException()
+### ThreadHandleException()
     void    ThreadHandleException(
             ThreadHandle        th,         /* thread to handle the exception */
             ThreadExceptions    exception,  /* exception to handle */
@@ -1845,7 +1845,7 @@ pointer to use the GEOS default exception handler.
 **Include:** thread.h
 
 ----------
-#### ThreadModify()
+### ThreadModify()
     void    ThreadModify(
             ThreadHandle        th,                 /* thread to modify */
             word                newBasePriority,    /* thread's new base priority */
@@ -1872,7 +1872,7 @@ zero.
 **Include:** thread.h
 
 ----------
-#### ThreadPrivAlloc()
+### ThreadPrivAlloc()
     word    ThreadPrivAlloc(
             word            wordsRequested,     /* number of words to allocate */
             GeodeHandle     owner);             /* handle of geode to own data */
@@ -1886,7 +1886,7 @@ geodes (loaded and yet-to-be loaded). It is exactly the same as
 **See Also:** GeodePrivAlloc()
 
 ----------
-#### ThreadPrivFree()
+### ThreadPrivFree()
     void    ThreadPrivFree(
             word    range,              /* offset to first word to be freed */
             word    wordsRequested);    /* number of words to free */
@@ -1900,7 +1900,7 @@ the entry for that routine for full information.
 **See Also:** GeodePrivFree()
 
 ----------
-#### ThreadPSem()
+### ThreadPSem()
     SemaphoreError ThreadPSem(
             SemaphoreHandle sem);               /* semaphore to grab */
 
@@ -1928,7 +1928,7 @@ lock instead (see **ThreadAllocThreadLock()** for more information).
 **Include:** sem.h
 
 ----------
-#### ThreadPTimedSem()
+### ThreadPTimedSem()
     SemaphoreError ThreadPTimedSem(
             SemaphoreHandle     sem,        /* semaphore to grab */
             word                timeout);   /* ticks before timeout */
@@ -1974,7 +1974,7 @@ lock instead, though there is no timeout equivalent for thread locks (see
 **Include:** sem.h
 
 ----------
-#### ThreadReleaseThreadLock()
+### ThreadReleaseThreadLock()
     void    ThreadReleaseThreadLock(
             ThreadLockHandle sem);              /* threadlock to release */
 
@@ -1988,7 +1988,7 @@ results are unpredictable.
 **Include:** sem.h
 
 ----------
-#### ThreadVSem()
+### ThreadVSem()
     void    ThreadVSem(
             SemaphoreHandle sem);               /* semaphore to release */
 
@@ -2002,7 +2002,7 @@ one of the above routines. The results are unpredictable.
 **Include:** sem.h
 
 ----------
-#### TimerGetCount()
+### TimerGetCount()
     dword   TimerGetCount();
 
 This routine returns the value of the system counter. The returned value is 
@@ -2011,7 +2011,7 @@ the number of ticks since GEOS started.
 **Include:** timer.h
 
 ----------
-#### TimerGetDateAndTime()
+### TimerGetDateAndTime()
     void    TimerGetDateAndTime(
             TimerDateAndTime * dateAndTime);    /* buffer for returned values */
 
@@ -2021,7 +2021,7 @@ This routine returns the current time and date. Pass it a pointer to an empty
 **Include:** timedate.h
 
 ----------
-#### TimerSetDateAndTime()
+### TimerSetDateAndTime()
     void    TimerSetDateAndTime(
             word                    flags,          /* which item to set */
             const TimerDateAndTime  * dateAndTime); /* new values */
@@ -2039,7 +2039,7 @@ information to be set.
 **Include:** timedate.h
 
 ----------
-#### TimerSleep()
+### TimerSleep()
     void    TimerSleep(
             word    ticks);     /* number of ticks the thread should sleep */
 
@@ -2053,7 +2053,7 @@ synchronization.
 **Include:** timer.h
 
 ----------
-#### TimerStart()
+### TimerStart()
     TimerHandle TimerStart(
             TimerType   timerType,      /* type of timer to start */
             optr        destObject,     /* object to receive notification
@@ -2128,7 +2128,7 @@ wake a sleeping machine.
 **Include:** timer.h
 
 ----------
-#### TimerStop()
+### TimerStop()
     Boolean TimerStop(
             TimerHandle     th,     /* handle of timer to be stopped */
             word            id);    /* timer ID (returned by TimerStart() */
@@ -2148,7 +2148,7 @@ destination an "all-safe" message with the MF_FORCE_QUEUE flag.
 **Include:** timer.h
 
 ----------
-#### TocDBLock()
+### TocDBLock()
     void * TocDBLock(
             DBGroupAndItem      thing);
 
@@ -2157,7 +2157,7 @@ Use this routine to lock a name array maintained by a PrefTocList object.
 **Include:** config.goh
 
 ----------
-#### TocDBLockGetRef()
+### TocDBLockGetRef()
     void * TocDBLockGetRef(
             DBGroupAndItem      thing,
             optr                *refPtr);
@@ -2168,7 +2168,7 @@ returning the item's pointer and optr.
 **Include:** config.goh
 
 ----------
-#### TocFindCategory()
+### TocFindCategory()
     Boolean TocFindCategory(
             TocCategoryStruct       *cat);
 
@@ -2187,7 +2187,7 @@ This routine searches a PrefTocList object's name list for a given token.
 **Include:** config.goh
 
 ----------
-#### TocGetFileHandle()
+### TocGetFileHandle()
     word TocGetFileHandle();
 
 Use this routine to get the handle of the file used by PrefTocLists to store 
@@ -2196,7 +2196,7 @@ their name array data.
 **Include:** config.goh
 
 ----------
-#### TocNameArrayAdd()
+### TocNameArrayAdd()
     word TocNameArrayAdd(
             DBGroupAndItem      array, 
             const char          *nameToFind,
@@ -2208,7 +2208,7 @@ object.
 **Include:** config.h
 
 ----------
-#### TocNameArrayFind()
+### TocNameArrayFind()
     word TocNameArrayGetElement(
             DBGroupAndItem      array, 
             word                element,
@@ -2220,7 +2220,7 @@ object.
 **Include:** config.goh
 
 ----------
-#### TocNameArrayGetElement()
+### TocNameArrayGetElement()
     word TocNameArrayGetElement(
             DBGroupAndItem      array, 
             word        element,
@@ -2232,7 +2232,7 @@ by a PrefTocList object.
 **Include:** config.goh
 
 ----------
-#### TocSortedNameArrayAdd()
+### TocSortedNameArrayAdd()
     word TocSortedNameArrayAdd(
             word                arr, 
             const char          *nameToAdd,
@@ -2250,7 +2250,7 @@ PrefTocList object.
 **Include:** config.goh
 
 ----------
-#### TocSortedNameArrayFind()
+### TocSortedNameArrayFind()
     Boolean TocSortedNameArrayFind(
             word                        arr, 
             const char                  *nameToFind,
@@ -2269,7 +2269,7 @@ PrefTocList object.
 **Include:** config.goh
 
 ----------
-#### TocUpdateCategory()
+### TocUpdateCategory()
     void TocUpdateCategory(
             TocUpdateCategoryParams *params);
 
@@ -2295,7 +2295,7 @@ directory with a given token.
 **Include:** config.goh
 
 ----------
-#### TOKEN_CHARS()
+### TOKEN_CHARS()
     dword   TOKEN_CHARS(a, b, c, d);
             char    a, b, c, d;
 
@@ -2303,7 +2303,7 @@ This macro creates a single dword value from four given characters. This is
 useful when creating a token characters value for a specific token.
 
 ----------
-#### TokenDefineToken()
+### TokenDefineToken()
     word    TokenDefineToken(
             dword           tokenChars,         /* four token characters */
             ManufacturerID  manufacturerID,     /* manufacturer ID for token */
@@ -2334,7 +2334,7 @@ thereby invalidating all pointers to token database items.
 **Include:** token.h
 
 ----------
-#### TokenGetTokenInfo()
+### TokenGetTokenInfo()
     Boolean TokenGetTokenInfo(
             dword           tokenChars,         /* four characters of token */
             ManufacturerID  manufacturerID,     /* manufacturer ID of token */
@@ -2359,7 +2359,7 @@ found in the token database. It returns zero if successful.
 **Include:** token.h
 
 ----------
-#### TokenListTokens()
+### TokenListTokens()
     dword   TokenListTokens(
             TokenRangeFlags     tokenRangeFlags,
             word                headerSize,
@@ -2378,7 +2378,7 @@ handle of the newly-allocated block and can be extracted with the macro
 **Include:** token.h
 
 ----------
-#### TokenListTokensCountFromDWord()
+### TokenListTokensCountFromDWord()
     word    TokenListTokensCountFromDWord(d);
             dword   d;
 
@@ -2386,7 +2386,7 @@ This macro extracts the number of tokens from the value returned by
 **TokenListTokens()**.
 
 ----------
-#### TokenListTokensHandleFromDWord()
+### TokenListTokensHandleFromDWord()
     word    TokenListTokensHandleFromDWord(d);
             dword   d;
 
@@ -2394,7 +2394,7 @@ This routine extracts the MemHandle from the value returned by
 **TokenListTokens()**.
 
 ----------
-#### TokenLoadMonikerBlock()
+### TokenLoadMonikerBlock()
     Boolean TokenLoadMonikerBlock(
             dword                   tokenChars,     /* four characters of token */
             ManufacturerID          manufacturerID, /* manufacturer ID of token */
@@ -2434,7 +2434,7 @@ returned.
 **Include:** token.h
 
 ----------
-#### TokenLoadMonikerBuffer()
+### TokenLoadMonikerBuffer()
     Boolean TokenLoadMonikerBuffer(
             dword                   tokenChars,         /* four characters of token */
             ManufacturerID          manufacturerID,     /* manufacturer ID of token */
@@ -2475,7 +2475,7 @@ moniker that may be returned.
 **Include:** token.h
 
 ----------
-#### TokenLoadMonikerChunk()
+### TokenLoadMonikerChunk()
     Boolean TokenLoadMonikerChunk(
             dword                   tokenChars,     /* four characters of token */
             ManufacturerID          manufacturerID, /* manufacturer ID of token */
@@ -2520,7 +2520,7 @@ pointers to any chunk in the block.
 **Include:** token.h
 
 ----------
-#### TokenLoadTokenBlock()
+### TokenLoadTokenBlock()
     Boolean TokenLoadTokenBlock(
             dword           tokenChars,         /* four characters of token */
             ManufacturerID  manufacturerID,     /* manufacturer ID of token */
@@ -2549,7 +2549,7 @@ newly-allocated block will be returned.
 **Include:** token.h
 
 ----------
-#### TokenLoadTokenBuffer()
+### TokenLoadTokenBuffer()
     Boolean TokenLoadTokenBuffer(
             dword           tokenChars,         /* four characters of token */
             ManufacturerID  manufacturerID,     /* manufacturer ID of token */
@@ -2572,7 +2572,7 @@ will be copied.
 **Include:** token.h
 
 ----------
-#### TokenLoadTokenChunk()
+### TokenLoadTokenChunk()
     Boolean TokenLoadTokenChunk(
             dword           tokenChars,         /* four characters of token */
             ManufacturerID  manufacturerID,     /* manufacturer ID of token */
@@ -2609,7 +2609,7 @@ pointers to any chunk in the block.
 **Include:** token.h
 
 ----------
-#### TokenLockTokenMoniker()
+### TokenLockTokenMoniker()
     void    * TokenLockTokenMoniker(
             TokenMonikerInfo    tokenMonikerInfo);  /* The DB group and item numbers
                                  * as returned by TokenLookupMoniker() */
@@ -2624,7 +2624,7 @@ drawing it.
 **Include:** token.h
 
 ----------
-#### TokenLookupMoniker()
+### TokenLookupMoniker()
     Boolean TokenLookupMoniker(
             dword                   tokenChars,         /* four characters of token */
             ManufacturerID          manufacturerID,     /* manufacturer ID of token */
@@ -2658,13 +2658,13 @@ in the token database, *false* otherwise.
 **Include:** token.h
 
 ----------
-#### TokenCloseLocalTokenDB()
+### TokenCloseLocalTokenDB()
     void    TokenCloseLocalTokenDB()
 
 This routine closes the local token database.
 
 ----------
-#### TokenListTokens()
+### TokenListTokens()
     dword TokenListTokens(
             TokenRangeFlags     tokenRangeFlags,
             word                headerSize,
@@ -2676,7 +2676,7 @@ is the number of matching tokens found; the lower word is the handle of the
 block which was allocated.
 
 ----------
-#### TokenOpenLocalTokenDB()
+### TokenOpenLocalTokenDB()
     word    TokenOpenLocalTokenDB()
 
 This routine opens the local token database. It returns zero on success, and 
@@ -2685,7 +2685,7 @@ a **VMStatus** error code on failure.
 **Include:** token.h
 
 ----------
-#### TokenRemoveToken
+### TokenRemoveToken
     Boolean TokenRemoveToken(
             dword           tokenChars,         /* four characters of token */
             ManufacturerID  manufacturerID,     /* manufacturer ID of token */
@@ -2704,7 +2704,7 @@ for the token database entry.
 **Include:** token.h
 
 ----------
-#### TokenUnlockTokenMoniker()
+### TokenUnlockTokenMoniker()
     void    TokenUnlockTokenMoniker(
             void * moniker);
 
@@ -2715,7 +2715,7 @@ the locking routine.
 **Include:** token.h
 
 ----------
-#### TypeFromFormatID()
+### TypeFromFormatID()
     word    TypeFromFormatID(id);
             ClipboardItemFormatID   id;
 

--- a/TechDocs/Markdown/Routines/rroutu_z.md
+++ b/TechDocs/Markdown/Routines/rroutu_z.md
@@ -1,6 +1,6 @@
 ## 3.7 Routines U-Z
 ----------
-#### UserAddAutoExec()
+### UserAddAutoExec()
     void    UserAddAutoExec(
             const char *        appName);
 
@@ -14,7 +14,7 @@ SP_APPLICATION or SP_SYS_APPLICATION.
 **Include:** ui.goh
 
 ----------
-#### UserCreateDialog()
+### UserCreateDialog()
     optr    UserCreateDialog(
             optr    dialogBox);
 
@@ -32,7 +32,7 @@ dialog box.
 **See Also:** UserDestroyDialog()
 
 ----------
-#### UserCreateInkDestinationInfo()
+### UserCreateInkDestinationInfo()
     MemHandle   UserCreateInkDestinationInfo(
             optr                dest,
             GStateHandle        gs,
@@ -53,7 +53,7 @@ declared _pascal.
         word numStrokes);
 
 ----------
-#### UserDestroyDialog()
+### UserDestroyDialog()
     void    UserDestroyDialog(
             optr    dialogBox);
 
@@ -66,7 +66,7 @@ routine to destroy dialogs created with **UserCreateDialog()**.
 **See Also:** UserCreateDialog()
 
 ----------
-#### UserDoDialog()
+### UserDoDialog()
     InteractionCommand UserDoDialog(
             optr    dialogBox);
 
@@ -106,7 +106,7 @@ messages from the response triggers.
 **See Also:** UserStandardDialog(), UserStandardDialogOptr()
 
 ----------
-#### UserGetInterfaceLevel()
+### UserGetInterfaceLevel()
     UIInterfaceLevel UserGetInterfaceLevel(void)
 
 This routine returns the current **UIInterfaceLevel**. This is a word-sized 
@@ -121,7 +121,7 @@ enumerated type. It has the following values:
 **Include:** ui.goh
 
 ----------
-#### UserLoadApplication
+### UserLoadApplication
     extern  GeodeHandle UserLoadApplication(
             AppLaunchFlags      alf,
             Message             attachMethod,
@@ -136,7 +136,7 @@ launched into the AppLaunchBlock, so that information needed to restore
 this application instance will be around later if needed.
 
 ----------
-#### UserRemoveAutoExec()
+### UserRemoveAutoExec()
     void    UserRemoveAutoExec(
             const char *        appName);
 
@@ -149,7 +149,7 @@ name of the application.
 **Include:** ui.goh
 
 ----------
-#### UserStandardDialog()
+### UserStandardDialog()
     word    UserStandardDialog(
             char *                  helpContext,
             char *                  customTriggers,
@@ -190,7 +190,7 @@ If the **CustomDialogType** is GIT_MULTIPLE_RESPONSE, you must also set
 up a Response Trigger Table with several trigger parameters.
 
 ----------
-#### UserStandardDialogOptr()
+### UserStandardDialogOptr()
     word    UserStandardDialogOptr(
             char                    *helpContext,
             optr                    customTriggers,
@@ -207,7 +207,7 @@ blocks.
 **See Also:** UserStandardDialog(), UserDoDialog() 
 
 ----------
-#### UserStandardSound()
+### UserStandardSound()
     void    UserStandardSound(
             StandardSoundType       type,
             ...);
@@ -260,7 +260,7 @@ played. You must provide one further argument, the handle of
 the note (such as returned by **SoundAllocNote()**).
 
 ----------
-#### UtilAsciiToHex32()
+### UtilAsciiToHex32()
     Boolean UtilAsciiToHex32(
             const char *        string,
             dword *             value);
@@ -286,7 +286,7 @@ signed 32-bit integer.
 **Include:** system.h
 
 ----------
-#### UtilHex32ToAscii()
+### UtilHex32ToAscii()
     word    UtilHex32ToAscii(
             char *                      buffer,
             sdword                      value, 
@@ -318,7 +318,7 @@ ten bytes long.
 **Include:** system.h
 
 ----------
-#### VarDataFlagsPtr()
+### VarDataFlagsPtr()
     VarDataFlags    VarDataFlagsPtr(
             void *  ptr);
 
@@ -333,7 +333,7 @@ returned.
 space.
 
 ----------
-#### VarDataSizePtr()
+### VarDataSizePtr()
     word    VarDataSizePtr(
             void *  ptr);
 
@@ -346,7 +346,7 @@ the extra data for the type.
 space.
 
 ----------
-#### VarDataTypePtr()
+### VarDataTypePtr()
     word    VarDataTypePtr(
             void *  ptr);
 
@@ -360,11 +360,11 @@ flags outside the VDF_TYPE section will be cleared.
 space.
 
 ----------
-#### VisObjectHandlesInkReply()
+### VisObjectHandlesInkReply()
     void    VisObjectHandlesInkReply(void);
 
 ----------
-#### VisTextGraphicCompressGraphic()
+### VisTextGraphicCompressGraphic()
     extern VMChain VisTextGraphicCompressGraphic(
             VisTextGraphic      *graphic,
             FileHandle          sourceFile,
@@ -376,7 +376,7 @@ space.
 This routine compresses the bitmaps in a VisTextGraphic.
 
 ----------
-#### VMAlloc()
+### VMAlloc()
     VMBlockHandle   VMAlloc(
             VMFileHandle    file,           
             word            size,       /* Size of a file in bytes */
@@ -393,7 +393,7 @@ assigned with **VMAttach()**.
 **See Also:** VMAllocLMem(), VMAttach()
 
 ----------
-#### VMAllocLMem()
+### VMAllocLMem()
     VMBlockHandle   VMAllocLmem(
             VMFileHandle    file,               
             LMemType        ltype,          /* Type of LMem heap to create */
@@ -419,7 +419,7 @@ to the LMem routines (not the block's VM handle).
 **See Also:** LMemInitHeap(), VMAlloc(), VMAttach()
 
 ----------
-#### VMAttach()
+### VMAttach()
     VMBlockHandle   VMAttach(
             VMFileHandle        file,
             VMBlockHandle       vmBlock,
@@ -447,7 +447,7 @@ undefined.
 **Include:** vm.h
 
 ----------
-#### VMCheckForModifications()
+### VMCheckForModifications()
 Boolean VMCheckForModifications(
             VMFileHandle        file);
 
@@ -457,7 +457,7 @@ last full save.
 **Include:** vm.h
 
 ----------
-#### VMClose()
+### VMClose()
     word    VMClose(
             VMFileHandle        file,
             Boolean             noErrorFlag);
@@ -475,7 +475,7 @@ update and close the file.
 **Include:** vm.h
 
 ----------
-#### VMCompareVMChains()
+### VMCompareVMChains()
     Boolean VMCompareVMChains(
             VMFileHandle        sourceFile,
             VMChain             sourceChain,
@@ -488,7 +488,7 @@ are identical; otherwise it returns *false*.
 **Include:** vm.h
 
 ----------
-#### VMCopyVMBlock()
+### VMCopyVMBlock()
     VMBlockHandle   VMCopyVMBlock(
             VMFileHandle        sourceFile,
             VMBlockHandle       sourceBlock,
@@ -501,7 +501,7 @@ handle. The duplicate will have the same user ID as the original block.
 **Include:** vm.h
 
 ----------
-#### VMCopyVMChain()
+### VMCopyVMChain()
     VMChain     VMCopyVMChain(
             VMFileHandle        sourceFile,
             VMChain             sourceChain,
@@ -515,7 +515,7 @@ same user ID numbers as the corresponding original blocks.
 **Include:** vm.h
 
 ----------
-#### VMDetach()
+### VMDetach()
     MemHandle   VMDetach(
             VMFileHandle    file,
             VMBlockHandle   block,
@@ -530,7 +530,7 @@ the block to the file before detaching it.
 **Include:** vm.h
 
 ----------
-#### VMDirty()
+### VMDirty()
     void    VMDirty(
             MemHandle       mh);
 
@@ -539,7 +539,7 @@ This routine marks a locked VM block as dirty.
 **Include:** vm.h
 
 ----------
-#### VMFind()
+### VMFind()
     VMBlockHandle   VMFind(
             VMFileHandle        file,
             VMBlockHandle       startBlock,
@@ -554,7 +554,7 @@ order).
 **Include:** vm.h
 
 ----------
-#### VMFree()
+### VMFree()
     void    VMFree(
             VMFileHandle        file,
             VMBlockHandle       block);
@@ -565,7 +565,7 @@ currently attached to the VM block, it is freed too.
 **Include:** vm.h
 
 ----------
-#### VMFreeVMChain()
+### VMFreeVMChain()
     void    VMFreeVMChain(
             VMFileHandle        file,
             VMChain             chain);
@@ -576,7 +576,7 @@ all blocks in the chain will be freed.
 **Include:** vm.h
 
 ----------
-#### VMGetAttributes()
+### VMGetAttributes()
     word    VMGetAttributes(
             VMFileHandle        file);
 
@@ -591,7 +591,7 @@ the attributes appropriately.
 **See Also:** VMSetAttributes()
 
 ----------
-#### VMGetDirtyState()
+### VMGetDirtyState()
     word    VMGetDirtyState(
             VMFileHandle        file);
 
@@ -608,7 +608,7 @@ to call **VMUpdate()** than it is to first check the dirty state, then call
 **VMUpdate()** only if the file is dirty.
 
 ----------
-#### VMGetMapBlock()
+### VMGetMapBlock()
     VMBlockHandle   VMGetMapBlock(
             VMFIleHandle        file);
 
@@ -617,7 +617,7 @@ This routine returns the VM block handle of the file's map block.
 **Include:** vm.h
 
 ----------
-#### VMGrabExclusive()
+### VMGrabExclusive()
     VMStartExclusiveReturnValue VMGrabExclusive(
             VMFileHandle        file,
             word                timeout,
@@ -629,7 +629,7 @@ This routine gets exclusive access to a VM file for this thread.
 **Include:** vm.h
 
 ----------
-#### VMInfo()
+### VMInfo()
     Boolean VMInfo(
             VMFileHandle        file,
             VMBlockHandle       block,
@@ -641,7 +641,7 @@ block. It returns *false* if the handle is invalid or free.
 **Include:** vm.h
 
 ----------
-#### VMLock()
+### VMLock()
     void *  VMLock(
             VMFileHandle        file,
             VMBlockHandle       block,
@@ -653,7 +653,7 @@ address.
 **Include:** vm.h
 
 ----------
-#### VMMemBlockToVMBlock()
+### VMMemBlockToVMBlock()
     VMBlockHandle   VMMemBlockToVMBlock(
             MemHandle           mh,
             VMFileHandle*       file);
@@ -667,7 +667,7 @@ to a VM file. If it is not, the results are undefined.
 **Include:** vm.h
 
 ----------
-#### VMModifyUserID()
+### VMModifyUserID()
     void    VMModifyUserID(
             VMFileHandle        file,
             VMBlockHandle       block,
@@ -678,7 +678,7 @@ This routine changes a VM block's user ID number.
 **Include:** vm.h
 
 ----------
-#### VMOpen()
+### VMOpen()
     VMFileHandle    VMOpen(
             char *          name,           /* Name of file to open/create */
             VMAccessFlags   flags,
@@ -813,7 +813,7 @@ necessary; you will not need to call **VMOpen()**.
 **See Also:** FileOpen()
 
 ----------
-#### VMPreserveBlocksHandle()
+### VMPreserveBlocksHandle()
     void    VMPreserveBlocksHandle(
             VMFileHandle        file,
             VMBlockHandle       block);
@@ -824,7 +824,7 @@ explicitly detached or the VM block is freed.
 **Include:** vm.h
 
 ----------
-#### VMReleaseExclusive()
+### VMReleaseExclusive()
     void VMReleaseExclusive(
             VMFileHandle        file);
 
@@ -833,7 +833,7 @@ This routine releases a thread's exclusive access to a VM file.
 **Include:** vm.h
 
 ----------
-#### VMRevert()
+### VMRevert()
     void    VMRevert(
             VMFileHandle        file,);
 
@@ -842,7 +842,7 @@ This routine reverts a file to its last-saved state.
 **Include:** vm.h
 
 ----------
-#### VMSave()
+### VMSave()
     void    VMSave(
             VMFileHandle        file);
 
@@ -851,7 +851,7 @@ This routine updates and saves a file, freeing all backup blocks.
 **Include:** vm.h
 
 ----------
-#### VMSaveAs()
+### VMSaveAs()
     VMFileHandle VMSaveAs(
             VMFileHandle        file,
             const char          *name,
@@ -865,7 +865,7 @@ last-saved condition.
 **Include:** vm.h
 
 ----------
-#### VMSetAttributes()
+### VMSetAttributes()
     word    VMSetAttributes(
             VMFileHandle    file,
             VMAttributes    attrToSet,      /* Turn these flags on... */
@@ -885,7 +885,7 @@ the attributes appropriately.
 **See Also:** VMGetAttributes()
 
 ----------
-#### VMSetExecThread()
+### VMSetExecThread()
     void    VMSetExecThread(
             VMFileHandle        file,
             ThreadHandle        thread);
@@ -895,7 +895,7 @@ Set which thread will execute methods of all objects in the file.
 **Include:** vm.h
 
 ----------
-#### VMSetMapBlock()
+### VMSetMapBlock()
     void    VMSetMapBlock(
             VMFileHandle        file,
             VMBlockHandle       block);
@@ -905,7 +905,7 @@ This routine sets the map block for a VM file.
 **Include:** vm.h
 
 ----------
-#### VMSetReloc()
+### VMSetReloc()
     void    VMSetReloc(
             VMFileHandle    file,
             void (*reloc)   (VMFileHandle       file,
@@ -919,7 +919,7 @@ This routine sets a data-relocation routine for the VM file.
 **Include:** vm.h
 
 ----------
-#### VMUnlock()
+### VMUnlock()
     void    VMUnlock(
             MemHandle       mh);
 
@@ -929,7 +929,7 @@ handle is passed (not its VM handle).
 **Include:** vm.h
 
 ----------
-#### VMUpdate()
+### VMUpdate()
     word    VMUpdate(
             VMFileHandle        file);
 
@@ -943,7 +943,7 @@ is to check the dirty state and then call **VMUpdate()** only if the file is
 actually dirty.
 
 ----------
-#### VMVMBlockToMemBlock()
+### VMVMBlockToMemBlock()
     MemHandle   VMVMBlockToMemBlock(
             VMFileHandle        file,
             VmBlockHandle       block);
@@ -955,7 +955,7 @@ attach one.
 **Include:** vm.h
 
 ----------
-#### WinAckUpdate()
+### WinAckUpdate()
     void    WinAckUpdate(
             WindowHandle        win);
 
@@ -966,7 +966,7 @@ updating.
 **Include:** win.h
 
 ----------
-#### WinApplyRotation()
+### WinApplyRotation()
     void    WinApplyRotation(
             WindowHandle        win,
             WWFixedAsDWord      angle,
@@ -978,7 +978,7 @@ matrix.
 **Include:** win.h
 
 ----------
-#### WinApplyScale()
+### WinApplyScale()
     void    WinApplyScale(
             WindowHandle        win,
             WWFixedAsDWord      xScale,
@@ -991,7 +991,7 @@ matrix.
 **Include:** win.h
 
 ----------
-#### WinApplyTranform()
+### WinApplyTranform()
     void    WinApplyTransform(
             WindowHandle            win,
             const TransMatrix *     tm,
@@ -1004,7 +1004,7 @@ transformation matrix.
 **Include:** win.h
 
 ----------
-#### WinApplyTranslation()
+### WinApplyTranslation()
     void    WinApplyTranslation(
             WindowHandle        win,
             WWFixedAsDWord      xTrans,
@@ -1017,7 +1017,7 @@ matrix.
 **Include:** win.h
 
 ----------
-#### WinApplyTranslationDWord()
+### WinApplyTranslationDWord()
     void    WinApplyExtTranslation(
             WindowHandle        win,
             sdword              xTrans,
@@ -1030,7 +1030,7 @@ matrix. The translations are specified as 32-bit integers.
 **Include:** win.h
 
 ----------
-#### WinChangeAck()
+### WinChangeAck()
     WindowHandle WinChangeAck(
             WindowHandle        win,
             sword               x,
@@ -1039,7 +1039,7 @@ matrix. The translations are specified as 32-bit integers.
             Include:            win.h
 
 ----------
-#### WinChangePriority()
+### WinChangePriority()
     void    WinChangePriority(
             WindowHandle        win,
             WinPassFlags        flags,
@@ -1050,7 +1050,7 @@ This routine changes the priority for the specified window.
 **Include:** win.h
 
 ----------
-#### WinClose()
+### WinClose()
     void    WinClose(
             WindowHandle        win);
 
@@ -1059,20 +1059,20 @@ This routine closes and frees the specified window.
 **Include:** win.h
 
 ----------
-#### WinDecRefCount()
+### WinDecRefCount()
     void    WinDecRefCount(
             WindowHandle        win);
 
 This routine is part of the window closing mechanism.
 
 ----------
-#### WinEnsureChangeNotification()
+### WinEnsureChangeNotification()
     void    WinEnsureChangeNotification(void);
 
 **Include:** win.h
 
 ----------
-#### WinGeodeGetInputObj()
+### WinGeodeGetInputObj()
     optr    WinGeodeGetInputObj(
             GeodeHandle     obj);
 
@@ -1082,7 +1082,7 @@ there is no such object, it returns a null optr.
 **Include:** win.h
 
 ----------
-#### WinGeodeGetParentObj()
+### WinGeodeGetParentObj()
     optr    WinGeodeGetParentObj(
             GeodeHandle     obj);
 
@@ -1092,7 +1092,7 @@ there is no such object, it returns a null optr.
 **Include:** win.h
 
 ----------
-#### WinGeodeSetActiveWin()
+### WinGeodeSetActiveWin()
     void    WinGeodeSetActiveWin(
             GeodeHandle         gh,
             WindowHandle        win);
@@ -1102,7 +1102,7 @@ This routine sets the active window for the specified geode.
 **Include:** win.h
 
 ----------
-#### WinGeodeSetInputObj()
+### WinGeodeSetInputObj()
     void    WinGeodeSetInputObj(
             GeodeHandle     gh,
             optr            iObj);
@@ -1112,7 +1112,7 @@ This routine sets the input object for the specified geode.
 **Include:** win.h
 
 ----------
-#### WinGeodeSetParentObj()
+### WinGeodeSetParentObj()
     void    WinGeodeSetParentObj(
             GeodeHandle     gh,
             optr            pObj);
@@ -1122,7 +1122,7 @@ This routine sets the parent object for the specified geode.
 **Include:** win.h
 
 ----------
-#### WinGeodeSetPtrImage()
+### WinGeodeSetPtrImage()
     void    WinGeodeSetPtrImage(
             GeodeHandle     gh,
             optr            ptrCh);
@@ -1132,7 +1132,7 @@ This routine sets the pointer image for the specified geode.
 **Include:** win.h
 
 ----------
-#### WinGetInfo()
+### WinGetInfo()
     dword   WinGetInfo(
             WindowHandle        win,
             WinInfoTypes        type,
@@ -1143,7 +1143,7 @@ This routine retrieves the private data from a GState.
 **Include:** win.h
 
 ----------
-#### WinGetTransform()
+### WinGetTransform()
     void    WinGetTransform(
             WindowHandle        win,
             TransMatrix *       tm);
@@ -1154,7 +1154,7 @@ writes the matrix to *tm.
 **Include:** win.h
 
 ----------
-#### WinGetWinScreenBounds()
+### WinGetWinScreenBounds()
     void    WinGetWinScreenBounds(
             WindowHandle        win,
             Rectangle *         bounds);
@@ -1165,7 +1165,7 @@ This routine returns the bounds of the on-screen portion of a window
 **Include:** win.h
 
 ----------
-#### WinGrabChange()
+### WinGrabChange()
     Boolean WinGrabChange(
             WindowHandle        win,
             optr                newObj);
@@ -1176,7 +1176,7 @@ successful; otherwise it returns non-zero.
 **Include:** win.h
 
 ----------
-#### WinInvalReg()
+### WinInvalReg()
     void    WinInvalReg(
             WindowHandle        win,
             const Region *      reg,
@@ -1190,7 +1190,7 @@ This routine invalidates the specified region or rectangle.
 **Include:** win.h
 
 ----------
-#### WinMove()
+### WinMove()
     void    WinMove(
             WindowHandle        win,
             sword       xMove,
@@ -1204,7 +1204,7 @@ window's new position is specified relative to its current position.
 **Include:** win.h
 
 ----------
-#### WinOpen()
+### WinOpen()
     WindowHandle WinOpen(
             Handle          parentWinOrVidDr,
             optr            inputRecipient,
@@ -1228,7 +1228,7 @@ GState.
 **Include:** win.h
 
 ----------
-#### WinReleaseChange()
+### WinReleaseChange()
     void    WinReleaseChange(
             WindowHandle        win,
             optr        obj);
@@ -1238,7 +1238,7 @@ This routine releases an object's grab on the change OD.
 **Include:** win.h
 
 ----------
-#### WinResize()
+### WinResize()
     void    WinResize(
             WindowHandle        win,
             const Region *      reg,
@@ -1252,7 +1252,7 @@ This routine resizes a window. It can move it as well.
 **Include:** win.h
 
 ----------
-#### WinScroll()
+### WinScroll()
     void    WinScroll(
             WindowHandle        win,
             WWFixedAsDWord      xMove,
@@ -1264,7 +1264,7 @@ This routine scrolls a window.
 **Include:** win.h
 
 ----------
-#### WinSetInfo()
+### WinSetInfo()
     void    WinSetInfo(
             WindowHandle        win,
             WinInfoType         type,
@@ -1275,7 +1275,7 @@ This routine sets some data for the specified window.
 **Include:** win.h
 
 ----------
-#### WinSetNullTransform()
+### WinSetNullTransform()
     void    WinSetNullTransform(
             WindowHandle        win,
             WinInvalFlag        flag);
@@ -1286,7 +1286,7 @@ identity) matrix.
 **Include:** win.h
 
 ----------
-#### WinSetPtrImage()
+### WinSetPtrImage()
     void    WinSetPtrImage(
             WindowHandle            win,
             WinSetPtrImageLevel     ptrLevel,
@@ -1298,7 +1298,7 @@ window.
 **Include:** win.h
 
 ----------
-#### WinSetTransform()
+### WinSetTransform()
     void    WinSetTransform(
             WindowHandle            win,
             const TransMatrix *     tm,
@@ -1310,7 +1310,7 @@ passed in **tm*.
 **Include:** win.h
 
 ----------
-#### WinSuspendUpdate()
+### WinSuspendUpdate()
     void    WinSuspendUpdate(
             WindowHandle        win);
 
@@ -1320,7 +1320,7 @@ messages will be sent when **WinUnSuspendUpdate()** is called.
 **Include:** win.h
 
 ----------
-#### WinTransform()
+### WinTransform()
     XYValueAsDWord  WinTransform(
             WindowHandle        win,
             sword               x,
@@ -1332,7 +1332,7 @@ coordinates.
 **Include:** win.h
 
 ----------
-#### WinTransformDWord()
+### WinTransformDWord()
     void    WinTransformDWord(
             WindowHandle        win,
             sdword              xCoord,
@@ -1345,7 +1345,7 @@ coordinates. The translated coordinates are written to **screenCoordinates*.
 **Include:** win.h
 
 ----------
-#### WinUnSuspendUpdate()
+### WinUnSuspendUpdate()
     void    WinUnSuspendUpdate(
             WindowHandle        win);
 
@@ -1354,7 +1354,7 @@ This routine cancels a previous **WinSuspendUpdate()** call.
 **Include:** win.h
 
 ----------
-#### WinUntransform
+### WinUntransform
     XYValueAsDWord  WinUntransform(
             WindowHandle        win,
             sword               x,
@@ -1366,7 +1366,7 @@ coordinates.
 **Include:** win.h
 
 ----------
-#### WinUnTransformDWord()
+### WinUnTransformDWord()
     void    WinTransformDWord(
             WindowHandle        win,
             sdword              xCoord,
@@ -1380,7 +1380,7 @@ coordinates. The translated coordinates are written to
 **Include:** win.h
 
 ----------
-#### WWFixedToFrac
+### WWFixedToFrac
     word    WWFixedToFrac(WWFixed wwf)
 
 This macro lets you address the fractional portion of a **WWFixed** value. It is 
@@ -1393,7 +1393,7 @@ is perfectly legal.
 **Include:** geos.h
 
 ----------
-#### WWFixedToInt
+### WWFixedToInt
     word    WWFixedToInt(WWFixed wwf)
 
 This macro lets you address the intetgral portion of a **WWFixed** value. It is 

--- a/TechDocs/Markdown/Routines/rstra_e.md
+++ b/TechDocs/Markdown/Routines/rstra_e.md
@@ -4,13 +4,13 @@ Global data structures and types are listed alphabetically below. Some data stru
 ## 4.1 Data Structures A-E
 
 ----------
-#### AddUndoActionFlags
+### AddUndoActionFlags
     typedef WordFlags AddUndoActionFlags;
     #define AUAF_NOTIFY_BEFORE_FREEING                          0x8000
     #define AUAF_NOTIFY_IF_FREED_WITHOUT_BEING_PLAYED_BACK      0x4000
 
 ----------
-#### AddUndoActionStruct
+### AddUndoActionStruct
     typedef struct {
         UndoActionStruct            AUAS_data;
         optr                        AUAS_output;
@@ -21,7 +21,7 @@ The "undo" structures work together to provide information vital to processes
 which will be working with undo events.
 
 ----------
-#### AppAttachFlags
+### AppAttachFlags
     typedef WordFlags AppAttachFlags;
         #define AAF_RESTORING_FROM_STATE        0x8000
         #define AAF_STATE_FILE_PASSED           0x4000
@@ -35,7 +35,7 @@ Note that if AAF_RESTORING_FROM_STATE is set, then
 AAF_STATE_FILE_PASSED will also be set.
 
 ----------
-#### AppInstanceReference
+### AppInstanceReference
     typedef struct {
         /* AIR_fileName:
          * Application being launched. Pathname is relative to application 
@@ -60,7 +60,7 @@ AAF_STATE_FILE_PASSED will also be set.
     } AppInstanceReference;
 
 ----------
-#### AppLaunchBlock
+### AppLaunchBlock
     typedef struct {
         /* ALB_appRef:
          * Instance reference. Contains full pathname to application, as 
@@ -127,13 +127,13 @@ The first fields (*ALB_appRef*, *ALB_appMode*, *ALB_launchFlags*, and
 information must be set correctly on launch.
 
 ----------
-#### AppLaunchFlags
+### AppLaunchFlags
     typedef ByteFlags AppLaunchFlags;
         #define ALF_SEND_LAUNCH_REQUEST_TO_UI_TO_HANDLE     0x80
         #define ALF_OPEN_IN_BACK                            0x40
 
 ----------
-#### ApplicationStates
+### ApplicationStates
     typedef ByteFlags ApplicationStates;
         #define AS_QUITTING                         0x80
         #define AS_DETACHING                        0x40
@@ -145,7 +145,7 @@ information must be set correctly on launch.
         #define AS_ATTACHING                        0x01
 
 ----------
-#### ArcCloseType
+### ArcCloseType
     typedef enum /* word */ {
         ACT_OPEN,
         ACT_CHORD,
@@ -155,7 +155,7 @@ information must be set correctly on launch.
 This structure is used when filling arcs.
 
 ----------
-#### AreaAttr
+### AreaAttr
     typedef struct {
         byte            AA_colorFlag;
         RGBValue        AA_color;
@@ -164,14 +164,14 @@ This structure is used when filling arcs.
     } AreaAttr;
 
 ----------
-#### ArgumentStackElement
+### ArgumentStackElement
     typedef struct {
         EvalStackArgumentType ASE_type;
         EvalStackArgumentData ASE_data;
     } ArgumentStackElement;
 
 ----------
-#### BBFixed
+### BBFixed
     typedef struct {
         byte BBF_frac;
         byte BBF_int;
@@ -180,13 +180,13 @@ This structure is used when filling arcs.
 This structure represents an 8.8 fixed point number.
 
 ----------
-#### BBFixedAsWord
+### BBFixedAsWord
     typedef word BBFixedAsWord;
 
 This structure represents an 8.8 fixed point number.
 
 ----------
-#### Bitmap
+### Bitmap
     typedef struct {
         word    B_width;            /* In bitmap pixels */
         word    B_height;           /* In bitmap pixels */
@@ -277,13 +277,13 @@ Thus a 16x4 color "=" with a matching mask would appear:
 **See Also:** CBitmap.
 
 ----------
-#### BitmapMode
+### BitmapMode
     typedef WordFlags BitmapMode;
         #define BM_EDIT_MASK                    0x0002
         #define BM_CLUSTERED_DITHER             0x0001
 
 ----------
-#### BLTMode
+### BLTMode
     typedef enum /* word */ {
         BLTM_COPY,
         BLTM_MOVE,
@@ -291,7 +291,7 @@ Thus a 16x4 color "=" with a matching mask would appear:
     } BLTMode;
 
 ----------
-#### BMCompact
+### BMCompact
     typedef ByteEnum ByteCompact;
         #define BMC_UNCOMPACTED             0
         #define BMC_PACKBITS                1
@@ -301,13 +301,13 @@ This data structure is used to specify what sort of compaction is used to store
 a graphics bitmap.
 
 ----------
-#### BMDestroy
+### BMDestroy
     typedef ByteEnum BMDestroy;
         #define BMD_KILL_DATA               0
         #define BMD_LEAVE_DATA              1
 
 ----------
-#### BMFormat
+### BMFormat
     typedef ByteEnum BMFormat
         #define BMF_MONO  0
         #define BMF_4BIT  1
@@ -317,7 +317,7 @@ a graphics bitmap.
 This enumerated type determines a graphics bitmap's depth.
 
 ----------
-#### BMType
+### BMType
     typedef ByteFlags BMType;
         #define BMT_PALETTE             0x40
         #define BMT_HUGE                0x20
@@ -327,13 +327,13 @@ This enumerated type determines a graphics bitmap's depth.
 This structure is used to store various facts about a graphics bitmap.
 
 ----------
-#### Boolean
+### Boolean
     typedef word Boolean;
 Booleans represent true/false values. If the Boolean is *false*, it will evaluate 
 to zero; otherwise, it will be non-zero.
 
 ----------
-#### Button
+### Button
     typedef ByteEnum Button;
         #define BUTTON_0                0
         #define BUTTON_1                1
@@ -341,7 +341,7 @@ to zero; otherwise, it will be non-zero.
         #define BUTTON_3                3
 
 ----------
-#### ButtonInfo
+### ButtonInfo
     typedef ByteFlags ButtonInfo;
         #define BI_PRESS                0x80
         #define BI_DOUBLE_PRESS         0x40
@@ -357,15 +357,15 @@ This structure contains the state of a mouse's buttons.
     typedef unsigned char byte;
 
 ----------
-#### ByteEnum
+### ByteEnum
     typedef byte ByteEnum;
 
 ----------
-#### ByteFlags
+### ByteFlags
     typedef byte ByteFlags;
 
 ----------
-#### CallbackType
+### CallbackType
     typedef ByteEnum CallbackType;
         #define CT_FUNCTION_TO_TOKEN        0
         #define CT_NAME_TO_TOKEN            1
@@ -384,7 +384,7 @@ This structure contains the state of a mouse's buttons.
         #define CT_SPECIAL_FUNCTION         14
 
 ----------
-#### CBitmap
+### CBitmap
     typedef struct {
         Bitmap  CB_simple;
         word    CB_startScan;
@@ -400,13 +400,13 @@ the CBitmap structure to hold bitmaps which need to keep track of resolution
 information, a palette, or a mask.
 
 ----------
-#### CellFunctionParameterFlags
+### CellFunctionParameterFlags
     typedef ByteFlags CellFunctionParameterFlags;
         #define CFPF_DIRTY          0x80 /* apps may read or change this. */
         #define CFPF_NO_FREE_COUNT  0x07
 
 ----------
-#### CellFunctionParameters
+### CellFunctionParameters
     typedef struct {
         CellFunctionParameterFlags  CFP_flags;
         VMFileHandle                CFP_file;       /* File containing cells */
@@ -443,27 +443,27 @@ motionless for the duration of a call. Therefore, if you allocate it as a DB ite
 in the cell file, you must not have the structure be an ungrouped item.
 
 ----------
-#### CellRange
+### CellRange
     typedef struct {
         CellReference           CR_start;
         CellReference           CR_end;
     } CellRange;
 
 ----------
-#### CellReference
+### CellReference
     typedef struct {
         CellRowColumn           CR_row;
         CellRowColumn           CR_column;
     } CellReference;
 
 ----------
-#### CellRowColumn
+### CellRowColumn
     typedef WordFlags CellRowColumn;
         #define CRC_ABSOLUTE                0x8000
         #define CRC_VALUE               0x7fff
 
 ----------
-#### CharacterSet
+### CharacterSet
     typedef ByteEnum CharacterSet;
         #define CS_BSW                  0
         #define CS_CONTROL              0xff
@@ -473,7 +473,7 @@ in the cell file, you must not have the structure be an ungrouped item.
         #define VC_ISUI                 CS_UI_FUNCS
 
 ----------
-#### CharFlags
+### CharFlags
     typedef ByteFlags CharFlags;
         #define CF_STATE_KEY                0x80
         #define CF_EXTENDED                 0x10
@@ -483,7 +483,7 @@ in the cell file, you must not have the structure be an ungrouped item.
         #define CF_RELEASE                  0x01
 
 ----------
-#### Chars
+### Chars
     typedef ByteEnum Chars;
         #define C_NULL              0x0 /* NULL */
         #define C_CTRL_A            0x1 /* <ctrl>-A */
@@ -792,7 +792,7 @@ treated as Chars, then the debugger will print out the constant names.
 **Include:** char.h
 
 ----------
-#### ChunkArrayHeader
+### ChunkArrayHeader
     typedef struct {
         word    CAH_count;          /* # of elements in chunk array */
         word    CAH_elementSize;    /* Size of each element (in bytes) */
@@ -819,7 +819,7 @@ elements are variable-sized, *CAH_elementSize* will be zero.
 in the array.
 
 ----------
-#### ChunkHandle
+### ChunkHandle
     typedef word ChunkHandle;
 
 Chunk handles are offsets into a local memory heap. To find the current 
@@ -830,14 +830,14 @@ offset of the chunk itself.
 **See Also:** optr, LMemDeref()
 
 ----------
-#### ChunkMapList
+### ChunkMapList
     typedef struct {
         word    CML_source;
         word    CML_dest;
     } ChunkMapList;
 
 ----------
-#### ClassFlags
+### ClassFlags
     typedef ByteFlags ClassFlags;
         #define CLASSF_HAS_DEFAULT                      0x80
         #define CLASSF_MASTER_CLASS                         0x40
@@ -852,7 +852,7 @@ flags are internal and may not be set or retrieved directly. See the entry on
 **@class** for more information about these flags.
 
 ----------
-#### ClassStruct
+### ClassStruct
     typedef struct  _ClassStruct {
         struct _ClassStruct *Class_superClass;  /* superclass pointer */
         word        Class_masterOffset;         /* offset to master offset in chunk */
@@ -868,13 +868,13 @@ This is the structure that defines a class. It is internal and used only very
 rarely by anything other than the kernel and the UI.
 
 ----------
-#### ClipboardItemFlags
+### ClipboardItemFlags
     typedef WordFlags ClipboardItemFlags;
         #define CIF_QUICK               0x4000
         #define TIF_NORMAL              0x0000
 
 ----------
-#### ClipboardItemFormat
+### ClipboardItemFormat
     typedef enum /* word */ {
         CIF_TEXT,
         CIF_GRAPHICS_STRING,
@@ -889,11 +889,11 @@ rarely by anything other than the kernel and the UI.
     } ClipboardItemFormat;
 
 ----------
-#### ClipboardItemFormatID
+### ClipboardItemFormatID
     typedef dword ClipboardItemFormatID;
 
 ----------
-#### ClipboardItemFormatInfo
+### ClipboardItemFormatInfo
     typedef struct {
         ClipboardItemFormatID       CIFI_format;
         word                        CIFI_extra1;
@@ -903,7 +903,7 @@ rarely by anything other than the kernel and the UI.
     } ClipboardItemFormatInfo;
 
 ----------
-#### ClipboardItemHeader
+### ClipboardItemHeader
     typedef struct {
         optr                        CIH_owner;
         ClipboardItemFlags          CIH_flags;
@@ -915,15 +915,15 @@ rarely by anything other than the kernel and the UI.
     } ClipboardItemHeader;
 
 ----------
-#### ClipboardItemNameBuffer
+### ClipboardItemNameBuffer
     typedef char ClipboardItemNameBuffer[CLIPBOARD_ITEM_NAME_LENGTH+1];
 
 ----------
-#### ClipboardQueryArgs
+### ClipboardQueryArgs
 See **ClipboardQueryItem()**.
 
 ----------
-#### ClipboardQuickNotifyFlags
+### ClipboardQuickNotifyFlags
     typedef WordFlags ClipboardQuickNotifyFlags;
         #define CQNF_ERROR                      0x8000
         #define CQNF_SOURCE_EQUAL_DEST          0x4000
@@ -936,7 +936,7 @@ These flags give information about the success or failure of a quick transfer
 operation.
 
 ----------
-#### ClipboardQuickTransferFeedback
+### ClipboardQuickTransferFeedback
     typedef enum {
         CQTF_SET_DEFAULT,
         CQTF_CLEAR_DEFAULT,
@@ -946,7 +946,7 @@ operation.
     } ClipboardQuickTransferFeedback;
 
 ----------
-#### ClipboardQuickTransferFlags
+### ClipboardQuickTransferFlags
     typedef WordFlags ClipboardQuickTransferFlags;
         #define CQTF_IN_PROGRESS            0x8000
         #define CQTF_COPY_ONLY              0x4000
@@ -954,7 +954,7 @@ operation.
         #define CQTF_NOTIFICATION           0x1000
 
 ----------
-#### ClipboardQuickTransferRegionInfo
+### ClipboardQuickTransferRegionInfo
     typedef struct {
         word    CQTRI_paramAX;
         word    CQTRI_paramBX;
@@ -966,11 +966,11 @@ operation.
     } ClipboardQuickTransferRegionInfo;
 
 ----------
-#### ClipboardRequestArgs
+### ClipboardRequestArgs
 See entry for **ClipboardRequestItemFormat()**.
 
 ----------
-#### CMYKTransfer
+### CMYKTransfer
     typedef struct {
         byte    CMYKT_cyan[256];
         byte    CMYKT_magenta[256];
@@ -979,7 +979,7 @@ See entry for **ClipboardRequestItemFormat()**.
     } CMYKTransfer;
 
 ----------
-#### Color
+### Color
     typedef ByteEnum Color;
         #define C_BLACK                 0
         #define C_BLUE                  1
@@ -1258,7 +1258,7 @@ See entry for **ClipboardRequestItemFormat()**.
 **Include:** color.h
 
 ----------
-#### ColorFlag
+### ColorFlag
     typedef ByteEnum ColorFlag;
         #define CF_INDEX        0
         #define CF_GRAY         1
@@ -1272,7 +1272,7 @@ described. The **ColorFlag** is normally used as part of a **ColorQuad**. See
 **ColorFlags**.
 
 ----------
-#### ColorMapMode
+### ColorMapMode
     typedef ByteFlags ColorMapMode;
         #define CMM_ON_BLACK 0x04   /* Set this bit if you're drawing on black */
         #define CMM_MAP_TYPE 0x01   /* Either CMT_CLOSEST or CMT_DITHER) */
@@ -1285,7 +1285,7 @@ more close colors in a dithered pattern. If you will be drawing against a black
 background, you may wish to set the CMM_ON_BLACK flag.
 
 ----------
-#### ColorQuad
+### ColorQuad
     typedef struct {
         byte            CQ_redOrIndex;
         ColorFlag       CQ_info;
@@ -1318,11 +1318,11 @@ area color will be used. The *CQ_redOrIndex*, *CQ_green*, and *CQ_blue* fields a
 all ignored.
 
 ----------
-#### ColorQuadAsDWord
+### ColorQuadAsDWord
     typedef dword ColorQuadAsDWord;
 
 ----------
-#### ColorTransfer
+### ColorTransfer
     typedef struct {
         RGBDelta                CT_data[125]; 
     } ColorTransfer;
@@ -1336,7 +1336,7 @@ factors" to tell the printer to use more or less ink than the raw RGB values
 would suggest.
 
 ----------
-#### ColorTransferData
+### ColorTransferData
     typedef union {
         MonoTransfer        CTD_mono;
         RGBTransfer         CTD_rgb;
@@ -1344,14 +1344,14 @@ would suggest.
     } ColorTransferData;
 
 ----------
-#### ColorTransferType
+### ColorTransferType
     typedef ByteEnum ColorTransferType;
         #define CTT_MONO                 0
         #define CTT_RGB                  1
         #define CTT_CMYK                 2
 
 ----------
-#### CommonParameters
+### CommonParameters
     typedef struct {
         word    CP_row;
         word    CP_column;
@@ -1362,7 +1362,7 @@ would suggest.
     } CommonParameters;
 
 ----------
-#### CompChildFlags
+### CompChildFlags
     typedef WordFlags CompChildFlags;
         #define CCF_MARK_DIRTY      0x8000
         #define CCF_REFERENCE       0x7fff
@@ -1384,7 +1384,7 @@ any number less than 32768, or it can be either of the two
 constants shown above (CCO_FIRST or CCO_LAST).
 
 ----------
-#### CountryType
+### CountryType
     typedef enum /* word */ {
         CT_UNITED_STATES=1,
         CT_CANADA,
@@ -1398,7 +1398,7 @@ constants shown above (CCO_FIRST or CCO_LAST).
     } CountryType;
 
 ----------
-#### CRangeEnumParams
+### CRangeEnumParams
     typedef struct {
         RangeEnumParams         CREP_params;
         void                    *CREP_locals;
@@ -1409,7 +1409,7 @@ constants shown above (CCO_FIRST or CCO_LAST).
 The *CREP_callback* routine should be declared _pascal.
 
 ----------
-#### CurrencyFormatFlags
+### CurrencyFormatFlags
     typedef ByteFlags CurrencyFormatFlags;
         #define CFF_LEADING_ZERO                    0x20
         #define CFF_SPACE_AROUND_SYMBOL             0x10
@@ -1419,14 +1419,14 @@ The *CREP_callback* routine should be declared _pascal.
         #define CFF_NEGATIVE_SIGN_BEFORE_SYMBOL     0x01
 
 ----------
-#### CustomDialogBoxFlags
+### CustomDialogBoxFlags
     typedef WordFlags CustomDialogBoxFlags;
         #define CDBF_SYSTEM_MODAL               0x8000
         #define CDBF_DIALOG_TYPE                0x6000
         #define CDBF_INTERACTION_TYPE           0x1e00
 
 ----------
-#### CustomDialogType
+### CustomDialogType
     typedef ByteEnum CustomDialogType;
         #define CDT_QUESTION                    0
         #define CDT_WARNING                     1
@@ -1436,19 +1436,19 @@ The *CREP_callback* routine should be declared _pascal.
         #define CDBF_INTERACTION_TYPE_OFFSET    9
 
 ----------
-#### DACPlayFlags
+### DACPlayFlags
     typedef ByteFlags DACPlayFlags;
     #define DACPF_CATENATE 0x80
 
 ----------
-#### DACReferenceByte
+### DACReferenceByte
     typedef enum {
          DACRB_NO_REFERENCE_BYTE,
          DACRB_WITH_REFERENCE_BYTE
     } DACReferenceByte;
 
 ----------
-#### DACSampleFormat
+### DACSampleFormat
     typedef enum {
         DACSF_8_BIT_PCM,
         DACSF_2_TO_1_ADPCM,
@@ -1460,11 +1460,11 @@ This structure specifies what sort of sampling should be used when recording
 or playing a sampled sound.
 
 ----------
-#### DashPairArray
+### DashPairArray
 **See:** LineStyle
 
 ----------
-#### DateTimeFormat
+### DateTimeFormat
     typedef enum /* word */ {
         DTF_LONG,
         DTF_LONG_CONDENSED,
@@ -1488,7 +1488,7 @@ or playing a sampled sound.
     } DateTimeFormat;
 
 ----------
-#### DayOfTheWeek
+### DayOfTheWeek
     typedef enum {
         DOTW_SUNDAY,
         DOTW_MONDAY,
@@ -1502,7 +1502,7 @@ or playing a sampled sound.
 This enumerated type is used in the **TimerDateAndTime** structure.
 
 ----------
-#### DBGroup
+### DBGroup
     typedef word DBGroup;
 
 This is the handle of a DB group. It is the VM handle of a DB group block. DB 
@@ -1510,7 +1510,7 @@ group handles do not change when a file is copied, or when it is closed and
 reopened.
 
 ----------
-#### DBGroupAndItem
+### DBGroupAndItem
     typedef dword DBGroupAndItem;
 
 This is a dword which contains the group and item handles of a database 
@@ -1538,14 +1538,14 @@ Extracts the **DBItem** from a given **DBGroupAndItem**.
 **Include:** geos.h
 
 ----------
-#### DBItem
+### DBItem
     typedef word DBItem;
 
 This is the handle of a DB item. The **DBItem** and **DBGroup** together 
 uniquely identify a DB item in a specified file.
 
 ----------
-#### DBReturn
+### DBReturn
     typedef struct {
         word    DBR_group;
         word    DBR_item;
@@ -1554,7 +1554,7 @@ uniquely identify a DB item in a specified file.
     } DBReturn;
 
 ----------
-#### DefaultPrintSizes
+### DefaultPrintSizes
     typedef struct {
         word    paperWidth;
         word    paperHeight;
@@ -1563,7 +1563,7 @@ uniquely identify a DB item in a specified file.
     } DefaultPrintSizes;
 
 ----------
-#### DevicePresent
+### DevicePresent
     typedef enum /* word */ {
         DP_NOT_PRESENT=0xffff,
         DP_CANT_TELL=0,
@@ -1572,7 +1572,7 @@ uniquely identify a DB item in a specified file.
     } DevicePresent;
 
 ----------
-#### DirPathInfo
+### DirPathInfo
     typedef word DirPathInfo;
         #define DPI_EXISTS_LOCALLY                  0x8000
         #define DPI_ENTRY_NUMBER_IN_PATH            0x7f00
@@ -1581,7 +1581,7 @@ uniquely identify a DB item in a specified file.
         #define DPI_STD_PATH_OFFSET                 0
 
 ----------
-#### DiskCopyCallback
+### DiskCopyCallback
     typedef enum /* word */ {
         CALLBACK_GET_SOURCE_DISK,
         CALLBACK_REPORT_NUM_SWAPS,
@@ -1592,7 +1592,7 @@ uniquely identify a DB item in a specified file.
     } DiskCopyCallback;
 
 ----------
-#### DiskCopyError
+### DiskCopyError
     typedef enum /* word */ {
         ERR_DISKCOPY_INSUFFICIENT_MEM=0xd0,
         ERR_CANT_COPY_FIXED_DISKS,
@@ -1604,7 +1604,7 @@ uniquely identify a DB item in a specified file.
     } DiskCopyError;
 
 ----------
-#### DiskFindResult
+### DiskFindResult
     typedef enum /* word */ {
         DFR_UNIQUE,
         DFR_NOT_UNIQUE,
@@ -1612,11 +1612,11 @@ uniquely identify a DB item in a specified file.
     } DiskFindResult;
 
 ----------
-#### DiskHandle
+### DiskHandle
     typedef Handle DiskHandle;
 
 ----------
-#### DiskInfoStruct
+### DiskInfoStruct
     typedef struct {
         word        DIS_blockSize;
         sdword      DIS_freeSpace;
@@ -1625,7 +1625,7 @@ uniquely identify a DB item in a specified file.
     } DiskInfoStruct;
 
 ----------
-#### DiskRestoreError
+### DiskRestoreError
     typedef enum /* word */ {
         DRE_DISK_IN_DRIVE,
         DRE_DRIVE_NO_LONGER_EXISTS,
@@ -1636,14 +1636,14 @@ uniquely identify a DB item in a specified file.
     } DiskRestoreError;
 
 ----------
-#### DisplayAspectRatio
+### DisplayAspectRatio
     typedef ByteEnum DisplayAspectRatio;
         #define DAR_NORMAL              0
         #define DAR_SQUISHED            1
         #define DAR_VERY_SQUISHED       2
 
 ----------
-#### DisplayClass
+### DisplayClass
     typedef ByteEnum DisplayClass;
         #define DC_TEXT                 0
         #define DC_GRAY_1               1
@@ -1655,7 +1655,7 @@ uniquely identify a DB item in a specified file.
         #define DC_CF_RGB               7
 
 ----------
-#### DisplaySize
+### DisplaySize
     typedef ByteEnum DisplaySize;
         #define DS_TINY             0
         #define DS_STANDARD         1
@@ -1663,14 +1663,14 @@ uniquely identify a DB item in a specified file.
         #define DS_HUGE             3
 
 ----------
-#### DisplayType
+### DisplayType
     typedef ByteFlags DisplayType;
         #define DT_DISP_SIZE                    0xc0
         #define DT_DISP_ASPECT_RATIO            0x30
         #define DT_DISP_CLASS                   0x0f
 
 ----------
-#### DistanceUnit
+### DistanceUnit
     typedef ByteEnum DistanceUnit;
         #define DU_POINTS                           0
         #define DU_INCHES                           1
@@ -1684,7 +1684,7 @@ uniquely identify a DB item in a specified file.
         #define LOCAL_DISTANCE_BUFFER_SIZE          32
 
 ----------
-#### DocQuitStatus
+### DocQuitStatus
     typedef enum /* word */ {
         DQS_OK,
         DQS_CANCEL,
@@ -1693,7 +1693,7 @@ uniquely identify a DB item in a specified file.
     } DocQuitStatus;
 
 ----------
-#### DocumentSize
+### DocumentSize
     typedef struct {
         int     leftMargin;
         int     topMargin;
@@ -1702,7 +1702,7 @@ uniquely identify a DB item in a specified file.
     } DocumentSize;
 
 ----------
-#### DosCodePage
+### DosCodePage
     typedef enum /* word */ {
         CODE_PAGE_US=437,
         CODE_PAGE_MULTILINGUAL=850,
@@ -1713,11 +1713,11 @@ uniquely identify a DB item in a specified file.
     } DosCodePage;
 
 ----------
-#### DosDotFileName
+### DosDotFileName
     typedef char DosDotFileName[DOS_DOT_DOS_FILE_NAME_SIZE];
 
 ----------
-#### DosExecFlags
+### DosExecFlags
     typedef ByteFlags DosExecFlags;
         #define DEF_PROMPT              0x80    /* prompt user to return to GEOS */
         #define DEF_FORCED_SHUTDOWN     0x40    /* force shutdown; no abort */
@@ -1727,7 +1727,7 @@ Flags used with **DosExec()**. **DosExec()** executes a DOS program based on
 these flags.
 
 ----------
-#### DosFileInfoStruct
+### DosFileInfoStruct
     typedef struct {
         byte DFIS_attributes;
         dword DFIS_modTimeDate;
@@ -1737,17 +1737,17 @@ these flags.
     } DosFileInfoStruct;
 
 ----------
-#### DosNoDotFileName
+### DosNoDotFileName
     typedef char DosNoDotFileName[DOS_NO_DOT_DOS_FILE_NAME_SIZE];
 
 ----------
-#### DrawMask
+### DrawMask
     typedef byte DrawMask[8];
 
 The graphics system uses this structure for defining custom draw masks.
 
 ----------
-####  DriveType
+###  DriveType
     typedef ByteEnum DriveType;
         #define DRIVE_5_25              0
         #define DRIVE_3_5               1
@@ -1766,7 +1766,7 @@ like **DriveGetStatus()** can return a **DriveTypes** value in the low four bits
 and other flags in the high four bits of a single byte.
 
 ----------
-#### DriverAttrs
+### DriverAttrs
     typedef WordFlags DriverAttrs;
         #define DA_FILE_SYSTEM                  0x8000
         #define DA_CHARACTER                    0x4000
@@ -1776,7 +1776,7 @@ This record contains flags that indicate a given driver's attributes. This
 record is stored in the driver's **DriverInfoStruct** structure.
 
 ----------
-#### DriverExtendedInfoStruct
+### DriverExtendedInfoStruct
     typedef struct {
         DriverInfoStruct    DEIS_common;    /* The base driver info structure */
         MemHandle           DEIS_resource;  /* Handle of driver's DriverExtendedInfo
@@ -1787,7 +1787,7 @@ This structure is used by Preferences to locate the names of devices
 supported by a particular driver.
 
 ----------
-#### DriverExtendedInfoTable
+### DriverExtendedInfoTable
     typedef struct {
         LMemBlockHeader     DEIT_common;
         word                DEIT_numDevices;
@@ -1796,7 +1796,7 @@ supported by a particular driver.
     } DriverExtendedInfoTable;
 
 ----------
-#### DriverInfoStruct
+### DriverInfoStruct
     typedef struct {
          void (*DIS_strategy)();                /* Pointer to strategy routine */
          DriverAttrs    DIS_driverAttributes;   /* driver's attribute flags */
@@ -1808,7 +1808,7 @@ applications will not need to access this structure unless they use a driver
 directly.
 
 ----------
-#### DriverType
+### DriverType
     typedef enum {
         DRIVER_TYPE_VIDEO = 1,          /* Video drivers */
         DRIVER_TYPE_INPUT,              /* Input (keyboard, mouse) drivers */
@@ -1830,22 +1830,22 @@ is used primarily with **GeodeUseDriver()** and its associated routines. Each
 driver stores its type in its **DriverInfoStruct** structure.
 
 ----------
-#### DWFixed
+### DWFixed
     typedef struct {
         word    WWF_frac;
         dword   WWF_int;
     } DWFixed;
 
 ----------
-#### dword
+### dword
     typedef unsigned long dword;
 
 ----------
-#### DWordFlags
+### DWordFlags
     typedef dword DWordFlags;
 
 ----------
-#### ElementArrayHeader
+### ElementArrayHeader
     typedef struct {
         ChunkArrayHeader    EAH_meta;       /* chunk array header structure */
         word                EAH_freePtr;    /* First free element */
@@ -1859,7 +1859,7 @@ track of the freed elements in the element array. Applications should not
 examine or change this field.
 
 ----------
-#### EndOfSongFlags
+### EndOfSongFlags
     typedef ByteFlags EndOfSongFlags;
             #define EOSF_UNLOCK 0x0080      /* unlock block at EOS ? */
             #define EOSF_DESTROY 0x0040     /* destroy block at EOS ? */
@@ -1868,14 +1868,14 @@ examine or change this field.
             #define DESTROY_ON_EOS EOSF_DESTROY
 
 ----------
-#### EntryPointRelocation
+### EntryPointRelocation
     typedef struct {
         char    EPR_geodeName[GEODE_NAME_SIZE];
         word    EPR_entryNumber;
     } EntryPointRelocation;
 
 ----------
-#### EnvelopeOrientation
+### EnvelopeOrientation
     typedef ByteEnum EnvelopeOrientation;
         #define EO_PORTAIT_LEFT             0x00
         #define EO_PORTAIT_RIGHT            0x01
@@ -1884,14 +1884,14 @@ examine or change this field.
 
 ----------
 
-#### EnvelopePath
+### EnvelopePath
     typedef ByteEnum EnvelopePath;
         #define EP_LEFT             0x00
         #define EP_CENTER           0x01
         #define EP_RIGHT            0x02
 
 ----------
-#### Errors
+### Errors
         #define ERROR_UNSUPPORTED_FUNCTION                  1
         #define ERROR_FILE_NOT_FOUND                        2
         #define ERROR_PATH_NOT_FOUND                        3
@@ -1937,7 +1937,7 @@ examine or change this field.
         #define ERROR_NO_TASK_DRIVER_LOADED                 147
 
 ----------
-#### ErrorCheckingFlags
+### ErrorCheckingFlags
     typedef WordFlags ErrorCheckingFlags;
         #define ECF_REGION                  0x8000
         #define ECF_HEAP_FREE_BLOCKS        0x4000
@@ -1960,13 +1960,13 @@ It is important to use error checking when debugging; it can help catch
 obscure bugs that might otherwise go unnoticed until after a product ships.
 
 ----------
-#### EvalErrorData
+### EvalErrorData
     typedef struct {
         byte    EED_errorCode;      /* ParserScannerEvaluatorError */
     } EvalErrorData;
 
 ----------
-#### EvalFlags
+### EvalFlags
     typedef ByteFlags EvalFlags;
         #define EF_MAKE_DEPENDENCIES            0x80
         #define EF_ONLY_NAMES                   0x40
@@ -1976,26 +1976,26 @@ obscure bugs that might otherwise go unnoticed until after a product ships.
         #define EVAL_MAX_NESTED_LEVELS          32
 
 ----------
-#### EvalFunctionData
+### EvalFunctionData
     typedef struct {
         FunctionID      EFD_functionID;
         word            EFD_nArgs;
     } EvalFunctionData;
 
 ----------
-#### EvalNameData
+### EvalNameData
     typedef struct {
         word    END_name;
     } EvalNameData;
 
 ----------
-#### EvalOperatorData
+### EvalOperatorData
     typedef struct {
         OperatorType        EOD_opType;
     } EvalOperatorData;
 
 ----------
-#### EvalStackArgumentData
+### EvalStackArgumentData
     typedef union {
         EvalStringData          ESAD_string;
         EvalRangeData           ESAD_range;
@@ -2003,7 +2003,7 @@ obscure bugs that might otherwise go unnoticed until after a product ships.
     } EvalStackArgumentData;
 
 ----------
-#### EvalParameters
+### EvalParameters
     typedef struct {
         CommonParameters    EP_common;
         EvalFlags           EP_flags;
@@ -2014,14 +2014,14 @@ obscure bugs that might otherwise go unnoticed until after a product ships.
     } EvalParameters;
 
 ----------
-#### EvalRangeData
+### EvalRangeData
     typedef struct {
         CellReference           ERD_firstCell;
         CellReference           ERD_lastCell;
     } EvalRangeData;
 
 ----------
-#### EvalStackArgumentType
+### EvalStackArgumentType
     typedef ByteFlags EvalStackArgumentType;
         #define ESAT_EMPTY                  0x80
         #define ESAT_ERROR                  0x40
@@ -2034,14 +2034,14 @@ obscure bugs that might otherwise go unnoticed until after a product ships.
         #define ESAT_FUNCTION               (ESAT_NUMBER | ESAT_STRING)
 
 ----------
-#### EvalStackOperatorData
+### EvalStackOperatorData
     typedef union {
         EvalOperatorData            ESOD_operator;
         EvalFunctionData            ESOD_function;
     } EvalStackOperatorData;
 
 ----------
-#### EvalStackOperatorType
+### EvalStackOperatorType
     typedef ByteEnum EvalStackOperatorType;
         #define ESOT_OPERATOR               0
         #define ESOT_FUNCTION               1
@@ -2049,17 +2049,17 @@ obscure bugs that might otherwise go unnoticed until after a product ships.
         #define ESOT_TOP_OF_STACK           3
 
 ----------
-#### EvalStringData
+### EvalStringData
     typedef struct {
         word    ESD_length;
     } EvalStringData;
 
 ----------
-#### EventHandle
+### EventHandle
     typedef Handle      EventHandle;
 
 ----------
-#### ExitFlags
+### ExitFlags
     typedef ByteFlags ExitFlags;
         #define EF_PANIC                0x80
         #define EF_RUN_DOS              0x40
@@ -2068,12 +2068,12 @@ obscure bugs that might otherwise go unnoticed until after a product ships.
         #define EF_RESTART              0x08
 
 ----------
-#### ExportControlFeatures
+### ExportControlFeatures
     typedef ByteFlags ExportControlFeatures;
         #define EXPORTCF_BASIC                      0x01
 
 ----------
-#### ExportControlToolboxFeatures
+### ExportControlToolboxFeatures
     typedef ByteFlags ExportControlToolboxFeatures;
         #define EXPORTCTF_DIALOG_BOX                0x01
 

--- a/TechDocs/Markdown/Routines/rstrf_k.md
+++ b/TechDocs/Markdown/Routines/rstrf_k.md
@@ -1,25 +1,25 @@
 ## 4.2 Data Structures F-K
 ----------
-#### FALSE
+### FALSE
     #define FALSE        0
     #define TRUE        (~0)    /* use as return value, not for comparisons */
 
 ----------
-#### FFFieldMessageBlock
+### FFFieldMessageBlock
     typedef struct {
         char    textBuffer[100];
         int     startOffset;
     } FFFieldMessageBlock;
 
 ----------
-#### FileAccess
+### FileAccess
     typedef ByteEnum FileAccess
         #define FA_READ_ONLY                0
         #define FA_WRITE_ONLY               1
         #define FA_READ_WRITE               2
 
 ----------
-#### FileAccessFlags
+### FileAccessFlags
     typedef ByteFlags FileAccessFlags;
         #define FILE_DENY_RW        0x10
         #define FILE_DENY_W         0x20
@@ -70,11 +70,11 @@ access while prohibiting other geodes from writing to the file, you would pass
 the flags "(FILE_ACCESS_R | FILE_DENY_W)".
 
 ----------
-#### FileAccessRights
+### FileAccessRights
     typedef char FileAccessRights[FILE_RIGHTS_SIZE];
 
 ----------
-#### FileAttrs
+### FileAttrs
     typedef ByteFlags FileAttrs;
         #define FA_ARCHIVE                      0x20
         #define FA_SUBDIR                       0x10
@@ -125,7 +125,7 @@ This flag is set if the file is read-only.
 **Include:** file.h
 
 ----------
-#### FileChangeNotificationData
+### FileChangeNotificationData
     typedef struct {
         PathName            FCND_pathname;
         DiskHandle          FCND_diskHandle;
@@ -133,7 +133,7 @@ This flag is set if the file is read-only.
     } FileChangeNotificationData;
 
 ----------
-#### FileChangeType
+### FileChangeType
     typedef ByteEnum FileChangeType;
         #define FCT_CREATE              0
         #define FCT_DELETE              1
@@ -142,18 +142,18 @@ This flag is set if the file is read-only.
         #define FCT_DISK_FORMAT         4
 
 ----------
-#### FileCopyrightNotice
+### FileCopyrightNotice
     typedef char FileCopyrightNotice[GFH_NOTICE_SIZE];
 
 ----------
-#### FileCreateFlags
+### FileCreateFlags
     typedef WordFlags FileCreateFlags;
         #define FCF_NATIVE      0x8000
         #define FCF_MODE        0x0300 /* Filled with FILE_CREATE_* constant */
         #define FCF_ACCESS      0x00ff /* Filled with FileAccessFlags */
 
 ----------
-#### FileDateAndTime
+### FileDateAndTime
     typedef DWordFlags FileDateAndTime;
         #define FDAT_HOUR                       0xf8000000
         #define FDAT_MINUTE                     0x07e00000
@@ -235,19 +235,19 @@ Macros are provided to extract values from each of the fields of a
 **Include:** file.h
 
 ----------
-#### FileDesktopInfo
+### FileDesktopInfo
     typedef char FileDesktopInfo[FILE_DESKTOP_INFO_SIZE];
 
 ----------
-#### FileDirID
+### FileDirID
     typedef dword FileDirID;
 
 ----------
-#### FileFileID
+### FileFileID
     typedef dword FileFileID;
 
 ----------
-#### FileExclude
+### FileExclude
     typedef ByteEnum FileExclude;
         #define FE_EXCLUSIVE            1
         #define FE_DENY_WRITE           2
@@ -255,7 +255,7 @@ Macros are provided to extract values from each of the fields of a
         #define FE_NONE                 4
 
 ----------
-#### FileExtAttrDesc
+### FileExtAttrDesc
     typedef struct {
         FileExtendedAttribute   FEAD_attr;  /* Attribute to get or set */
         void        *FEAD_value;        /* Pointer to buffer/new value */
@@ -283,7 +283,7 @@ FEA_END_OF_LIST.
 **Include:** file.h
 
 ----------
-#### FileExtendedAttribute
+### FileExtendedAttribute
     typedef enum /* word */ {
         FEA_MODIFICATION,
         FEA_FILE_ATTR,
@@ -326,46 +326,46 @@ Section 17.5.3 of the Concepts book.
 **Include:** file.h
 
 ----------
-#### FileHandle
+### FileHandle
     typedef Handle FileHandle;
 
 ----------
-#### FileLongName
+### FileLongName
     typedef char FileLongName[FILE_LONGNAME_BUFFER_SIZE];
 
 ----------
-#### FileOwnerName
+### FileOwnerName
     typedef char FileOwnerName[FILE_OWNER_NAME_SIZE];
 
 ----------
-#### FilePassword
+### FilePassword
     typedef char FilePassword[FILE_PASSWORD_SIZE];
 
 ----------
-#### FilePosMode
+### FilePosMode
     typedef ByteEnum FilePosMode;
         #define FILE_POS_START              0
         #define FILE_POS_RELATIVE           1
         #define FILE_POS_END                2
 
 ----------
-#### FileUserNotes
+### FileUserNotes
     typedef char FileUserNotes[GFH_USER_NOTES_BUFFER_SIZE];
 
 ----------
-#### FindNoteHeader
+### FindNoteHeader
     typedef struct {
         word    FNH_count;      /* The number of matching notes we've found */
     } FindNoteHeader;
 
 ----------
-#### FloatExponent
+### FloatExponent
     typedef WordFlags FloatExponent;
         #define FE_SIGN         0x8000
         #define FE_EXPONENT     0x7fff
 
 ----------
-#### FloatNum
+### FloatNum
     typedef struct {
         word                    F_mantissa_wd0;
         word                    F_mantissa_wd1;
@@ -375,7 +375,7 @@ Section 17.5.3 of the Concepts book.
     } FloatNum;
 
 ----------
-#### FontAttrs
+### FontAttrs
     typedef ByteFlags FontAttrs;
         #define FA_FIXED_WIDTH          0x40
         #define FA_ORIENT               0x20
@@ -386,7 +386,7 @@ Section 17.5.3 of the Concepts book.
 **Include:** font.h
 
 ----------
-#### FontEnumFlags
+### FontEnumFlags
     typedef ByteFlags FontEnumFlags;
         #define FEF_ALPHABETIZE     0x80    /* Alphabetize returned list of fonts */
         #define FEF_FIXED_WIDTH     0x20    /* Return only fixed-width fonts */
@@ -399,7 +399,7 @@ Section 17.5.3 of the Concepts book.
 **Include:** font.h
 
 ----------
-#### FontEnumStruct
+### FontEnumStruct
     typedef struct {
          FontIDs        FES_ID;
          char           FES_name[FID_NAME_LEN];
@@ -408,7 +408,7 @@ Section 17.5.3 of the Concepts book.
 **Include:** font.h
 
 ----------
-#### FontFamily
+### FontFamily
     typedef byte FontFamily;
         #define FF_NON_PORTABLE         0x0007
         #define FF_SPECIAL              0x0006
@@ -422,7 +422,7 @@ Section 17.5.3 of the Concepts book.
 **Include:** fontID.h
 
 ----------
-#### FontGroup
+### FontGroup
     typedef enum /* word */ {
         #define FG_NON_PORTABLE         0x0e00
         #define FG_SPECIAL              0x0c00
@@ -437,7 +437,7 @@ Section 17.5.3 of the Concepts book.
 **Include:** fontID.h
 
 ----------
-#### FontIDRecord
+### FontIDRecord
     typedef WordFlags FontIDRecord;
         #define FIDR_maker              0xf000
         #define FIDR_ID             0x0fff
@@ -447,7 +447,7 @@ Section 17.5.3 of the Concepts book.
 **Include:** font.h
 
 ----------
-#### FontID
+### FontID
     typedef word FontID;
         #define FID_PRINTER_20CPI                           0xfa05
         #define FID_PRINTER_17CPI                           0xfa04
@@ -1624,7 +1624,7 @@ Fonts are normally referenced by FontID.
 **Include:** fontID.h
 
 ----------
-#### FontMaker
+### FontMaker
     typedef word FontMaker;
         #define FM_PRINTER              0xf000
         #define FM_MICROLOGIC           0xe000
@@ -1639,7 +1639,7 @@ Fonts are normally referenced by FontID.
 **Include:** fontID.h
 
 ----------
-#### FontMap
+### FontMap
     typedef byte FontMap;
         #define FM_DONT_USE             0x00ff
         #define FM_EXACT                0x0000
@@ -1647,7 +1647,7 @@ Fonts are normally referenced by FontID.
 **Include:** fontID.h
 
 ----------
-#### FontWeight
+### FontWeight
     typedef ByteEnum FontWeight;
         #define FW_ULTRA_LIGHT              0
         #define FW_EXTRA_LIGHT              1
@@ -1663,7 +1663,7 @@ Fonts are normally referenced by FontID.
 **Include:** font.h
 
 ----------
-#### FontWidth
+### FontWidth
     typedef     ByteEnum FontWidth;
         #define FWI_NARROW                  0
         #define FWI_CONDENSED               1
@@ -1674,11 +1674,11 @@ Fonts are normally referenced by FontID.
 **Include:** font.h
 
 ----------
-#### FormatArray
+### FormatArray
     typedef ClipboardItemFormatInfo FormatArray[CLIPBOARD_MAX_FORMATS];
 
 ----------
-#### FormatError
+### FormatError
     typedef ByteEnum FormatError;
         #define FMT_DONE                                        0
         #define FMT_READY                                       1
@@ -1704,7 +1704,7 @@ Fonts are normally referenced by FontID.
         #define FMT_ERR_DISK_UNAVAILABLE                        21
 
 ----------
-#### FunctionID
+### FunctionID
     typedef enum /* word */ {
         FUNCTION_ID_ABS,
         FUNCTION_ID_ACOS,
@@ -1807,7 +1807,7 @@ Fonts are normally referenced by FontID.
     } FunctionID;
 
 ----------
-#### GCM_info
+### GCM_info
     typedef enum /* word */ {
         GCMI_MIN_X,
         GCMI_MIN_X_ROUNDED,
@@ -1820,34 +1820,34 @@ Fonts are normally referenced by FontID.
     } GCM_info;
 
 ----------
-#### GCNDriveChangeNotificationType
+### GCNDriveChangeNotificationType
     typedef enum {
         GCNDCNT_CREATED,
         GCNDCNT_DESTROYED
     } GCNDriveChangeNotificationType;
 
 ----------
-#### GCNExpressMenuNotificationType
+### GCNExpressMenuNotificationType
     typedef enum {
         GCNEMNT_CREATED,
         GCNEMNT_DESTROYED
     } GCNExpressMenuNotificationType;
 
 ----------
-#### GCNListBlockHeader
+### GCNListBlockHeader
     typedef struct {
         LMemBlockHeader         GCNLBH_lmemHeader;
         ChunkHandle             GCNLBH_listOfLists;
     } GCNListBlockHeader;
 
 ----------
-#### GCNListElement
+### GCNListElement
     typedef struct {
         optr    GCNLE_item;
     } GCNListElement;
 
 ----------
-#### GCNListHeader
+### GCNListHeader
     typedef struct {
         ChunkArrayHeader        GCNLH_meta;
         word                    GCNLH_statusEvent;
@@ -1857,46 +1857,46 @@ Fonts are normally referenced by FontID.
     } GCNListHeader;
 
 ----------
-#### GCNListOfListsElement
+### GCNListOfListsElement
     typedef struct {
         GCNListType         GCNLOLE_ID;
         ChunkHandle         GCNLOLE_list;
     } GCNListOfListsElement;
 
 ----------
-#### GCNListOfListsHeader
+### GCNListOfListsHeader
     typedef struct {
         ChunkArrayHeader                GCNLOL_meta;
         /* Start of GCNListOfListsElements */
     } GCNListOfListsHeader;
 
 ----------
-#### GCNListParams
+### GCNListParams
     typedef struct {
         GCNListType     GCNLP_ID;
         optr            GCNLP_optr;
     } GCNListParams;
 
 ----------
-#### GCNListSendFlags
+### GCNListSendFlags
     typedef WordFlags GCNListSendFlags;
         #define GCNLSF_SET_STATUS                       0x8000
         #define GCNLSF_IGNORE_IF_STATUS_TRANSITIONING   0x4000
 
 ----------
-#### GCNListType
+### GCNListType
     typedef struct {
         word    GCNLT_manuf;
         word    GCNLT_type;
     } GCNListType;
 
 ----------
-#### GCNListTypeFlags
+### GCNListTypeFlags
     typedef WordFlags GCNListTypeFlags;
         #define GCNLTF_SAVE_TO_STATE            0x8000
 
 ----------
-#### GCNShutdownControlType
+### GCNShutdownControlType
     typedef enum {
         GCNSCT_SUSPEND,
         GCNSCT_SHUTDOWN,
@@ -1904,7 +1904,7 @@ Fonts are normally referenced by FontID.
     } GCNShutdownControlType;
 
 ----------
-#### GCNStandardListType
+### GCNStandardListType
     typedef enum {
         GCNSLT_FILE_SYSTEM,
         GCNSLT_APPLICATION,
@@ -1915,7 +1915,7 @@ Fonts are normally referenced by FontID.
     } GCNStandardListType;
 
 ----------
-#### GenAppGCNListTypes
+### GenAppGCNListTypes
     typedef enum /* word */ {
         GAGCNLT_GEN_CONTROL_OBJECTS,
         GAGCNLT_GEN_CONTROL_NOTIFY_STATUS_CHANGE,
@@ -1947,7 +1947,7 @@ Fonts are normally referenced by FontID.
     } GenAppGCNListTypes;
 
 ----------
-#### GeneralEvent
+### GeneralEvent
     typedef enum {
         GE_NO_EVENT=0,                  /* dummy event (NOP) */
         GE_END_OF_SONG=2,               /* marks end of song */
@@ -1961,12 +1961,12 @@ These represent some of the miscellaneous events which can make up a
 music buffer.
 
 ----------
-#### GenTravelOption
+### GenTravelOption
 The **GenClass** defines some values meant to be used in the place of a 
 **TravelOption** enumerated value. See **TravelOption**.
 
 ----------
-#### GeodeAttrs
+### GeodeAttrs
     typedef WordFlags GeodeAttrs;
         #define GA_PROCESS                          0x8000
         #define GA_LIBRARY                          0x4000
@@ -1984,7 +1984,7 @@ The **GenClass** defines some values meant to be used in the place of a
         #define GA_ENTRY_POINTS_IN_C                0x0004
 
 ----------
-#### GeodeDefaultDriverType
+### GeodeDefaultDriverType
     typedef enum {
         GDDT_FILE_SYSTEM = 0,           /* File system driver */
         GDDT_KEYBOARD = 2,              /* Keyboard driver */
@@ -2000,7 +2000,7 @@ This type is used with **GeodeGetDefaultDriver()** and
 **GeodeSetDefaultDriver()**.
 
 ----------
-#### GeodeGetInfoType
+### GeodeGetInfoType
     typedef enum /* word */ {
         GGIT_ATTRIBUTES=0,
         GGIT_TYPE=2,
@@ -2012,20 +2012,20 @@ This type is used with **GeodeGetDefaultDriver()** and
     } GeodeGetInfoType;
 
 ----------
-#### GeodeHandle
+### GeodeHandle
     typedef Handle GeodeHandle;
 
 A standard handle that contains information about a loaded geode. When a 
 geode has been loaded, it is referred to by its handle.
 
 ----------
-#### GeodeHeapVars
+### GeodeHeapVars
     typedef struct {
         word        GHV_heapSpace;
     } GeodeHeapVars;
 
 ----------
-#### GeodeLoadError
+### GeodeLoadError
     typedef enum {
         GLE_PROTOCOL_IMPORTER_TOO_RECENT,
         GLE_PROTOCOL_IMPORTER_TOO_OLD,
@@ -2050,7 +2050,7 @@ These errors may be returned by routines that load geodes, including
 **GeodeLoad()**.
 
 ----------
-#### GeodeToken
+### GeodeToken
     typedef struct {
         TokenChars              GT_chars;
         ManufacturerID          GT_manufID;
@@ -2061,14 +2061,14 @@ the token; *GT_manufID* is the identifying number of the manufacturer of the
 item being referenced.
 
 ----------
-#### GeosFileHeaderFlags
+### GeosFileHeaderFlags
     typedef WordFlags GeosFileHeaderFlags;
         #define GFHF_TEMPLATE                   0x8000
         #define GFHF_SHARED_MULTIPLE            0x4000
         #define GFHF_SHARED_SINGLE              0x2000
 
 ----------
-#### GeosFileType
+### GeosFileType
     typedef enum /* word */ {
         GFT_NOT_GEOS_FILE,
         GFT_EXECUTABLE,
@@ -2103,7 +2103,7 @@ GFT_LINK
 The file is a symbolic link (not yet implemented).
 
 ----------
-#### GeoWorksGenAppGCNListType
+### GeoWorksGenAppGCNListType
     typedef enum /* word */ {
         GAGCNLT_SELF_LOAD_OPTIONS = 0x6800,
         GAGCNLT_GEN_CONTROL_NOTIFY_STATUS_CHANGE,
@@ -2184,14 +2184,14 @@ The file is a symbolic link (not yet implemented).
     } GeoWorksGenAppGCNListType;
 
 ----------
-#### GeoWorksMetaGCNListType
+### GeoWorksMetaGCNListType
     typedef enum /* word */ {
         MGCNLT_ACTIVE_LIST = 0x00,
         MGCNLT_APP_STARTUP = 0x02
     } GeoWorksMetaGCNListType;
 
 ----------
-#### GeoWorksNotificationType
+### GeoWorksNotificationType
     typedef enum {
         GWNT_INK,
         GWNT_GEN_CONTROL_NOTIFY_STATUS_CHANGE,
@@ -2289,27 +2289,27 @@ The file is a symbolic link (not yet implemented).
     } GeoWorksNotificationType;
 
 ----------
-#### GeoWorksVisContentGCNListType
+### GeoWorksVisContentGCNListType
     typedef enum {
         VCGCNLT_TARGET_NOTIFY_TEXT_PARA_ATTR_CHANGE = 0x4a00,
         PADDING_VCGCNLT_INVALID_ITEM_000
     } GeoWorksVisContentGCNListType;
 
 ----------
-#### GetMaskType
+### GetMaskType
     typedef ByteEnum GetMaskType;
         #define GMT_ENUM                0
         #define GMT_BUFFER              1
 
 ----------
-#### GetPalType
+### GetPalType
     typedef ByteEnum GetPalType;
         #define GPT_ACTIVE              0
         #define GPT_CUSTOM              1
         #define GPT_DEFAULT             2
 
 ----------
-#### GFM_info
+### GFM_info
     typedef enum /* word */ {
          GFMI_HEIGHT=0, /* 0 */
          GFMI_HEIGHT_ROUNDED=1,
@@ -2349,14 +2349,14 @@ The file is a symbolic link (not yet implemented).
     } GFM_info;
 
 ----------
-#### GraphicPattern
+### GraphicPattern
     typedef struct { 
         PatternType     HP_type;
         byte            HP_data;
     } GraphicPattern;
 
 ----------
-#### GSControl
+### GSControl
     typedef WordFlags GSControl;
         #define GSC_PARTIAL             0x0200
         #define GSC_ONE                 0x0100
@@ -2370,7 +2370,7 @@ The file is a symbolic link (not yet implemented).
         #define GSC_PATH                0x0001
 
 ----------
-#### GSRetType
+### GSRetType
     typedef ByteEnum GSRetType;
         #define GSRT_COMPLETE               0
         #define GSRT_FORM_FEED              1
@@ -2381,12 +2381,12 @@ The file is a symbolic link (not yet implemented).
         #define GSRT_FAULT                  0xff
 
 ----------
-#### GState
+### GState
 GStates are always referenced by means of GStateHandles, and are 
 documented there.
 
 ----------
-#### GStateHandle
+### GStateHandle
     typedef Handle GStateHandle;
 
 GStates, or graphics states, are used to interpret graphics commands. Any 
@@ -2407,7 +2407,7 @@ GStateHandle representing a bitmap or graphics string will affect the data
 structure instead of being drawn to screen.
 
 ----------
-#### GString
+### GString
     typedef void GString;
 
 A GString (short for "Graphics Strings") represents a string of graphics 
@@ -2433,7 +2433,7 @@ Thus, these macros just represent data, though they look like normal kernel
 graphics commands.
 
 ----------
-#### GStringElement
+### GStringElement
     typedef ByteEnum GStringElement;
         /* The following elements are defined :
                 (Miscellaneous GString opcodes:)
@@ -2582,20 +2582,20 @@ graphics commands.
         GR_SET_STROKE_PATH                                  */
 
 ----------
-#### GStringErrorType
+### GStringErrorType
     typedef enum /* word */ {
         GSET_NO_ERROR,
         GSET_DISK_FULL
     } GStringErrorType;
 
 ----------
-#### GStringKillType
+### GStringKillType
     typedef ByteEnum GStringKillType;
         #define GSKT_KILL_DATA          0
         #define GSKT_LEAVE_DATA         1
 
 ----------
-#### GStringSetPosType
+### GStringSetPosType
     typedef ByteEnum GStringSetPosType;
         #define GSSPT_SKIP_1                0
         #define GSSPT_RELATIVE              1
@@ -2603,7 +2603,7 @@ graphics commands.
         #define GSSPT_END                   3
 
 ----------
-#### GStringType
+### GStringType
     typedef ByteEnum GStringType;
         #define GST_CHUNK               0
         #define GST_STREAM              1
@@ -2612,18 +2612,18 @@ graphics commands.
         #define GST_PATH                4
 
 ----------
-#### Handle
+### Handle
     typedef word Handle;
 
 ----------
-#### HatchDash
+### HatchDash
     typedef struct {
         WWFixed     HD_on;
         WWFixed     HD_off;
     } HatchDash;
 
 ----------
-#### HatchLine
+### HatchLine
     typedef struct {
         PointWWFixed    HL_origin;
         WWFixed         HL_deltaX;
@@ -2635,14 +2635,14 @@ graphics commands.
     } HatchLine;
 
 ----------
-#### HatchPattern
+### HatchPattern
     typedef struct {
         word HP_numLines;
             /* array of HatchLine structures follows here */
     } HatchPattern;
 
 ----------
-#### HeapAllocFlags
+### HeapAllocFlags
     typedef ByteFlags HeapAllocFlags;
         #define HAF_ZERO_INIT               0x80
         #define HAF_LOCK                    0x40
@@ -2658,7 +2658,7 @@ graphics commands.
         #define HAF_STANDARD_NO_ERR_LOCK    (HAF_NO_ERR | HAF_LOCK)
 
 ----------
-#### HeapCongestion
+### HeapCongestion
     typedef enum /* word */ {
         HC_SCRUBBING,
         HC_CONGESTED,
@@ -2666,7 +2666,7 @@ graphics commands.
     } HeapCongestion;
 
 ----------
-#### HeapFlags
+### HeapFlags
     typedef ByteFlags HeapFlags;
         #define HF_FIXED                0x80
         #define HF_SHARABLE             0x40
@@ -2679,7 +2679,7 @@ graphics commands.
         #define HF_DYNAMIC              HF_SWAPABLE
 
 ----------
-#### HugeArrayDirectory
+### HugeArrayDirectory
     typedef struct {
         LMemBlockHeader         HAD_header;
         VMBlockHandle           HAD_data;
@@ -2690,7 +2690,7 @@ graphics commands.
     } HugeArrayDirectory;
 
 ----------
-#### IACPConnectFlags
+### IACPConnectFlags
     typedef WordFlags IACPConnectFlags;
         #define IACPCF_OBEY_LAUNCH_MODEL            0x0020
         #define IACPCF_CLIENT_OD_SPECIFIED          0x0010
@@ -2700,14 +2700,14 @@ graphics commands.
 **Include:** iacp.goh
 
 ----------
-#### IACPServerFlags
+### IACPServerFlags
     typedef ByteFlags IACPServerFlags;
         #define IACPSF_MULTIPLE_INSTANCES                       0x80
 
 **Include:** iacp.goh
 
 ----------
-#### IACPServerMode
+### IACPServerMode
     typedef ByteEnum IACPServerMode;
         #define IACPSM_NOT_USER_INTERACTIBLE        0
         #define IACPSM_IN_FLUX                      1
@@ -2716,7 +2716,7 @@ graphics commands.
 **Include:** iacp.goh
 
 ----------
-#### IACPSide
+### IACPSide
     typedef enum {
         IACPS_CLIENT,
         IACPS_SERVER
@@ -2725,7 +2725,7 @@ graphics commands.
 **Include:** iacp.goh
 
 ----------
-#### ImageFlags
+### ImageFlags
     typedef ByteFlags ImageFlags;
         #define IF_IGNORE_MASK      0x10
         #define IF_BORDER           0x08
@@ -2737,7 +2737,7 @@ graphics commands.
         #define IBS_16          4
 
 ----------
-#### IMCFeatures
+### IMCFeatures
     typedef ByteFlags IMCFeatures;
         #define IMCF_MAP                        0x01
         #define IMC_DEFAULT_FEATURES            IMCF_MAP
@@ -2745,7 +2745,7 @@ graphics commands.
         #define IMC_MAP_MONIKER_SIZE            1024
 
 ----------
-#### ImpexDataClasses
+### ImpexDataClasses
     typedef WordFlags ImpexDataClasses;
         #define IDC_TEXT                0x8000
         #define IDC_GRAPHICS            0x4000
@@ -2753,7 +2753,7 @@ graphics commands.
         #define IDC_FONT                0x1000
 
 ----------
-#### ImpexFileSelectionData
+### ImpexFileSelectionData
     typedef struct {
         FileLongName                IFSD_selection;
         PathName                    IFSD_path;
@@ -2762,13 +2762,13 @@ graphics commands.
     } ImpexFileSelectionData;
 
 ----------
-#### ImpexMapFlags
+### ImpexMapFlags
     typedef ByteFlags ImpexMapFlags;
         #define IMF_IMPORT              0x80
         #define IMF_EXPORT              0x40
 
 ----------
-#### ImpexMapFileInfoHeader
+### ImpexMapFileInfoHeader
     typedef struct {
         LMemBlockHeader         IMFIH_base;
         word                    IMFIH_fieldChunk;
@@ -2776,7 +2776,7 @@ graphics commands.
     } ImpexMapFileInfoHeader;
 
 ----------
-#### ImpexTranslationParams
+### ImpexTranslationParams
     typedef struct {
         optr            ITP_impexOD;
         Message         ITP_returnMsg;
@@ -2787,17 +2787,17 @@ graphics commands.
     } ImpexTranslationParams;
 
 ----------
-#### ImportControlAttrs
+### ImportControlAttrs
     typedef WordFlags ImportControlAttrs;
         #define ICA_IGNORE_INPUT 0x8000 /* ignore input while import occurs */
 
 ----------
-#### ImportControlToolboxFeatures
+### ImportControlToolboxFeatures
     typedef ByteFlags ImportControlToolboxFeatures;
         #define IMPORTCTF_DIALOG_BOX                    0x01
 
 ----------
-#### InitFileCharConvert
+### InitFileCharConvert
     typedef ByteEnum InitFileCharConvert;
         #define IFCC_INTACT         0   /* Leave all characters unchanged. */
         #define IFCC_UPCASE         1   /* Make all characters upper case. */
@@ -2807,7 +2807,7 @@ This enumerated type describes how **InitFileRead...()** routines should
 handle incoming strings.
 
 ----------
-#### InitFileReadFlags
+### InitFileReadFlags
     typedef WordFlags InitFileReadFlags;
         #define IFRF_CHAR_CONVERT   0xc000  /* 2 bits: InitFileCharConvert type */
         #define IFRF_READ_ALL       0x2000
@@ -2825,7 +2825,7 @@ When setting this record, make sure you shift the IFRF_CHAR_CONVERT
 value left an offset of IFRF_CHAR_CONVERT_OFFSET.
 
 ----------
-#### InkBackgroundType
+### InkBackgroundType
     typedef enum {
         IBT_NO_BACKGROUND = 0,
         IBT_NARROW_LINED_PAPER = 2,
@@ -2849,19 +2849,19 @@ This enumerated type is a set of standard background pictures for use with
 the Ink Database routines.
 
 ----------
-#### InkControlFeatures
+### InkControlFeatures
     typedef ByteFlags InkControlFeatures;
         #define ICF_PENCIL_TOOL             0x02
         #define ICF_ERASER_TOOL             0x01
 
 ----------
-#### InkControlToolboxFeatures
+### InkControlToolboxFeatures
     typedef ByteFlags InkControlToolboxFeatures;
         #define ICTF_PENCIL_TOOL                0x02
         #define ICTF_ERASER_TOOL                0x01
 
 ----------
-#### InkDBDisplayInfo
+### InkDBDisplayInfo
     typedef struct {
         dword   IDBDI_dword1;
         dword   IDBDI_dword2;
@@ -2869,7 +2869,7 @@ the Ink Database routines.
     } InkDBDisplayInfo;
 
 ----------
-#### InkDBFrame
+### InkDBFrame
     typedef struct {
         Rectangle IDBF_bounds;              /* bounds of data to save or coord at
                                              * which to load data */
@@ -2879,7 +2879,7 @@ the Ink Database routines.
     } InkDBFrame;
 
 ----------
-#### InkFlags
+### InkFlags
     typedef ByteFlags InkFlags;
         #define IF_HAS_TARGET                   0x20
         #define IF_DIRTY                        0x10
@@ -2889,7 +2889,7 @@ the Ink Database routines.
         #define IF_HAS_UNDO                     0x01
 
 ----------
-#### InkReturnValue
+### InkReturnValue
     typedef enum {
         IRV_NO_REPLY,
         /* VisComp objects use VisCallChildUnderPoint to send
@@ -2913,7 +2913,7 @@ This enumerated type is used by objects to let the system know whether
 incoming pointer events should be interpreted as mouse or pen data.
 
 ----------
-#### InsertChildFlags
+### InsertChildFlags
     typedef WordFlags InsertChildFlags
         #define ICF_MARK_DIRTY          0x8000
         #define ICF_OPTIONS             0x0003
@@ -2921,7 +2921,7 @@ incoming pointer events should be interpreted as mouse or pen data.
 This record specifies how children are to be added to an object tree.
 
 ----------
-#### InsertChildOption
+### InsertChildOption
     typedef ByteEnum InsertChildOption
         #define ICO_FIRST                   0
         #define ICO_LAST                    1
@@ -2932,7 +2932,7 @@ This enumerated type determines how a child is added and is used with the
 **InsertChildFlags** record. It has four enumerations, as shown above.
 
 ----------
-#### InstrumentPatch
+### InstrumentPatch
     typedef enum { 
         #define IP_ACOUSTIC_GRAND_PIANO     0
         #define IP_BRIGHT_ACOUSTIC_PIANO    1
@@ -3135,7 +3135,7 @@ This enumerated type determines how a child is added and is used with the
 These are standard simulated instruments. 
 
 ----------
-#### InstrumentTable
+### InstrumentTable
     typedef enum {
         IT_STANDARD_TABLE=0             /* default table */
     } InstrumentTable;
@@ -3144,7 +3144,7 @@ The sound library uses this enumerated type to keep track of which table of
 simulated musical instruments to use.
 
 ----------
-#### JobStatus
+### JobStatus
     typedef struct {
         char            JS_fname[13];       /* std DOS (8.3) spool filename */
         char            JS_parent[FILE_LONGNAME_LENGTH+1];
@@ -3157,7 +3157,7 @@ simulated musical instruments to use.
     } JobStatus;
 
 ----------
-#### Justification
+### Justification
     typedef ByteEnum Justification;
         #define J_LEFT          0
         #define J_RIGHT         1
@@ -3165,7 +3165,7 @@ simulated musical instruments to use.
         #define J_FULL          3
 
 ----------
-#### KeyboardShortcut
+### KeyboardShortcut
     typedef WordFlags KeyboardShortcut;
         #define KS_PHYSICAL             0x8000
         #define KS_ALT                  0x4000
@@ -3177,14 +3177,14 @@ simulated musical instruments to use.
         #define KS_CHAR_OFFSET          0
 
 ----------
-#### KeyboardType
+### KeyboardType
     typedef ByteEnum KeyboardType;
         #define KT_NOT_EXTD         1
         #define KT_EXTD             2
         #define KT_BOTH             3
 
 ----------
-#### KeyMapType
+### KeyMapType
         typedef enum /* word */ {
         KEYMAP_US_EXTD=1,
         KEYMAP_US,

--- a/TechDocs/Markdown/Routines/rstrl_z.md
+++ b/TechDocs/Markdown/Routines/rstrl_z.md
@@ -1,6 +1,6 @@
 ## 4.3 Data Structures L-Z
 ----------
-#### Language
+### Language
     typedef ByteEnum Language;
         #define L_DEFAULT               0
         #define L_GRAPHIC               0
@@ -13,7 +13,7 @@
         #define L_DUTCH                 7
 
 ----------
-#### LargeMouseData
+### LargeMouseData
     typedef struct {
         PointDWFixed                LMD_location;
         byte                        LMD_buttonInfo;
@@ -21,7 +21,7 @@
     } LargeMouseData;
 
 ----------
-#### LayerPriority
+### LayerPriority
     typedef ByteEnum LayerPriority;
         #define LAYER_PRIO_MODAL                 6
         #define LAYER_PRIO_ON_TOP                8
@@ -29,7 +29,7 @@
         #define LAYER_PRIO_ON_BOTTOM            14
 
 ----------
-#### LexicalOrder
+### LexicalOrder
     typedef ByteEnum LexicalOrder;
         #define LEX_SPACE                   0x20
         #define LEX_NONBRKSPACE             1
@@ -257,7 +257,7 @@
         #define LEX_CARON                   223
 
 ----------
-#### LexFirstOrder
+### LexFirstOrder
     typedef ByteEnum Lex1stOrder;
         #define LEX1_SPACE                  0x20
         #define LEX1_EXCLAMATION            1
@@ -382,7 +382,7 @@
         #define LEX1_CARON              120
 
 ----------
-#### LibraryCallType
+### LibraryCallType
     typedef enum /* word */ {
         LCT_ATTACH,             /* The library was just loaded. */
         LCT_DETACH,             /* The library is about to be unloaded. */
@@ -399,7 +399,7 @@ take a value of this enumerated type to determine what, if anything, is to be
 done.
 
 ----------
-#### LineAttr
+### LineAttr
     typedef struct {
         byte            LA_colorFlag;
         RGBValue        LA_color;
@@ -412,7 +412,7 @@ done.
     } LineAttr;
 
 ----------
-#### LineEnd
+### LineEnd
     typedef ByteEnum LineEnd;
         #define LE_BUTTCAP              0
         #define LE_ROUNDCAP             1
@@ -423,7 +423,7 @@ Line ends determine how the graphics system will draw the end of a line
 segment.
 
 ----------
-#### LineJoin
+### LineJoin
     typedef ByteEnum LineJoin;
         #define LJ_MITERED                  0
         #define LJ_ROUND                    1
@@ -434,7 +434,7 @@ This enumerated type determines how the graphics system will draw corners
 of rectangles and polylines.
 
 ----------
-#### LineStyle
+### LineStyle
     typedef ByteEnum LineStyle;
         #define LS_SOLID                    0
         #define LS_DASHED                   1
@@ -448,7 +448,7 @@ The **LineStyle** type describes a line's "dottedness." Lines using custom
 dashes will work with the **DashPairArray** structure.
 
 ----------
-#### LMemBlockHeader
+### LMemBlockHeader
     typedef struct {
         MemHandle       LMBH_handle;
         word            LMBH_offset;
@@ -507,7 +507,7 @@ automatically maintained by the LMem routines.
 **See Also:** LMemInitHeap()
 
 ----------
-#### LMemType
+### LMemType
     typdef enum {
         LMEM_TYPE_GENERAL,
         LMEM_TYPE_WINDOW,
@@ -568,19 +568,19 @@ DB routines, which see to it that the blocks are created.
 **Include:** lmem.h
 
 ----------
-#### LocalDistanceFlags
+### LocalDistanceFlags
     typedef WordFlags LocalDistanceFlags;
         #define LDF_FULL_NAMES                      0x8000
         #define LDF_PRINT_PLURAL_IF_NEEDED          0x4000
 
 ----------
-#### LocalCmpStringsDosToGeosFlags
+### LocalCmpStringsDosToGeosFlags
     typedef ByteFlags LocalCmpStringsDosToGeosFlags;
         #define LCSDTG_NO_CONVERT_STRING_2              0x02
         #define LCSDTGF_NO_CONVERT_STRING_1             0x01
 
 ----------
-#### LocalCurrencyFormat
+### LocalCurrencyFormat
     typedef struct {
         byte    CurrencyFormatFlags;
         byte    currencyDigits;
@@ -590,7 +590,7 @@ DB routines, which see to it that the blocks are created.
     } LocalCurrencyFormat;
 
 ----------
-#### LocalMemoryFlags
+### LocalMemoryFlags
     typedef WordFlags LocalMemoryFlags;
         #define LMF_HAS_FLAGS               0x8000
         #define LMF_IN_RESOURCE             0x4000
@@ -691,7 +691,7 @@ blocks.
 **Include:** lmem.h
 
 ----------
-#### LocalNumericFormat
+### LocalNumericFormat
     typedef struct {
         byte    numberFormatFlags;
         byte    decimalDigits;
@@ -701,7 +701,7 @@ blocks.
     } LocalNumericFormat;
 
 ----------
-#### LocalQuotes
+### LocalQuotes
     typedef struct {
         word    frontSingle;
         word    endSingle;
@@ -710,13 +710,13 @@ blocks.
     } LocalQuotes;
 
 ----------
-#### ManufacturerID
+### ManufacturerID
     typedef enum { /* word */
         MANUFACTURER_ID_GEOWORKS
     } ManufacturerID;
 
 ----------
-#### MapColorToMono
+### MapColorToMono
     typedef ByteEnum MapColorToMono;
         #define CMT_CLOSEST             0
         #define CMT_DITHER              1
@@ -726,7 +726,7 @@ in an unavailable color. It will either draw in the closest color, or else mix t
 or more close colors to get as close as possible overall.
 
 ----------
-#### MapListBlockHeader
+### MapListBlockHeader
     typedef struct {
         LMemBlockHeader         MLBH_base;
         word                    MLBH_numDestFields;
@@ -734,7 +734,7 @@ or more close colors to get as close as possible overall.
     } MapListBlockHeader;
 
 ----------
-#### MarginDimensions
+### MarginDimensions
     typedef struct {
         int     leftMargin;
         int     topMargin;
@@ -743,13 +743,13 @@ or more close colors to get as close as possible overall.
     } MarginDimensions;
 
 ----------
-#### MeasurementType
+### MeasurementType
     typedef ByteEnum MeasurementType;
         #define MEASURE_US              0
         #define MEASURE_METRIC          1
 
 ----------
-#### MediaType
+### MediaType
     typedef enum /* byte */ {
         #define MEDIA_NONEXISTENT       0
         #define MEDIA_160K              1
@@ -770,7 +770,7 @@ routines (e.g. **DriveGetDefaultMedia()**). A **MediaType** value is also
 passed to **DiskFormat()**, indicating how the disk should be formatted.
 
 ----------
-#### MemGetInfoType
+### MemGetInfoType
     typedef enum /* word */ {
         MGIT_SIZE=0,                    /* size in bytes */
         MGIT_FLAGS_AND_LOCK_COUNT=2,    /* use MGI_LOCK_COUNT and MGI_FLAGS */
@@ -781,15 +781,15 @@ passed to **DiskFormat()**, indicating how the disk should be formatted.
     } MemGetInfoType;
 
 ----------
-#### MemHandle
+### MemHandle
     typedef Handle MemHandle;
 
 ----------
-#### Message
+### Message
     typedef word Message;
 
 ----------
-#### MessageError
+### MessageError
     typedef enum /* word */ {
          MESSAGE_NO_ERROR,          /* no error was encountered */
          MESSAGE_NO_HANDLES         /* no handle could be allocated
@@ -802,7 +802,7 @@ whether the message was successfully sent. This is not encountered by C
 applications.
 
 ----------
-#### MessageFlags
+### MessageFlags
     typedef WordFlags MessageFlags;
         #define MF_CALL                     0x8000      /* @call */
         #define MF_FORCE_QUEUE              0x4000
@@ -825,15 +825,15 @@ of these flags are set properly by Goc and the kernel in C. See the reference
 entries for the Goc keywords **@call** and **@send**.
 
 ----------
-#### MessageHandle
+### MessageHandle
     typedef Handle MessageHandle;
 
 ----------
-#### MessageMethod
+### MessageMethod
     typedef void     MessageMethod();
 
 ----------
-#### MinIncrementType
+### MinIncrementType
     typedef union {
         MinUSMeasure                MIT_US;
         MinMetricMeasure            MIT_METRIC;
@@ -842,27 +842,27 @@ entries for the Goc keywords **@call** and **@send**.
     } MinIncrementType;
 
 ----------
-#### MinMetricMeasure
+### MinMetricMeasure
     typedef ByteEnum MinMetricMeasure;
         #define MMM_MILLIMETER                  0
         #define MMM_HALF_CENTIMETER             1
         #define MMM_CENTIMETER                  2
 
 ----------
-#### MinPicaMeasure
+### MinPicaMeasure
     typedef ByteEnum MinPicaMeasure;
         #define MPM_PICA                    0
         #define MPM_INCH                    1
 
 ----------
-#### MinPointMeasure
+### MinPointMeasure
     typedef ByteEnum MinPointMeasure;
         #define MPM_25_POINT                    0
         #define MPM_50_POINT                    1
         #define MPM_100_POINT                   2
 
 ----------
-#### MinUSMeasure
+### MinUSMeasure
     typedef ByteEnum MinUSMeasure;
         #define MUSM_EIGHTH_INCH                0
         #define MUSM_QUARTER_INCH               1
@@ -870,7 +870,7 @@ entries for the Goc keywords **@call** and **@send**.
         #define MUSM_ONE_INCH                   3
 
 ----------
-#### MixMode
+### MixMode
     typedef ByteEnum MixMode;
         #define MM_CLEAR        0   /* clear destination */
         #define MM_COPY         1   /* new drawing is opaque */
@@ -885,13 +885,13 @@ The **MixMode** determines what the graphics system will do when drawing
 one thing on top of another.
 
 ----------
-#### MonoTransfer
+### MonoTransfer
     typedef struct {
         byte MT_gray[256];
     } MonoTransfer;
 
 ----------
-#### MouseReturnFlags
+### MouseReturnFlags
     typedef WordFlags MouseReturnFlags;
         #define MRF_PROCESSED                       0x8000
         #define MRF_REPLAY                          0x4000
@@ -903,7 +903,7 @@ These flags are used in various parts of the system that work with mouse
 input. Which values are appropriate to pass will vary based on context.
 
 ----------
-#### MouseReturnParams
+### MouseReturnParams
     typedef struct {
         word                    unused;
         MouseReturnFlags        flags;
@@ -914,18 +914,18 @@ This structure is used in certain areas of the system which work with mouse
 input.
 
 ----------
-#### NameArrayAddFlags
+### NameArrayAddFlags
     typedef WordFlags NameArrayAddFlags;
         #define NAAF_SET_DATA_ON_REPLACE 0x8000
 
 ----------
-#### NameArrayElement
+### NameArrayElement
     typedef struct {
         RefElementHeader NAE_meta;
     } NameArrayElement;
 
 ----------
-#### NameArrayHeader
+### NameArrayHeader
     typedef struct{
         ElementArrayHeader      NAH_meta;
         word                    NAH_dataSize;   /* Size of data section of
@@ -940,7 +940,7 @@ of every element is. Applications may examine this field, but they must not
 change it.
 
 ----------
-#### NameArrayMaxElement
+### NameArrayMaxElement
     typedef struct {
         RefElementHeader NAME_meta;
         byte NAME_data[NAME_ARRAY_MAX_DATA_SIZE];
@@ -952,59 +952,59 @@ change it.
     #define NO_ERROR_RETURNED               0
 
 ----------
-#### NoteType
+### NoteType
     typedef ByteEnum NoteType;
         #define NT_INK          0
         #define NT_TEXT         1
 
 ----------
-#### NotificationType
+### NotificationType
     typedef struct {
         ManufacturerID          NT_manuf;
         word            NT_type;
     } NotificationType;
 
 ----------
-#### NotifyInkHasTarget
+### NotifyInkHasTarget
     typedef struct {
         optr    NIHT_optr;
     } NotifyInkHasTarget;
 
 ----------
-#### NULL
+### NULL
     #undef NULL
     #define NULL        0
 
 ----------
-#### NullChunk
+### NullChunk
     #define NullChunk       ((ChunkHandle) 0)
 
 ----------
-#### NullClass
+### NullClass
     #define NullClass       ((ClassStruct *) 0)
 
 ----------
-#### NullHandle
+### NullHandle
     #define NullHandle      ((Handle) 0)
 
 ----------
-#### NullOptr
+### NullOptr
     #define NullOptr        ((optr) 0)
 
 ----------
-#### NumberFormatFlags
+### NumberFormatFlags
     typedef ByteFlags NumberFormatFlags;
         #define NFF_LEADING_ZERO                0x01
 
 ----------
-#### NumberType
+### NumberType
     typedef ByteEnum NumberType;
         #define NT_VALUE                0
         #define NT_BOOLEAN              1
         #define NT_DATE_TIME            2
 
 ----------
-#### ObjChunkFlags
+### ObjChunkFlags
     typedef ByteFlags ObjChunkFlags;
         #define OCF_VARDATA_RELOC           0x10
         #define OCF_DIRTY                   0x08
@@ -1016,7 +1016,7 @@ This record is stored at the beginning of each chunk and gives specific
 information about the chunk. The flags are internal.
 
 ----------
-#### ObjLMemBlockHeader
+### ObjLMemBlockHeader
     typedef struct {
         LMemBlockHeader     OLMBH_header;   /* standard LMem block header */
         word                OLMBH_inUseCount;
@@ -1053,14 +1053,14 @@ Messages may also be sent to this output object via the
 The size of the object block (resource).
 
 ----------
-#### ObjRelocation
+### ObjRelocation
     typedef struct {
         ObjRelocationType       OR_type;
         word                    OR_offset;
     } ObjRelocation;
 
 ----------
-#### ObjRelocationSource
+### ObjRelocationSource
     typedef ByteEnum ObjRelocationSource;
         #define ORS_NULL                            0
         #define ORS_OWNING_GEODE                    1
@@ -1075,7 +1075,7 @@ The size of the object block (resource).
         #define RID_SOURCE_OFFSET                   12
 
 ----------
-#### ObjRelocationType
+### ObjRelocationType
     typedef ByteEnum ObjRelocationType;
         #define RELOC_END_OF_LIST                       0
         #define RELOC_RELOC_HANDLE                      1
@@ -1083,14 +1083,14 @@ The size of the object block (resource).
         #define RELOC_RELOC_ENTRY_POINT                 3
 
 ----------
-#### OperatorStackElement
+### OperatorStackElement
     typedef struct {
         EvalStackOperatorType OSE_type;
         EvalStackOperatorType OSE_data;
     } OperatorStackElement;
 
 ----------
-#### OperatorType
+### OperatorType
     typedef ByteEnum OperatorType;
         #define OP_RANGE_SEPARATOR                      0
         #define OP_NEGATION                             1
@@ -1119,11 +1119,11 @@ The size of the object block (resource).
 ----------
 
 ----------
-#### optr
+### optr
     typedef dword optr;
 
 ----------
-#### PageLayout
+### PageLayout
     typedef union {
         PageLayoutPaper             PL_paper;
         PageLayoutEnvelope          PL_envelope;
@@ -1131,27 +1131,27 @@ The size of the object block (resource).
     } PageLayout;
 
 ----------
-#### PageLayoutEnvelope
+### PageLayoutEnvelope
     typedef WordFlags PageLayoutEnvelope;
         #define PLE_PATH                0x0040
         #define PLE_ORIENTATION         0x0010
         #define PLE_TYPE                0x0004
 
 ----------
-#### PageLayoutLabel
+### PageLayoutLabel
     typedef WordFlags PageLayoutLabel;
         #define PLL_ROWS            0x7e00          /* labels down */
         #define PLL_COLUMNS         0x01f8          /* labels across */
         #define PLL_TYPE            0x0004          /* PT_LABEL */
 
 ----------
-#### PageLayoutPaper
+### PageLayoutPaper
     typedef WordFlags PageLayoutPaper;
         #define PLP_ORIENTATION         0x0008
         #define PLP_TYPE                0x0004
 
 ----------
-#### PageSize
+### PageSize
     typedef struct {
         word            unused;
         word            PS_width;
@@ -1160,21 +1160,21 @@ The size of the object block (resource).
     } PageSize;
 
 ----------
-#### PageSizeCtrlAttrs
+### PageSizeCtrlAttrs
     typedef WordFlags PageSizeCtrlAttrs;
         #define PZCA_ACT_LIKE_GADGET            0x8000
         #define PZCA_PAPER_SIZE                 0x4000
         #define PZCA_INITIALIZE                 0x2000
 
 ----------
-#### PageSizeCtrlFeatures
+### PageSizeCtrlFeatures
     typedef ByteFlags PageSizeControlFeatures;
         #define PSIZECF_MARGINS             0x04
         #define PSIZECF_ALL                 0x02
         #define PSIZECF_PAGE_TYPE           0x01
 
 ----------
-#### PageSizeReport
+### PageSizeReport
     typedef struct {
         dword               PSR_width;
         dword               PSR_height;
@@ -1183,7 +1183,7 @@ The size of the object block (resource).
     } PageSizeReport:
 
 ----------
-#### PageType
+### PageType
     typedef enum {
         PT_PAPER,
         PT_ENVELOPE,
@@ -1191,13 +1191,13 @@ The size of the object block (resource).
     } PageType;
 
 ----------
-#### PaperOrientation
+### PaperOrientation
     typedef ByteEnum PaperOrientation;
         #define PO_PORTRAIT             0x00
         #define PO_LANDSCAPE            0x01
 
 ----------
-#### ParallelUnit
+### ParallelUnit
     typedef enum
         {
             PARALLEL_LPT1 = 0,
@@ -1207,7 +1207,7 @@ The size of the object block (resource).
         } ParallelUnit;
 
 ----------
-#### ParserFlags
+### ParserFlags
     typedef ByteFlags ParserFlags;
         #define PF_HAS_LOOKAHEAD                0x80
         #define PF_CONTAINS_DISPLAY_FUNC        0x40
@@ -1219,7 +1219,7 @@ The size of the object block (resource).
         #define PF_NEW_NAMES                    0x01
 
 ----------
-#### ParserParameters
+### ParserParameters
     typedef struct {
         CommonParameters    PP_common;
         word                PP_parserBufferSize;
@@ -1233,7 +1233,7 @@ The size of the object block (resource).
     } ParserParameters;
 
 ----------
-#### ParserScannerEvaluatorError
+### ParserScannerEvaluatorError
     typedef ByteEnum ParserScannerEvaluatorError;
         /*
          * Scanner errors
@@ -1297,13 +1297,13 @@ The size of the object block (resource).
     } ParserToken;
 
 ----------
-#### ParserTokenCellData
+### ParserTokenCellData
     typedef struct {
         CellReference           PTCD_cellRef;
     } ParserTokenCellData;
 
 ----------
-#### ParserTokenData
+### ParserTokenData
     typedef union {
         ParserTokenNumberData               PTD_number;
         ParserTokenStringData               PTD_string;
@@ -1314,37 +1314,37 @@ The size of the object block (resource).
     } ParserTokenData;
 
 ----------
-#### ParserTokenFunctionData
+### ParserTokenFunctionData
     typedef struct {
         word        PTFD_functionID;
     } ParserTokenFunctionData;
 
 ----------
-#### ParserTokenNameData
+### ParserTokenNameData
     typedef struct {
         word        PTND_name;
     } ParserTokenNameData;
 
 ----------
-#### ParserTokenNumberData
+### ParserTokenNumberData
     typedef struct {
         FloatNum        PTND_value;
     } ParserTokenNumberData;
 
 ----------
-#### ParserTokenOperatorData
+### ParserTokenOperatorData
     typedef struct {
         OperatorType            PTOD_operatorID;
     } ParserTokenOperatorData;
 
 ----------
-#### ParserTokenStringData
+### ParserTokenStringData
     typedef struct {
         word        PTSD_length;
     } ParserTokenStringData;
 
 ----------
-#### ParserTokenType
+### ParserTokenType
     typedef ByteEnum ParserTokenType;
         #define PARSER_TOKEN_NUMBER                 0
         #define PARSER_TOKEN_STRING                 1
@@ -1359,7 +1359,7 @@ The size of the object block (resource).
         #define PARSER_TOKEN_OPERATOR               10
 
 ----------
-#### PathCombineType
+### PathCombineType
     typedef enum /* word */ {
         PCT_NULL,           /* wipe out old path */
         PCT_REPLACE,        /* replace old path with upcoming path */
@@ -1368,11 +1368,11 @@ The size of the object block (resource).
     } PathCombineType;
 
 ----------
-#### PathName
+### PathName
     typedef char PathName[PATH_BUFFER_SIZE];
 
 ----------
-#### PatternType
+### PatternType
     typedef ByteEnum PatternType;
         #define PT_SOLID                    0
         #define PT_SYSTEM_HATCH             1
@@ -1383,7 +1383,7 @@ The size of the object block (resource).
         #define PT_CUSTOM_BITMAP            6
 
 ----------
-#### PCDocSizeParams
+### PCDocSizeParams
     typedef struct {
         dword   PCDSP_width;
         dword   PCDSP_height;
@@ -1392,7 +1392,7 @@ The size of the object block (resource).
 Use this structure to communicate document sizes to a Print Control.
 
 ----------
-#### PCMarginParams
+### PCMarginParams
     typedef struct {
         word    PCMP_left;          /* left margin */
         word    PCMP_top;           /* top margin */
@@ -1403,7 +1403,7 @@ Use this structure to communicate document sizes to a Print Control.
 This structure holds information about a document's or printer's margins.
 
 ----------
-#### PCProgressType
+### PCProgressType
     typedef enum {
         PCPT_PAGE,
         PCPT_PERCENT,
@@ -1411,28 +1411,28 @@ This structure holds information about a document's or printer's margins.
     } PCProgressType;
 
 ----------
-#### Point
+### Point
     typedef struct {
         sword P_x;
         sword P_y;
     } Point;
 
 ----------
-#### PointDWord
+### PointDWord
     typedef struct {
         sdword PD_x;
         sdword PD_y;
     } PointDWord;
 
 ----------
-#### PointDWFixed
+### PointDWFixed
     typedef struct {
         DWFixed PDF_x;
         DWFixed PDF_y;
     } PointDWFixed;
 
 ----------
-#### PointerDef
+### PointerDef
     typedef struct {
         sbyte   PD_hotX;
         sbyte   PD_hotY;
@@ -1444,7 +1444,7 @@ This structure holds information about a document's or printer's margins.
 This structure defines a mouse pointer.
 
 ----------
-#### PointWWFixed
+### PointWWFixed
     typedef struct {
         WWFixed     PF_x;
         WWFixed     PF_y;
@@ -1455,7 +1455,7 @@ structure to use depends on size of the coordinate space and accuracy
 required.
 
 ----------
-#### PrintControlAttrs
+### PrintControlAttrs
     typedef WordFlags PrintControlAttrs;
         #define PCA_MARK_APP_BUSY       0x2000      /* mark busy while printing */
         #define PCA_VERIFY_PRINT        0x1000      /* verify before printing */
@@ -1472,26 +1472,26 @@ required.
         #define PCA_DEFAULT_QUALITY     0x0002      /* default print quality */
 
 ----------
-#### PrintControlFeatures
+### PrintControlFeatures
         typedef ByteFlags PrintControlFeatures;
         #define PRINTCF_PRINT_TRIGGER   0x02    /* wants a print trigger */
         #define PRINTCF_FAX_TRIGGER     0x01    /* wants a fax trigger */
 
 ----------
-#### PrintControlStatus
+### PrintControlStatus
     typedef enum {
         PCS_PRINT_BOX_VISIBLE,
         PCS_PRINT_BOX_NOT_VISIBLE
     } PrintControlStatus;
 
 ----------
-#### PrintControlToolboxFeatures
+### PrintControlToolboxFeatures
     typedef ByteFlags PrintControlToolboxFeatures;
         #define PRINTCTF_PRINT_TRIGGER  0x02    /* wants a print tool trigger */
         #define PRINTCTF_FAX_TRIGGER    0x01    /* wants a fax tool trigger */
 
 ----------
-#### PrinterDriverType
+### PrinterDriverType
     typedef enum PrinterDriverType;
         PDT_PRINTER,
         PDT_PLOTTER,
@@ -1504,7 +1504,7 @@ This enumerated type indicates the type of printer driver that we are
 dealing with.
 
 ----------
-#### PrinterOutputModes
+### PrinterOutputModes
     typedef ByteFlags PrinterOutputModes;
         #define POM_GRAPHICS_LOW        0x10
         #define POM_GRAPHICS_MEDIUM     0x08
@@ -1516,7 +1516,7 @@ dealing with.
         #define PRINT_TEXT = (POM_TEXT_DRAFT | POM_TEXT_NLQ)
 
 ----------
-#### PrintQualityEnum
+### PrintQualityEnum
     typedef enum {
         PQT_HIGH,
         PQT_MEDIUM,
@@ -1524,7 +1524,7 @@ dealing with.
     } PrintQualityEnum;
 
 ----------
-#### ProtocolNumber
+### ProtocolNumber
     typedef struct {
         word    PN_major;
         word    PN_minor;
@@ -1537,11 +1537,11 @@ they are incompatible. If the minor protocol is different, they may or may not
 be incompatible.
 
 ----------
-#### QueueHandle
+### QueueHandle
     typedef Handle QueueHandle;
 
 ----------
-#### QuickSortParameters
+### QuickSortParameters
     typedef struct _QuickSortParameters {
         word _pascal (*QSP_compareCallback) (void *     el1, 
                                              void *     el2,
@@ -1590,7 +1590,7 @@ If there are fewer than *QSP_medianLimit* elements in a sublist,
 instead of searching for the median element.
 
 ----------
-#### RangeEnumCallbackParams
+### RangeEnumCallbackParams
     typedef struct {
         RangeEnumParams     *RECP_params;
         word                RECP_row;
@@ -1601,7 +1601,7 @@ instead of searching for the median element.
 This structure is passed to the callback routine for **RangeEnum()**.
 
 ----------
-#### RangeEnumFlags
+### RangeEnumFlags
     typedef ByteFlags RangeEnumFlags;
         #define REF_ALL_CELLS                   0x80
         #define REF_NO_LOCK                     0x40
@@ -1615,7 +1615,7 @@ This structure is passed to the callback routine for **RangeEnum()**.
 These flags are used by RangeEnum().
 
 ----------
-#### RangeEnumParams
+### RangeEnumParams
     typedef struct {
         PCB(RANGE_ENUM_CALLBACK_RETURN_TYPE, REP_callback,
                                         (RangeEnumCallbackParams));
@@ -1638,7 +1638,7 @@ The callback routine, if any, should be declared _pascal.
 **Include:** cell.h
 
 ----------
-#### RangeInsertParams
+### RangeInsertParams
     typedef struct {
         Rectangle       RIP_bounds;
         Point           RIP_delta;
@@ -1660,27 +1660,27 @@ don't have to initialize this; the routine will do so automatically.
 **See Also:** RangeInsert()
 
 ----------
-#### RangeSortError
+### RangeSortError
     typedef enum /* word */ {
         RSE_NO_ERROR,
         RSE_UNABLE_TO_ALLOC,
     } RangeSortError;
 
 ----------
-#### RangeSortCellExistFlags
+### RangeSortCellExistFlags
     typedef ByteFlags RangeSortCellExistsFlags;
         #define RSCEF_SECOND_CELL_EXISTS    0x02
         #define RSCEF_FIRST_CELL_EXISTS     0x01
 
 ----------
-#### RangeSortFlags
+### RangeSortFlags
     typedef ByteFlags RangeSortFlags;
         #define RSF_SORT_ROWS               0x80
         #define RSF_SORT_ASCENDING          0x40
         #define RSF_IGNORE_CASE             0x20
 
 ----------
-#### RangeSortParams
+### RangeSortParams
     typedef struct {
         Rectangle       RSP_range;
         Point           RSP_active;
@@ -1695,7 +1695,7 @@ don't have to initialize this; the routine will do so automatically.
     } RangeSortParams;
 
 ----------
-#### Rectangle
+### Rectangle
     typedef struct {
         sword   R_left;
         sword   R_top;
@@ -1706,7 +1706,7 @@ don't have to initialize this; the routine will do so automatically.
 This structure represents a graphics rectangle.
 
 ----------
-#### RectDWord
+### RectDWord
     typedef struct {
         sdword  RD_left;
         sdword  RD_top;
@@ -1717,7 +1717,7 @@ This structure represents a graphics rectangle.
 This structure represents a graphics rectangle.
 
 ----------
-#### RectRegion
+### RectRegion
     typedef struct {
         word    RR_y1M1;
         word    RR_eo1;     /* EOREGREC */
@@ -1729,13 +1729,13 @@ This structure represents a graphics rectangle.
     } RectRegion;
 
 ----------
-#### RefElementHeader
+### RefElementHeader
     typedef struct {
          WordAndAHalf REH_refCount;
     } RefElementHeader;
 
 ----------
-#### Region
+### Region
     typedef word Region;
         #define EOREGREC                0x8000
         #define EOREG_HIGH               0x80
@@ -1770,7 +1770,7 @@ number corresponds to the first column in which the pixel is on; the next
 number is the first subsequent column in which the pixel is off; and so on.
 
 ----------
-#### RegionFillRule
+### RegionFillRule
     typedef ByteEnum RegionFillRule;
         #define ODD_EVEN            0
         #define WINDING             1
@@ -1780,7 +1780,7 @@ Winding fill is more versatile, but requires that the path or polygon's edges
 run in the correct direction.
 
 ----------
-#### ReleaseNumber
+### ReleaseNumber
     typedef struct {
         word    RN_major;
         word    RN_minor;
@@ -1793,13 +1793,13 @@ release level; the most significant numbers are *RN_major* and *RN_minor*. The
 other fields are typically used only internally to a manufacturer.
 
 ----------
-#### ResolveStandardPathFlags
+### ResolveStandardPathFlags
     typedef WordFlags FileResolveStandardPathFlags;
         #define FRSPF_ADD_DRIVE_NAME            0x0002
         #define FRSPF_RETURN_FIRST_DIR          0x0001
 
 ----------
-#### RGBColorAsDWord
+### RGBColorAsDWord
     typedef dword RGBColorAsDWord;
         RGB_RED(val) ( val & 0xff)
         RGB_GREEN(val) ( (val >> 8) & 0xff )
@@ -1809,7 +1809,7 @@ other fields are typically used only internally to a manufacturer.
 See the **ColorQuad** data structure to find out the meanings of the fields.
 
 ----------
-#### RGBDelta
+### RGBDelta
     typedef struct {
         byte    RGBD_red;
         byte    RGBD_green;
@@ -1817,7 +1817,7 @@ See the **ColorQuad** data structure to find out the meanings of the fields.
     } RGBDelta;
 
 ----------
-#### RGBTransfer
+### RGBTransfer
     typedef struct {
         byte    RGBT_red[256];
         byte    RGBT_green[256];
@@ -1825,7 +1825,7 @@ See the **ColorQuad** data structure to find out the meanings of the fields.
     } RGBTransfer;
 
 ----------
-#### RGBValue
+### RGBValue
     typedef struct {
         byte    RGB_red;
         byte    RGB_green;
@@ -1833,14 +1833,14 @@ See the **ColorQuad** data structure to find out the meanings of the fields.
     } RGBValue;
 
 ----------
-#### SampleFormat
+### SampleFormat
     typedef struct {
         DACSampleFormat SMID_format:15;
         DACReferenceByte SMID_reference:1;
     } SampleFormat;
 
 ----------
-#### SampleFormatDescription
+### SampleFormatDescription
     typedef struct {
          word   SFD_manufact;
          word   SFD_format;
@@ -1852,30 +1852,30 @@ This structure acts as a header for a sampled sound, giving format
 information needed to properly interpret the sound data.
 
 ----------
-#### SansFace
+### SansFace
     typedef byte SansFace;
         #define SF_A_CLOSED 0x0080
         #define SF_A_OPEN 0x0000
 
 ----------
-#### sbyte
+### sbyte
     typedef char sbyte;
 
 ----------
-#### ScannerToken
+### ScannerToken
     typedef struct {
         ScannerTokenType                ST_type;
         ScannerTokenData                ST_data;
     } ScannerToken;
 
 ----------
-#### ScannerTokenCellData
+### ScannerTokenCellData
     typedef struct {
         CellReference           STCD_cellRef;
     } ScannerTokenCellData;
 
 ----------
-#### ScannerTokenData
+### ScannerTokenData
     typedef union {
         ScannerTokenNumberData                  STD_number;
         ScannerTokenStringData                  STD_string;
@@ -1885,32 +1885,32 @@ information needed to properly interpret the sound data.
     } ScannerTokenData;
 
 ----------
-#### ScannerTokenIdentifierData
+### ScannerTokenIdentifierData
     typedef struct {
         word        STID_start;
     } ScannerTokenIdentifierData;
 
 ----------
-#### ScannerTokenNumberData
+### ScannerTokenNumberData
     typedef struct {
         FloatNum        STND_value;
     } ScannerTokenNumberData;
 
 ----------
-#### ScannerTokenOperatorData
+### ScannerTokenOperatorData
     typedef struct {
         OperatorType            STOD_operatorID;
     } ScannerTokenOperatorData;
 
 ----------
-#### ScannerTokenStringData
+### ScannerTokenStringData
     typedef struct {
         word    STSD_start;
         word    STSD_length;
     } ScannerTokenStringData;
 
 ----------
-#### ScannerTokenType
+### ScannerTokenType
     typedef ByteEnum ScannerTokenType;
         #define SCANNER_TOKEN_NUMBER                        0
         #define SCANNER_TOKEN_STRING                        1
@@ -1923,7 +1923,7 @@ information needed to properly interpret the sound data.
         #define SCANNER_TOKEN_LIST_SEPARATOR                8
 
 ----------
-#### ScriptAttrAsWord
+### ScriptAttrAsWord
     typedef word ScriptAttrAsWord;
         /*  High byte is a vertical offset, as a fraction of the font size.
             Low byte is a fractional scale to use.
@@ -1934,21 +1934,21 @@ This structure specifies the offset and scale factor with which sub- and
 superscript characters should draw.
 
 ----------
-#### ScriptFace
+### ScriptFace
     typedef byte ScriptFace;
         #define SF_CURSIVE 0x0080
         #define SF_CALLIGRAPHIC 0x0000
 
 ----------
-#### sdword
+### sdword
     typedef long sdword;
 
 ----------
-#### segment
+### segment
     typedef word segment;
 
 ----------
-#### SemaphoreError
+### SemaphoreError
     typedef enum {
         SE_NO_ERROR,            /* No error occurred */
         SE_TIMEOUT,             /* The semaphore timed out before
@@ -1961,7 +1961,7 @@ Determines the error encountered by semaphore and threadlock routines
 such as **ThreadPSem()** and **ThreadPTimedSem()**.
 
 ----------
-#### SerialBaud
+### SerialBaud
     typedef enum
         {
             SERIAL_BAUD_115200          = 1,
@@ -1982,7 +1982,7 @@ such as **ThreadPSem()** and **ThreadPTimedSem()**.
         } SerialBaud;
 
 ----------
-#### SerialFormat
+### SerialFormat
     typedef ByteFlags SerialFormat;
         #define SERIAL_FORMAT_DLAB_OFFSET       (7)
         #define SERIAL_FORMAT_DLAB              (0x01 << SERIAL_FORMAT_DLAB_OFFSET)
@@ -2001,7 +2001,7 @@ such as **ThreadPSem()** and **ThreadPTimedSem()**.
         #define SERIAL_FORMAT_LENGTH            (0x03 << SERIAL_FORMAT_LENGTH_OFFSET)
 
 ----------
-#### SerialMode
+### SerialMode
     typedef enum {
             SERIAL_MODE_RAW,
             SERIAL_MODE_RARE,
@@ -2009,7 +2009,7 @@ such as **ThreadPSem()** and **ThreadPTimedSem()**.
     } SerialMode;
 
 ----------
-#### SerialModem
+### SerialModem
     typedef ByteFlags SerialModem;
         #define SERIAL_MODEM_OUT2_OFFSET    (3)
         #define SERIAL_MODEM_OUT2           (0x01 << SERIAL_MODEM_OUT2_OFFSET)
@@ -2024,7 +2024,7 @@ such as **ThreadPSem()** and **ThreadPTimedSem()**.
         #define SERIAL_MODEM_DTR            (0x01 << SERIAL_MODEM_DTR_OFFSET)
 
 ----------
-#### SerialPortNum
+### SerialPortNum
     typedef enum
         {
             SERIAL_COM1         = 0,
@@ -2038,7 +2038,7 @@ such as **ThreadPSem()** and **ThreadPTimedSem()**.
         } SerialPortNum;
 
 ----------
-#### SerialUnit
+### SerialUnit
     typedef enum
         {
             SERIAL_COM1         = 0,
@@ -2052,11 +2052,11 @@ such as **ThreadPSem()** and **ThreadPTimedSem()**.
         } SerialUnit;
 
 ----------
-#### SemaphoreHandle
+### SemaphoreHandle
     typedef Handle SemaphoreHandle;
 
 ----------
-#### SerifFace
+### SerifFace
     typedef byte SerifFace;
         #define SF_SLAB     0x00c0
         #define SF_MODERN   0x0080
@@ -2064,13 +2064,13 @@ such as **ThreadPSem()** and **ThreadPTimedSem()**.
         #define SF_OLD      0x0000
 
 ----------
-#### SetPalType
+### SetPalType
     typedef ByteEnum SetPalType;
         #define SPT_DEFAULT             0
         #define SPT_CUSTOM              1
 
 ----------
-#### ShiftState
+### ShiftState
     typedef ByteFlags ShiftState;
         #define SS_LALT                 0x80
         #define SS_RALT                 0x40
@@ -2087,7 +2087,7 @@ bits will only be set if not already accounted for; that is, if you are passed t
 character "E", the shift modifiers of this structure will not be marked.
 
 ----------
-#### SoundDriverCapability
+### SoundDriverCapability
     typedef WordFlags SoundDriverCapability;
         #define SDC_NOISE               0x8000
         #define SDC_WAVEFORM            0x6000
@@ -2118,12 +2118,12 @@ These fields encode information about what the sound driver is capable of in
 terms of music synthesis.
 
 ----------
-#### SoundPlayFlags
+### SoundPlayFlags
     typedef WordFlags SoundPlayFlags;
         #define SPF_HIGH_PRIORITY               0x8000
 
 ----------
-#### SoundPriority
+### SoundPriority
     typedef enum {
          SP_SYSTEM_LEVEL=10,        /* most urgent */
          SP_ALARM=20,
@@ -2143,7 +2143,7 @@ The highest priority sound you may construct using these values is
 (SP_BACKGROUND + SP_THEME).
 
 ----------
-#### SoundSteamDeltaTimeType
+### SoundSteamDeltaTimeType
     typedef enum {
          SSDTT_MSEC=8,                  /* wait for N mili seconds */
          SSDTT_TICKS=10,                /* wait for N ticks */
@@ -2159,7 +2159,7 @@ milliseconds, timer "ticks" (each 1/60 second), or by means of an
 independently supplied tempo.
 
 ----------
-#### SoundStreamEvents
+### SoundStreamEvents
     typedef enum {
          SSE_VOICE_ON=0,            /* turn on voice event */
          SSE_VOICE_OFF=2,           /* turn off voice event */
@@ -2190,7 +2190,7 @@ independently supplied tempo.
 These are the "events" that make up a music buffer. 
 
 ----------
-#### SoundStreamSize
+### SoundStreamSize
     typedef word SoundStreamSize;
         #define SSS_ONE_SHOT 128    /* 128 bytes (very small) */
         #define SSS_SMALL 256       /* 256 bytes */
@@ -2198,14 +2198,14 @@ These are the "events" that make up a music buffer.
         #define SSS_LARGE 1024 
 
 ----------
-#### SoundStreamType
+### SoundStreamType
     #define SST_ONE_SHOT        128
     #define SST_SMALL           256
     #define SST_MEDIUM          512
     #define SST_LARGE           1024
 
 ----------
-#### SpecialFunctions
+### SpecialFunctions
     typedef enum /* word */ {
         SF_FILENAME,
         SF_PAGE,
@@ -2213,7 +2213,7 @@ These are the "events" that make up a music buffer.
     } SpecialFunctions;
 
 ----------
-#### SpoolError
+### SpoolError
     typedef enum /* word */ {
         SERROR_NO_SPOOL_FILE,
         SERROR_NO_PRINT_DRIVER,
@@ -2233,7 +2233,7 @@ These are the "events" that make up a music buffer.
     } SpoolError;
 
 ----------
-#### SpoolFileName
+### SpoolFileName
     typedef struct {
         char    SFN_base[5];
         char    SFN_num[3];
@@ -2241,14 +2241,14 @@ These are the "events" that make up a music buffer.
     } SpoolFileName;
 
 ----------
-#### SpoolInfoType
+### SpoolInfoType
     typedef enum /* word */ {
         SIT_JOB_INFO,
         SIT_QUEUE_INFO
     } SpoolInfoType;
 
 ----------
-#### SpoolOpStatus
+### SpoolOpStatus
     typedef enum /* word */ {
         SPOOL_OPERATION_SUCCESSFUL,
         SPOOL_JOB_NOT_FOUND,
@@ -2260,7 +2260,7 @@ These are the "events" that make up a music buffer.
     } SpoolOpStatus;
 
 ----------
-#### SpoolTimeStruct
+### SpoolTimeStruct
     typedef struct {
         byte    STS_second;         /* second of the minute (0-59) */
         byte    STS_minute;         /* minute of the hour (0-59) */
@@ -2268,7 +2268,7 @@ These are the "events" that make up a music buffer.
     } SpoolTimeStruct;
 
 ----------
-#### SpoolVerifyAction
+### SpoolVerifyAction
     typedef enum {
         SVA_NO_MESSAGE,
         SVA_WARNING,
@@ -2276,7 +2276,7 @@ These are the "events" that make up a music buffer.
     } SpoolVerifyAction;
 
 ----------
-#### StandardDialogBoxType
+### StandardDialogBoxType
     typedef enum {
         SDBT_FILE_NEW_CANNOT_CREATE_TEMP_NAME,
         SDBT_FILE_NEW_INSUFFICIENT_DISK_SPACE,
@@ -2313,7 +2313,7 @@ These are the "events" that make up a music buffer.
     } StandardDialogBoxType;
 
 ----------
-#### StandardDialogParams
+### StandardDialogParams
     typedef struct {
         word                                 SDP_customFlags;
         char                                *SDP_customString;
@@ -2323,7 +2323,7 @@ These are the "events" that make up a music buffer.
     } StandardDialogParams;
 
 ----------
-#### StandardDialogOptrParams
+### StandardDialogOptrParams
     typedef struct {
         word    SDOP_customFlags;
         optr    SDOP_customString;
@@ -2333,21 +2333,21 @@ These are the "events" that make up a music buffer.
     } StandardDialogOptrParams;
 
 ----------
-#### StandardDialogResponseTriggerEntry
+### StandardDialogResponseTriggerEntry
     typedef struct {
         optr    SDRTE_moniker;
         word    SDRTE_responseValue;
     } StandardDialogResponseTriggerEntry;
 
 ----------
-#### StandardDialog1ResponseTriggerTable
+### StandardDialog1ResponseTriggerTable
     typedef struct {
          word                                   SD1RTT_numTriggers;
          StandardDialogResponseTriggerEntry     SD1RTT_trigger1;
     } StandardDialog1ResponseTriggerTable;
 
 ----------
-#### StandardDialog2ResponseTriggerTable
+### StandardDialog2ResponseTriggerTable
     typedef struct {
          word                                   SD2RTT_numTriggers;
          StandardDialogResponseTriggerEntry     SD2RTT_trigger1;
@@ -2355,7 +2355,7 @@ These are the "events" that make up a music buffer.
     } StandardDialog2ResponseTriggerTable;
 
 ----------
-#### StandardDialog3ResponseTriggerTable
+### StandardDialog3ResponseTriggerTable
     typedef struct {
          word                                   SD3RTT_numTriggers;
          StandardDialogResponseTriggerEntry     SD3RTT_trigger1;
@@ -2364,7 +2364,7 @@ These are the "events" that make up a music buffer.
     } StandardDialog3ResponseTriggerTable;
 
 ----------
-#### StandardDialog4ResponseTriggerTable
+### StandardDialog4ResponseTriggerTable
     typedef struct {
          word                                   SD4RTT_numTriggers;
          StandardDialogResponseTriggerEntry     SD4RTT_trigger1;
@@ -2374,7 +2374,7 @@ These are the "events" that make up a music buffer.
     } StandardDialog4ResponseTriggerTable;
 
 ----------
-#### StandardPath
+### StandardPath
     typedef enum /* word */ {
         SP_NOT_STANDARD_PATH=0,
         SP_TOP=1,
@@ -2416,7 +2416,7 @@ applications may not make any assumption about how the standard paths
 are arranged.
 
 ----------
-#### StandardSoundType
+### StandardSoundType
     typedef enum /* word */ {
         SST_ERROR,                  /* Sound produced when an Error box comes up. */
         SST_WARNING,                /* General warning beep sound */
@@ -2433,14 +2433,14 @@ are arranged.
     } StandardSoundType;
 
 ----------
-#### StreamBlocker
+### StreamBlocker
     typedef enum{
             STREAM_BLOCK            = 2,
             STREAM_NO_BLOCK         = 0
     } StreamBlocker;
 
 ----------
-#### StreamError
+### StreamError
     typedef enum{
             STREAM_WOULD_BLOCK,
             STREAM_CLOSING,
@@ -2451,18 +2451,18 @@ are arranged.
     } StreamError;
 
 ----------
-#### StreamOpenFlags
+### StreamOpenFlags
     typedef enum {
             STREAM_OPEN_NO_BLOCK                = 0x01,
             STREAM_OPEN_TIMEOUT             = 0x02
     } StreamOpenFlags
 
 ----------
-#### StreamToken
+### StreamToken
     typedef Handleword StreamToken;
 
 ----------
-#### StreamRoles
+### StreamRoles
     typedef enum {
             STREAM_ROLES_WRITER             = 0,
             STREAM_ROLES_READER             = -1,
@@ -2470,7 +2470,7 @@ are arranged.
     } StreamRoles;
 
 ----------
-#### StyleChunkDesc
+### StyleChunkDesc
     typedef struct {
         VMFileHandle        SCD_vmFile;
         word                SCD_vmBlockOrMemHandle;
@@ -2478,12 +2478,12 @@ are arranged.
     } StyleChunkDesc;
 
 ----------
-#### StyleElementFlags
+### StyleElementFlags
     typedef WordFlags StyleElementFlags;
         #define SEF_DISPLAY_IN_TOOLBOX                      0x8000
 
 ----------
-#### StyleElementHeader
+### StyleElementHeader
     typedef struct {
         NameArrayElement        SEH_meta;
         word                    SEH_baseStyle;
@@ -2492,14 +2492,14 @@ are arranged.
     } StyleElementHeader;
 
 ----------
-#### StyleSheetElementHeader
+### StyleSheetElementHeader
     typedef struct {
          RefElementHeader           SSEH_meta;
          word                       SSEH_style;
     } StyleSheetElementHeader;
 
 ----------
-#### SupportedEnvelopeFormat
+### SupportedEnvelopeFormat
     typedef enum {
          SEF_NO_FORMAT,
          SEF_SBI_FORMAT,
@@ -2510,11 +2510,11 @@ These values specify how a sound device can simulate musical instruments,
 if it can at all.
 
 ----------
-#### sword
+### sword
     typedef signed short sword;
 
 ----------
-#### SysConfigFlags
+### SysConfigFlags
     typedef ByteFlags SysConfigFlags;
         #define SCF_UNDER_SWAT          0x80
         #define SCF_2ND_IC              0x40
@@ -2530,17 +2530,17 @@ may be set at a time; if a flag is set, the description is true. These flags are
 used by the kernel and can be retrieved with **SysGetConfig()**.
 
 ----------
-#### SysDrawMask
+### SysDrawMask
     typedef ByteFlags SysDrawMask;
         #define SDM_INVERSE             0x80
         #define SDM_MASK                0x7f
 
 ----------
-#### SysGetInfoType
+### SysGetInfoType
 **See:** SysGetInfo().
 
 ----------
-#### SysMachineType
+### SysMachineType
     typedef ByteEnum SysMachineType;
         #define SMT_UNKNOWN             0
         #define SMT_PC                  1
@@ -2559,11 +2559,11 @@ A byte-sized value indicating the type of machine running GEOS. This value
 can be retrieved with **SysGetConfig()**.
 
 ----------
-#### SysNotifyFlags
+### SysNotifyFlags
 **See:** SysNotify().
 
 ----------
-#### SysProcessorType
+### SysProcessorType
     typedef ByteEnum SysProcessorType;
         #define SPT_8088                0
         #define SPT_8086                0
@@ -2576,11 +2576,11 @@ This enumerated type is a byte that indicates the type of processor on the
 system running GEOS. It can be retrieved with **SysGetConfig()**.
 
 ----------
-#### SysShutdownType
+### SysShutdownType
 **See:** SysShutdown().
 
 ----------
-#### SysStats
+### SysStats
     typedef struct {
         dword           SS_idleCount;       /* Idle ticks in the last second. */
         SysSwapInfo     SS_swapOuts;        /* Outward-bound swap activity. */
@@ -2595,7 +2595,7 @@ This structure is returned by **SysStatistics()** and represents the current
 performance statistics of GEOS.
 
 ----------
-#### SysSwapInfo
+### SysSwapInfo
     typedef struct {
         word    SSI_paragraphs;     /* Number of paragraphs swapped. */
         word    SSI_blocks;         /* Number of blocks swapped. */
@@ -2604,7 +2604,7 @@ performance statistics of GEOS.
 Structure used to represent current swap activity in **SysStats** structure.
 
 ----------
-#### SystemDrawMask
+### SystemDrawMask
     typedef ByteEnum SystemDrawMask;
         #define SDM_TILE                0
         #define SDM_SHADED_BAR          1
@@ -2629,7 +2629,7 @@ Structure used to represent current swap activity in **SysStats** structure.
         #define SET_CUSTOM_PATTERN      SDM_CUSTOM
 
 ----------
-#### SystemHatch
+### SystemHatch
     typedef ByteEnum SystemHatch;
         #define SH_VERTICAL             0
         #define SH_HORIZONTAL           1
@@ -2639,7 +2639,7 @@ Structure used to represent current swap activity in **SysStats** structure.
         #define SH_SLANTED_BRICK        5
 
 ----------
-#### TargetLevel
+### TargetLevel
     typedef enum /* word */ {
         TL_TARGET                   = 0,
         TL_CONTENT,
@@ -2656,14 +2656,14 @@ Structure used to represent current swap activity in **SysStats** structure.
     } TargetLevel;
 
 ----------
-#### TestRectReturnType
+### TestRectReturnType
     typedef ByteEnum TestRectReturnType;
         #define TRRT_OUT            0
         #define TRRT_PARTIAL        1
         #define TRRT_IN             2
 
 ----------
-#### TextAttr
+### TextAttr
     typedef struct {
         byte                TA_colorFlag;
         RGBValue            TA_color;
@@ -2680,7 +2680,7 @@ Structure used to represent current swap activity in **SysStats** structure.
     } TextAttr;
 
 ----------
-#### TextMode
+### TextMode
     typedef ByteFlags TextMode;
         #define TM_TRACK_KERN                       0x40
         #define TM_PAIR_KERN                        0x20
@@ -2691,7 +2691,7 @@ Structure used to represent current swap activity in **SysStats** structure.
         #define TM_DRAW_OPTIONAL_HYPHENS            0x01
 
 ----------
-#### TextStyle
+### TextStyle
     typedef ByteFlags TextStyle;
         #define TS_OUTLINE                  0x40
         #define TS_BOLD                     0x20
@@ -2702,7 +2702,7 @@ Structure used to represent current swap activity in **SysStats** structure.
         #define TS_UNDERLINE                0x01
 
 ----------
-#### ThreadException
+### ThreadException
     typedef enum {
         TE_DIVIDE_BY_ZERO=0,
         TE_OVERFLOW=4,
@@ -2716,7 +2716,7 @@ Processor exceptions used primarily for debugging, these are used with
 **ThreadHandleException()**.
 
 ----------
-#### ThreadGetInfoType
+### ThreadGetInfoType
     typedef enum {
         TGIT_PRIORITY_AND_USAGE,    /* high byte is thread's recent CPU usage
                                      * low byte is thread's base priority */
@@ -2730,15 +2730,15 @@ TGI_RECENT_CPU_USAGE to separate the TGIT_PRIORITY_AND_USAGE
 value into its components.
 
 ----------
-#### ThreadHandle
+### ThreadHandle
     typedef Handle ThreadHandle;
 
 ----------
-#### ThreadLockHandle
+### ThreadLockHandle
     typedef Handle ThreadLockHandle;
 
 ----------
-#### ThreadModifyFlags
+### ThreadModifyFlags
     typedef ByteFlags ThreadModifyFlags;
         #define TMF_BASE_PRIO               0x80
         #define TMF_ZERO_USAGE              0x40
@@ -2747,14 +2747,14 @@ Used with **ThreadModify()**, these flags determine what aspect of the thread
 is modified.
 
 ----------
-#### TimerCompressedDate
+### TimerCompressedDate
     typedef WordFlags TimerCompressedDate;
         #define TCD_YEAR        0xfe00  /* years since 1980; e.g. 1988 is `8' */
         #define TCD_MONTH       0x01e0  /* months (1 - 12) (0 illegal) */
         #define TCD_DAY         0x001f  /* days (1-31) (0 illegal) */
 
 ----------
-#### TimerDateAndTime
+### TimerDateAndTime
     typedef struct {
         word            TDAT_year;      /* Year based on 1980. (10 => 1990) */
         word            TDAT_month;     /* Number of month (1 through 12) */
@@ -2768,15 +2768,15 @@ is modified.
 This structure is used to keep track of the current time and date.
 
 ----------
-#### TimerHandle
+### TimerHandle
     typedef Handle TimerHandle;
 
 ----------
-#### TimerType
+### TimerType
 **See:** TimerStart().
 
 ----------
-#### ToggleState
+### ToggleState
     typedef ByteFlags ToggleState;
         #define TS_CAPSLOCK             0x80
         #define TS_NUMLOCK              0x40
@@ -2787,15 +2787,15 @@ input is interpreted. These toggles correspond to the caps lock, num lock, and
 scroll lock keys.
 
 ----------
-#### TokenChars
+### TokenChars
     typedef char TokenChars[TOKEN_CHARS_LENGTH]; /* TOKEN_CHARS_LENGTH=4 */
 
 ----------
-#### TokenDBItem
+### TokenDBItem
     typedef DBGroupAndItem TokenDBItem;
 
 ----------
-#### TokenEntry
+### TokenEntry
     typedef struct {
         GeodeToken      TE_token;       /* A GeodeToken structure for this file */
         TokenDBItem     TE_monikerList; /* A list of monikers for this token */
@@ -2810,7 +2810,7 @@ identifies the structures and other information of each token. The
 chunks of the token.
 
 ----------
-#### TokenFlags
+### TokenFlags
     typedef WordFlags TokenFlags;
         #define TF_NEED_RELOCATION              0x8000
 
@@ -2819,7 +2819,7 @@ token has fields which must be relocated when the token is loaded or
 unloaded.
 
 ----------
-#### TokenGroupEntry
+### TokenGroupEntry
     typedef struct {
         TokenIndexType  TGE_type;           /* The type of structure this is. */
         GroupType       TGE_groupType;      /* The type of the group item. */
@@ -2830,7 +2830,7 @@ unloaded.
 Used to index token groups in the token database.
 
 ----------
-#### TokenGroupType
+### TokenGroupType
     typedef enum {
         TGT_MAP_GROUP,              /* The TokenGroupEntry is a map group. */
         TGT_MONIKER_LIST_GROUP,     /* The TokenGroupEntry is a moniker list group. */
@@ -2845,7 +2845,7 @@ This enumerated type describes which type of moniker group is stored in the
 particular chunk.
 
 ----------
-#### TokenIndexType
+### TokenIndexType
     typedef enum {
         TIT_TOKEN_ENTRY,        /* The type is a TokenEntry structure. */
         TIT_GROUP_ENTRY,        /* The type is a GroupEntry structure. */
@@ -2855,7 +2855,7 @@ Used to indicate the types of structures that may be stored in the token
 database's map item.
 
 ----------
-#### TokenMonikerInfo
+### TokenMonikerInfo
     typedef struct {
         TokenDBItem TMI_moniker;
         word        TMI_fileFlag;   /* 0 if token is in shared token DB file; 
@@ -2863,14 +2863,14 @@ database's map item.
     } TokenMonikerInfo;
 
 ----------
-#### TokenRangeFlags
+### TokenRangeFlags
     typedef WordFlags TokenRangeFlags;
         #define TRF_ONLY_GSTRING            0x8000
         #define TRF_ONLY_PASSED_MANUFID     0x4000
         #define TRF_UNUSED                  0x3fff
 
 ----------
-#### TransError
+### TransError
     typedef enum {
          TE_NO_ERROR, /* No error */
          TE_ERROR, /* General error */
@@ -2895,7 +2895,7 @@ This enumerated type contains error values the impex library may wish to
 generate when translating.
 
 ----------
-#### TransErrorInfo
+### TransErrorInfo
     typedef struct {
          TransError     transError; 
          /* NOTE: customMsgHandle will be valid only if transError is TE_CUSTOM. */  
@@ -2903,14 +2903,14 @@ generate when translating.
     } TransErrorInfo; 
 
 ----------
-#### TransferBlockID
+### TransferBlockID
     typedef dword TransferBlockID;
         #define BlockIDFromFileAndBlock(f,b)    (((dword)(f) << 16) | (b))
         #define FileFromTransferBlockID(id)     ((VMFileHandle) ((id) >> 16))
         #define BlockFromTransferBlockID(id)    ((VMBlockHandle) (id))
 
 ----------
-#### TransMatrix
+### TransMatrix
     typedef struct {
         WWFixed         TM_e11;
         WWFixed         TM_e12;
@@ -2923,7 +2923,7 @@ generate when translating.
 The six variable elements of a coordinate transformation matrix.
 
 ----------
-#### TravelOption
+### TravelOption
     typedef enum {
          TO_NULL,
          TO_SELF,
@@ -2953,12 +2953,12 @@ that the values set up in the **TravelOption**, **VisTravelOption**, and
 **GenTravelOption** have been set up as discrete values.
 
 ----------
-#### TRUE
+### TRUE
     #define TRUE        -1  /* use as return value, not for comparisons */
     #define FALSE        0
 
 ----------
-#### UIFunctionsActive
+### UIFunctionsActive
     typedef ByteFlags UIFunctionsActive;
         #define UIFA_SELECT             0x80
         #define UIFA_MOVE_COPY          0x40
@@ -2979,7 +2979,7 @@ These flags describe the context of the user's input, providing some modal
 information. 
 
 ----------
-#### UIInterfaceLevel
+### UIInterfaceLevel
     typedef enum /* word */ {
         UIIL_NOVICE,
         UIIL_BEGINNING_INTERMEDIATE,
@@ -2989,21 +2989,21 @@ information.
     } UIInterfaceLevel;
 
 ----------
-#### UndoActionDataFlags
+### UndoActionDataFlags
     typedef struct {
         dword       UADF_flags;
         word        UADF_extraflags;
     } UndoActionDataFlags;
 
 ----------
-#### UndoActionDataPtr
+### UndoActionDataPtr
     typedef struct {
         void        *UADP_ptr;
         word        UADP_size;
     } UndoActionDataPtr;
 
 ----------
-#### UndoActionDataType
+### UndoActionDataType
     typedef enum /* word */ {
         UADT_FLAGS,
         UADT_PTR,
@@ -3011,7 +3011,7 @@ information.
     } UndoActionDataType;
 
 ----------
-#### UndoActionDataUnion
+### UndoActionDataUnion
     typedef union {
         /* To find out the type of data stored in this
          * union, check the value of the UndoActionStruct's
@@ -3023,7 +3023,7 @@ information.
     #define NULL_UNDO_CONTEXT 0
 
 ----------
-#### UndoActionDataVMChain
+### UndoActionDataVMChain
     typedef struct {
         /* This structure is filled in by the code for
          * MSG_META_UNDO. VMChains passed to 
@@ -3035,7 +3035,7 @@ information.
     } UndoActionDataVMChain;
 
 ----------
-#### UndoActionStruct
+### UndoActionStruct
     typedef struct {
         UndoActionDataType          UAS_dataType;
         UndoActionDataUnion         UAS_data;
@@ -3043,20 +3043,20 @@ information.
     } UndoActionStruct;
 
 ----------
-#### UtilAsciiToHexError
+### UtilAsciiToHexError
     typedef enum /* word */ {
         UATH_NON_NUMERIC_DIGIT_IN_STRING,
         UATH_CONVERT_OVERFLOW,
     } UtilAsciiToHexError;
 
 ----------
-#### UtilHexToAsciiFlags
+### UtilHexToAsciiFlags
     typedef WordFlags UtilHexToAsciiFlags;
         #define UHTAF_INCLUDE_LEADING_ZEROS     0x0002
         #define UHTAF_NULL_TERMINATE            0x0001
 
 ----------
-#### VarDataCHandler
+### VarDataCHandler
     typedef struct {
         word    VDCH_dataType;
         void    (*VDCH_handler) (MemHandle mh, ChunkHandle ch,
@@ -3069,7 +3069,7 @@ which acts as the entry's index in the handler table. The second field is a far
 pointer to the handler routine.
 
 ----------
-#### VarDataEntry
+### VarDataEntry
     typedef struct {
         word    VDE_dataType;   /* vardata data type */
         word    VDE_entrySize;  /* size of extra data; this field only exists
@@ -3082,7 +3082,7 @@ will be no *VDE_entrySize* field. The extra data begins at offset
 *VDE_extraData*, defined above.
 
 ----------
-#### VarDataFlags
+### VarDataFlags
     typedef WordFlags VarDataFlags;
         #define VDF_TYPE            0xfffc  /* 14-bit data type */
         #define VDF_EXTRA_DATA      0x0002  /* set if has extra data */
@@ -3092,18 +3092,18 @@ This is a word record containing three fields. This word is stored in the
 vardata structure's VDE_dataType field (see VarDataEntry, above).
 
 ----------
-#### VarDataKey
+### VarDataKey
     typedef word VardataKey;
 
 ----------
-#### VarObjRelocation
+### VarObjRelocation
     typedef struct {
         VarDataFlags    VOR_type;       /* type and tag */
         word            VOR_offset;
     } VarObjRelocation;
 
 ----------
-#### VChar
+### VChar
     typedef ByteEnum VChar;
         #define VC_NULL                 0x0 /* NULL */
         #define VC_CTRL_A               0x1 /* <ctrl>-A */
@@ -3226,7 +3226,7 @@ vardata structure's VDE_dataType field (see VarDataEntry, above).
         #define VC_ENTER                VC_CTRL_M
 
 ----------
-#### VisRulerType
+### VisRulerType
     typedef ByteEnum VisRulerType;
         #define VRT_INCHES              0
         #define VRT_CENTIMETERS         1
@@ -3237,7 +3237,7 @@ vardata structure's VDE_dataType field (see VarDataEntry, above).
         #define VRT_DEFAULT             SYSTEM_DEFAULT
 
 ----------
-#### VisTextVariableType
+### VisTextVariableType
     typedef enum {
          VTVT_PAGE_NUMBER,
          VTVT_PAGE_NUMBER_IN_SECTION,
@@ -3252,13 +3252,13 @@ vardata structure's VDE_dataType field (see VarDataEntry, above).
     } VisTextVariableType;
 
 ----------
-#### VisTravelOption
+### VisTravelOption
 The **VisClass** defines an enumerated value to be used in the place of a 
 standard **TravelOption**. See the entry for **TravelOption** to see all possible 
 values.
 
 ----------
-#### VisUpdateMode
+### VisUpdateMode
     typedef ByteEnum VisUpdateMode;
         #define VUM_MANUAL                          0
         #define VUM_NOW                             1
@@ -3266,7 +3266,7 @@ values.
         #define VUM_DELAYED_VIA_APP_QUEUE           3
 
 ----------
-#### VMAccessFlags
+### VMAccessFlags
     typedef ByteFlags VMAccessFlags;
         #define VMAF_FORCE_READ_ONLY                            0x80
         #define VMAF_FORCE_READ_WRITE                           0x40
@@ -3276,7 +3276,7 @@ values.
         #define VMAF_USE_BLOCK_LEVEL_SYNCHRONIZATION            0x04
 
 ----------
-#### VMAttributes
+### VMAttributes
     typedef ByteFlags VMAttributes;
         #define VMA_SYNC_UPDATE                     0x80
         #define VMA_BACKUP                          0x40
@@ -3293,21 +3293,21 @@ values.
                                      VMA_SINGLE_THREAD_ACCESS)
 
 ----------
-#### VMBlockHandle
+### VMBlockHandle
     typedef word VMBlockHandle;
 
 ----------
-#### VMChain
+### VMChain
     typedef dword VMChain;
 
 ----------
-#### VMChainLink
+### VMChainLink
     typedef struct {
         VMBlockHandle           VMC_next;
     } VMChainLink;
 
 ----------
-#### VMChainTree
+### VMChainTree
     typedef struct {
         VMChainLink     VMCT_meta;
         word            VMCT_offset;
@@ -3315,11 +3315,11 @@ values.
     } VMChainTree;
 
 ----------
-#### VMFileHandle
+### VMFileHandle
     typedef Handle VMFileHandle;
 
 ----------
-#### VMInfoStruct
+### VMInfoStruct
     typedef struct {
         MemHandle       mh;
         word            size;
@@ -3327,7 +3327,7 @@ values.
     } VMInfoStruct;
 
 ----------
-#### VMOpenType
+### VMOpenType
     typedef ByteEnum VMOpenType;
         #define VMO_OPEN                        0
         #define VMO_TEMP_FILE                   1
@@ -3337,7 +3337,7 @@ values.
         #define VMO_NATIVE_WITH_EXT_ATTRS       0x80
 
 ----------
-#### VMOperation
+### VMOperation
     typedef enum {
         VMO_READ,
         VMO_INTERNAL,
@@ -3349,7 +3349,7 @@ values.
     } VMOperation;
 
 ----------
-#### VMRelocType
+### VMRelocType
     typedef enum {
         VMRT_UNRELOCATE_BEFORE_WRITE,
         VMRT_RELOCATE_AFTER_READ,
@@ -3359,7 +3359,7 @@ values.
     } VMRelocType;
 
 ----------
-#### VMStartExclusiveReturnValue
+### VMStartExclusiveReturnValue
     typedef enum {
          VMSERV_NO_CHANGES,
          VMSERV_CHANGES,
@@ -3383,26 +3383,26 @@ This call to **VMGrabExclusive()** failed and timed out without
 getting access to the file.
 
 ----------
-#### VolumeName
+### VolumeName
     typedef char VolumeName[VOLUME_BUFFER_SIZE];
 
 ----------
-#### WBFixed
+### WBFixed
     typedef struct {
         byte    WBF_frac;
         word    WBF_int;
     } WBFixed;
 
 ----------
-#### wchar
+### wchar
     typedef unsigned int wchar;
 
 ----------
-#### WindowHandle
+### WindowHandle
     typedef Handle WindowHandle;
 
 ----------
-#### WinInfoType
+### WinInfoType
     typedef enum /* word */ {
         WIT_PRIVATE_DATA =0,
         WIT_COLOR =2,
@@ -3420,13 +3420,13 @@ getting access to the file.
     } WinInfoType;
 
 ----------
-#### WinInvalFlag
+### WinInvalFlag
     typedef ByteEnum WinInvalFlag;
         #define WIF_INVALIDATE                  0
         #define WIF_DONT_INVALIDATE             1
 
 ----------
-#### WinPassFlags
+### WinPassFlags
     typedef WordFlags WinPassFlags;
         #define WPF_CREATE_GSTATE               0x8000
         #define WPF_ROOT                        0x4000
@@ -3439,7 +3439,7 @@ getting access to the file.
         #define WPF_PRIORITY                    0x00ff
 
 ----------
-#### WinPriority
+### WinPriority
     typedef ByteEnum WinPriority;
         #define WIN_PRIO_POPUP                   4
         #define WIN_PRIO_MODAL                   6
@@ -3449,33 +3449,33 @@ getting access to the file.
         #define WIN_PRIO_ON_BOTTOM              14
 
 ----------
-#### word
+### word
     typedef unsigned int word;
 
 ----------
-#### WordAndAHalf
+### WordAndAHalf
     typedef struct {
         word    WAAH_low;
         byte    WAAH_high;
     } WordAndAHalf;
 
 ----------
-#### WordFlags
+### WordFlags
     typedef word WordFlags;
 
 ----------
-#### WWFixed
+### WWFixed
     typedef struct {
         word    WWF_frac;
         word    WWF_int;
     } WWFixed;
 
 ----------
-#### WWFixedAsDWord
+### WWFixedAsDWord
     typedef dword WWFixedAsDWord
 
 ----------
-#### XYOffset
+### XYOffset
     typedef struct {
         sword   XYO_x;
         sword   XYO_y;
@@ -3484,7 +3484,7 @@ getting access to the file.
 A graphics coordinate offset.
 
 ----------
-#### XYSize
+### XYSize
     typedef struct {
         word    XYS_width;
         word    XYS_height;
@@ -3493,7 +3493,7 @@ A graphics coordinate offset.
 A graphics size, in two dimensions.
 
 ----------
-#### XYValueAsDWord
+### XYValueAsDWord
     typedef dword XYValueAsDWord;
 
 A graphics size, in two dimensions, expressed as a DWord.

--- a/TechDocs/Markdown/Tools/tconfig.md
+++ b/TechDocs/Markdown/Tools/tconfig.md
@@ -1,8 +1,8 @@
-## 2 System Configuration
+# 2 System Configuration
 
 This chapter details how your software layout should look after installation. This information is provided both so that you can confirm your setup and so that you can make appropriate modifications later.
 
-### 2.1 Development Directories and Files
+## 2.1 Development Directories and Files
 
 The installation program will install a large number of tool files, debugging files, and sample applications on to the development machine. These are arranged in the directory of your choice (with name specified in the ROOT_DIR environment variable). Most developers will use \PCGEOS as the root directory of their development tree, and this is the name assumed throughout this section.
 
@@ -62,7 +62,7 @@ The subdirectories of the \PCGEOS\APPL directory are
 
 The EXTRA directory in this directory contains additional Tcl scripts that are both undocumented and unsupported. They are provided because you might find them useful even though they are unsupported.
 
-### 2.2 Target Directories and Files
+## 2.2 Target Directories and Files
 
 The target machine install will set up a standard GEOS environment. It will set up the proper directory structure; note that this structure is important-the pcs tool, which automatically downloads geodes to their proper directory assumes that those proper directories exist. Also note that the install program will set up two trees: one with error-checking code, and one with normal code. When the instructions tell you to do something from the top-level target directory, then you should be in the top-level EC directory if using error checking code and the top-level normal directory when testing regular code.
 
@@ -140,7 +140,7 @@ The standard GEOS setup includes the following directories:
 
 >Utilities  Contains utility applications that are not desk accessories. GeoManager, the icon editor, Preferences, and the screen dumper are all examples of utility applications; these should all be installed on your system.
 
-### 2.3 Environment Variables
+## 2.3 Environment Variables
 
 To make development easier, the environment variables on your 
 development machine should have the following additions.
@@ -159,7 +159,7 @@ where comPort is the number of the development machine's serial port you are usi
 
 Your target machine needs only one extra environment variable-a PTTY variable to control the target machine's side of communications with the development machine. It is set up in the same way as the development machine. However, you should use the number of the COM port by which the target machine is connected.
 
-### 2.4 System Files
+## 2.4 System Files
 
 The \AUTOEXEC.BAT and \CONFIG.SYS files on the development machine should have certain changes made to them for the tools to function properly. These changes are normally invoked by the installation program, but they are listed below for reference.
 
@@ -167,7 +167,7 @@ The AUTOEXEC.BAT file should define the PATH, ROOT_DIR, and PTTY environment var
 
 The CONFIG.SYS file on the host machine defines the number of files and buffers DOS can have open at one time. For best results, the FILES should be set to something larger than 80, and BUFFERS should be set to something larger than 30. On the target machine, set them to similar numbers. The exact numbers best for your system may be different. See your DOS manual for more information on these items.
 
-### 2.5 Sample C Applications
+## 2.5 Sample C Applications
 
 In your development machine's \PCGEOS\APPL\SDK_C directory, there should be a number of sample applications. The documentation will refer to these applications to illustrate certain points, but you may find a brief description of each useful if you wish to browse.
 
@@ -316,7 +316,7 @@ VTEXT   Demonstrates simple use of a visible text object.
 
 WAVSAMP This sample application, meant for the Zoomer only, shows how to use the wav library to play sample sounds.
 
-### 2.6 Sample Esp Programs
+## 2.6 Sample Esp Programs
 
 The SDK_ASM directory contains a number of Esp sample programs. For the most part, these programs are Esp versions of previously described C sample programs. They are listed below.
 

--- a/TechDocs/Markdown/Tools/tdebug.md
+++ b/TechDocs/Markdown/Tools/tdebug.md
@@ -1,4 +1,4 @@
-## 6 Debug Utility
+# 6 Debug Utility
 
 The Debug application allows the user to quickly change the debugging 
 environment on the target machine. It works with the target's .ini to simulate 
@@ -14,7 +14,7 @@ system files (e.g., to test a Zoomer program, use the ZOOM target directory).
 If your program is meant to work on a particular type of device, you should 
 run some tests on that device as well.
 
-### 6.1 Changing Platforms
+## 6.1 Changing Platforms
 
 Select the "Platform" item of the Options menu to change to another 
 platform. Debug allows the target machine to simulate different platforms by 
@@ -38,7 +38,7 @@ directory. The platform descriptions are stored in the notes field of the
 [system] category in the .ini file. See one of the provided .ini files for an 
 example of this.
 
-### 6.2 Switching Kernels
+## 6.2 Switching Kernels
 
 The "Profile" item of the Options menu allows you to switch between the 
 regular and profiling GEOS kernels. The profiling kernel runs slower than the 

--- a/TechDocs/Markdown/Tools/ticoned.md
+++ b/TechDocs/Markdown/Tools/ticoned.md
@@ -1,10 +1,10 @@
-## 7 Icon Editor
+# 7 Icon Editor
 
 The Icon Editor tool allows you to create icons for your application, both file 
 icons used by file manager applications and simple tool monikers which you 
 may use to provide graphic monikers for a geode's UI gadgetry.
 
-### 7.1 Creating Icons
+## 7.1 Creating Icons
 
 The icons produced by the icon editor are stored in an "icon database" so that 
 they can be viewed and retrieved easily. The icon database is the Icon Editor's 
@@ -46,7 +46,7 @@ dialog will present 4 options for the type of icon. If you decide to create a
 custom icon, you should enter the height, width and color scheme for the icon 
 in the provided fields. 
 
-### 7.2 Importing Icons
+## 7.2 Importing Icons
 
 There are 2 other ways to create icons. You can import a graphic such as a 
 GIF, TIF, BMP or other supported file format for use as an icon, provided that 
@@ -58,7 +58,7 @@ moniker group from the token database, which is the cache of file monikers
 kept by GeoManager. Select "Token Database" from the Icon menu to get a 
 list of monikers that you may import. 
 
-### 7.3 Editing Icons
+## 7.3 Editing Icons
 
 There are a number of features that are useful when editing icons:
 
@@ -103,7 +103,7 @@ copies, or transformed copies, of one format to another.
     The "resize format" dialog changes the size and shape of a 
 single format.
 
-### 7.4 Writing Source Code
+## 7.4 Writing Source Code
 
 When the icon is finished, make sure it's saved (File->Save), and then choose 
 "Write Source Code" from the Icon Menu. Follow these steps to get source 
@@ -148,7 +148,7 @@ used as toolbox UI, to assist the specific UI in deciding how to draw them.
 graphics string data structures used to describe visual monikers are 
 described. (Esp programs include **gstring.def**.)
 
-### 7.5 Icon Databases
+## 7.5 Icon Databases
 
 The icon editor can work with more than one icon database at a time via the 
 Multiple Document Interface standard. Each database has its own window, 
@@ -185,7 +185,7 @@ This can only be done with the mouse.
 To get more room for editing, use the Options menu to temporarily hide the 
 database viewer or format list while editing. 
 
-### 7.6 Exporting to Database
+## 7.6 Exporting to Database
 
 This is the function that most people associate with an icon editor. the token 
 database is a cache of moniker lists used by GeoManager and other 

--- a/TechDocs/Markdown/Tools/tini.md
+++ b/TechDocs/Markdown/Tools/tini.md
@@ -1,4 +1,4 @@
-## 9 The INI File
+# 9 The INI File
 
 Most programmers are familiar with the structure and function of an 
 initialization file, or INI file. GEOS uses one or more INI files depending on 
@@ -11,7 +11,7 @@ as the specific UI expected and information about the type of display and
 input devices used. It may also be used by applications for storing their 
 configuration information as set by the user.
 
-### 9.1 How to Use the INI File
+## 9.1 How to Use the INI File
 
 As a software developer, you will have two uses for the INI file. First, the INI 
 file controls your system configuration to a certain extent. For example, if you 
@@ -31,7 +31,7 @@ combinations are described in the special add-on documents that describe
 developing for each system. For more information, contact Geoworks 
 Developer Support.
 
-### 9.2 Categories in the INI File
+## 9.2 Categories in the INI File
 
 Code Display 9-1 shows a short list, without description, of all the categories 
 and keys available in the INI file. Following the display are explanations of 

--- a/TechDocs/Markdown/Tools/tresed.md
+++ b/TechDocs/Markdown/Tools/tresed.md
@@ -1,4 +1,4 @@
-## 8 Resource Editor
+# 8 Resource Editor
 
 The Resource Editor is a tool created by Geoworks to translate the existing 
 English language GEOS executables into your local language. 
@@ -17,7 +17,7 @@ code. If you are following this model, you may wish to give just this piece of
 documentation to your translator instead of burdening them with a full 
 documentation set.
 
-### 8.1 Glossary
+## 8.1 Glossary
 
 In explaining how to use the Resource Editor, it is important that we use the 
 same vocabulary to describe a certain portion of the code or the operation 
@@ -131,7 +131,7 @@ Editor is however able to match these two executables and
 show the newest changes. The process of updating a file will be 
 discussed in more detail later in these instructions.
 
-### 8.2 Getting Started
+## 8.2 Getting Started
 
 You will need to install localization target version of Ensemble 2.0 in a 
 directory of your target machine (for example \TARGET.20); This 
@@ -142,7 +142,7 @@ your translated executables. This will be explained in more detail later.
 Note: you may wish to not have these directories in your path. We suggest 
 that you edit batch files to run each installation.
 
-### 8.3 What Needs to be Translated?
+## 8.3 What Needs to be Translated?
 
 To create a localized version of your applications, you will need to translate 
 only the applications, libraries, and drivers you have created. All Geoworks 
@@ -156,14 +156,14 @@ library is not translated, that UI will always appear in its original form. Your
 application will work with the Spell library, whether or not it has been 
 translated.
 
-### 8.4 Translating
+## 8.4 Translating
 
 At this point you are ready to translate geodes into the target language. The 
 following set of steps can be carried out by a non-programmer running the 
 ResEdit tool. Of course, the translator should have a good idea of the geode's 
 function and use.
 
-#### 8.4.1 Choosing a new translation file
+### 8.4.1 Choosing a new translation file
 
 To begin creating new translation files, double click on the "Res Edit" icon in 
 the Tools folder of the WORLD directory of the LOCALIZE.20 version of 
@@ -192,7 +192,7 @@ GEOS20 installation (or whichever installation is currently set as the
 top-level source directory) you must change the top-level source directory 
 first.
 
-#### 8.4.2 Main translation screen
+### 8.4.2 Main translation screen
 
 After selecting a localization (.vm) file to translate, the Resource Editor will 
 then load the information from this file and the corresponding geode into an 
@@ -207,7 +207,7 @@ completely sure that the translation is accurate is to enter the translation
 and then actually run the translated executable (to be discussed later) and 
 see how the translations appear in the program.
 
-#### 8.4.3 Translating a Text String
+### 8.4.3 Translating a Text String
 
 Click on any text string in the right portion of the screen. The blinking text 
 editing cursor should appear, and you will be able to edit the text in the right 
@@ -255,7 +255,7 @@ shortcut. Currently, only text-based shortcuts are displayed, and are
 therefore, modifiable. Again, it is important to watch out for overlapping 
 shortcuts, as these cannot be detected by the Resource Editor.
 
-#### 8.4.4 Moving between chunks
+### 8.4.4 Moving between chunks
 
 + Use the mouse to click on any chunk.
 
@@ -267,7 +267,7 @@ to move to the previous chunk.
 + Click on the Chunk pop-up menu in the upper left corner of the screen 
 and  choose any chunk.
 
-#### 8.4.5 Moving between resources
+### 8.4.5 Moving between resources
 
 + Type Ctrl > (Ctrl-greater) to move to the next resource or Ctrl < 
 (Ctrl-less) to move to the previous resource. 
@@ -277,13 +277,13 @@ and  choose any chunk.
 + Click on the Resource pop-up menu in the upper left corner of the screen 
 and choose any resource.
 
-### 8.5 Resource Editor Menus
+## 8.5 Resource Editor Menus
 
 Many of these features available in the Resource Editor are identical to those 
 in the Ensemble 2.0 software. The quick overview of the menu items below 
 should give you the necessary information to use all of the features.
 
-#### 8.5.1 File Menu
+### 8.5.1 File Menu
 
 **New/Open:**  
 brings up the New/Open dialog box, allowing you to open a new           
@@ -348,7 +348,7 @@ newest version of the translation file
 **Exit:**  
 exits the Resource Editor
 
-#### 8.5.2 Edit Menu
+### 8.5.2 Edit Menu
 
 **Cut:**  
 takes highlighted information and moves it to the clipboard
@@ -370,7 +370,7 @@ with local language translation. You can limit a forward or backward
 search by selecting filters for certain types of chunks from the Filters 
 menu.
 
-#### 8.5.3 Project Menu
+### 8.5.3 Project Menu
 
 The items in this menu keep track of how your project is organized.
 
@@ -383,7 +383,7 @@ Set the top level directory holding modified geodes.
 **Reset Source Geode Path:**  
 Reset the path of the source geode if it moves to a different subdirectory.
 
-#### 8.5.4 Filter Menu
+### 8.5.4 Filter Menu
 
 Each of these menu items is a radio button, which allows you to turn on or      
 off as many of these filters as you like. These options can be helpful when         
@@ -408,7 +408,7 @@ chunks affected by updating the translation file.
 
 **Show deleted chunks:**
 
-#### 8.5.5 Utilities Menu
+### 8.5.5 Utilities Menu
 
 These menu items allow for quick movement between chunks and resources.
 
@@ -420,7 +420,7 @@ These menu items allow for quick movement between chunks and resources.
 
 **Previous Resource:**
 
-#### 8.5.6 Window Menu
+### 8.5.6 Window Menu
 
 These menu items make manipulation of multiple translation files easy, by       
 opening overlapping windows or tiling active windows.
@@ -431,7 +431,7 @@ opening overlapping windows or tiling active windows.
 
 **Tile:**
 
-### 8.6 Creating an Executable
+## 8.6 Creating an Executable
 
 After all of the chunks and resources in the selected .vm file have been 
 translated and saved in a translation file, a new local language executable 
@@ -463,7 +463,7 @@ the WORLD directory and the Screen Savers, to reflect local language names.
 In this case, the new geode will not overwrite the original one, and you will 
 have to go back and delete the old one to avoid duplicates. 
 
-### 8.7 Updating an Executable
+## 8.7 Updating an Executable
 
 Even after all the translations are complete, there may be a need to replace 
 a certain executable with a newer version containing a bug fix or a feature 
@@ -493,7 +493,7 @@ by clicking on the Commit the Update trigger in the File/Update menu. This
 will remove information which marks the chunks as "new" or "changed" and 
 will delete the Deleted Chunks resource.
 
-### 8.8 Testing Your New Executables
+## 8.8 Testing Your New Executables
 
 You may find that you would like to be able to test your translations as soon 
 as you make them. At any point during a translation, you can create an 

--- a/TechDocs/Markdown/Tools/tswatcm.md
+++ b/TechDocs/Markdown/Tools/tswatcm.md
@@ -1,4 +1,4 @@
-## 3 Swat Introduction
+# 3 Swat Introduction
 
 Most programmers are familiar with the process of debugging code. Many, 
 however, will not be familiar with the issues of debugging programs in an 
@@ -74,7 +74,7 @@ As you gain familiarity with Swat while using Swat with the sample
 applications and with your own programs, you will discover your own 
 preferred methods of debugging.
 
-### 3.1 DOS Command Line Options
+## 3.1 DOS Command Line Options
 
 To use Swat, you must have the pccom tool running on the target machine. 
 You may then invoke Swat on the development machine. Swat takes the 
@@ -121,7 +121,7 @@ specify a fifth directory in which to look for geodes. You may specify absolute
 pathnames in this file; if you give relative paths, they will be assumed to start 
 at the directory specified with your ROOT_DIR variable.
 
-### 3.2 Notation
+## 3.2 Notation
 
 The rest of this chapter is devoted to interacting with Swat once you have it running. Most of this is done by means of commands typed at a prompt. Some Swat commands may have subcommands, some may have flag options, and 
 some combine the two. Others may have special options; all, however, are 
@@ -153,7 +153,7 @@ or more repetitions of the construct may be used. For example, `unalias <word>*`
 can be the `unalias` command by itself, or it can be followed by 
 a list of words to be unaliased.
 
-### 3.3 Address Expressions
+## 3.3 Address Expressions
 
 Address expressions are used as arguments to any Swat command that 
 accesses memory. For example, the `pobject` command takes an address 
@@ -252,7 +252,7 @@ Much of the time the type of data stored at the address given by the address exp
 
 the data at `ds:14h` will be treated as a double word.
 
-### 3.4 On-line Help
+## 3.4 On-line Help
 
 Swat provides on-line help, both for looking up Swat topics and GEOS 
 reference material.
@@ -363,7 +363,7 @@ fast help on a particular command. (See Swat Display 3-2.)
 
 
 
-### 3.5 Essential Commands
+## 3.5 Essential Commands
 
 This section covers the function and usage of some of the most important 
 Swat commands. These commands fall into the following command groups:
@@ -389,7 +389,7 @@ aforementioned groups.
 
 A complete list of the Swat commands is contained in the Reference chapter.
 
-#### 3.5.1 Cycle of Development
+### 3.5.1 Cycle of Development
 
     send, run, exit, patient-default
 
@@ -434,7 +434,7 @@ Use this command to set a default patient to use with the **send** and **run**
 commands. The send and run commands will operate on this patient if they 
 are not passed arguments.
 
-#### 3.5.2 Attaching and Detaching
+### 3.5.2 Attaching and Detaching
 
     attach, att, detach, quit, cont, Ctrl-C
 
@@ -593,7 +593,7 @@ pressing the c key. It is used to stop GEOS in order to set a breakpoint,
 examine memory, or to get a command line prompt.
 
 
-#### 3.5.3 Breakpoints and Code Stepping
+### 3.5.3 Breakpoints and Code Stepping
 
 The commands in this group are used to stop at specified breakpoints in an 
 application's code and then step through the code line by line if necessary. 
@@ -906,7 +906,7 @@ This finishes the current stack frame, stops, and remains in step mode.
 This skips the current instruction, does not execute it, and goes on to the 
 next instruction in step mode.
 
-#### 3.5.4 Examining and Modifying Memory
+### 3.5.4 Examining and Modifying Memory
 
 The commands in this section all deal with the examination, manipulation, 
 or modification of the memory used by an application. Memory from 
@@ -1588,7 +1588,7 @@ The **why** command prints the error code for an occurrence of a fatal error.
 This command is useful because it can give a good idea of why GEOS crashed.
 
 
-### 3.6 Additional Features
+## 3.6 Additional Features
 
 This section covers the features of Swat that make it easier to use when 
 debugging an application.

--- a/TechDocs/Markdown/Tools/tswta_i.md
+++ b/TechDocs/Markdown/Tools/tswta_i.md
@@ -1,4 +1,4 @@
-## 4 Swat Reference
+# 4 Swat Reference
 
 This chapter is intended to provide documentation for the majority of useful 
 Swat commands. The general structure of the descriptions in this chapter 
@@ -734,7 +734,7 @@ alias, unbind-key.
 
 ### break
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -770,7 +770,7 @@ brk, irq.
 
 ### brk
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -864,7 +864,7 @@ words, dwords, imem, assign.
 
 ### cache
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -968,17 +968,17 @@ cdr.
 ----------
 ### case
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 ### catch
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 ### cbrk
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -1124,7 +1124,7 @@ top-level-read.
 ----------
 ### concat
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 ### condenseSmall
@@ -1227,9 +1227,9 @@ systemobj, gentree, impliedgrab.
 
 ----------
 
-###continue
+### continue
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -1255,7 +1255,7 @@ step-patient.
 
 ----------
 
-###cup
+### cup
 
 **Usage:**  
 `cup <class>`  
@@ -1640,7 +1640,7 @@ help.
 
 ### defsubr
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2279,13 +2279,13 @@ elist, eqlist, eqfind, pevent.
 
 ### error
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
 ### eval
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2298,7 +2298,7 @@ Chapter 5.
 
 ### exec
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2412,7 +2412,7 @@ foreach, index, range.
 
 ### expr
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2526,7 +2526,7 @@ Print the address of the target machine's current top-most field window.
 
 ### file
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2893,19 +2893,19 @@ pfont, pfontinfo, pusage, pchar, pfontinfo.
 
 ### for
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
 ### foreach
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
 #### format
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -3471,7 +3471,7 @@ addr-parse, addr-preprocess.
 
 ### global
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -3560,7 +3560,7 @@ gentree, vup, vistree, impliedgrab.
 
 ### handle
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4067,7 +4067,7 @@ Number of instructions to skip when using the ^D and ^U commands of ibrk.
 
 ### if
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4244,13 +4244,13 @@ command if they properly cast the handle.
 
 ### index
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
 ### info
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 

--- a/TechDocs/Markdown/Tools/tswtj_z.md
+++ b/TechDocs/Markdown/Tools/tswtj_z.md
@@ -1,4 +1,4 @@
-### 4.3 Swat Reference J-Z
+## 4.3 Swat Reference J-Z
 
 ----------
 
@@ -81,7 +81,7 @@ repeatCommand, top-level-read.
 
 ### length
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -144,7 +144,7 @@ help-fetch.
 
 ### list
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -1046,7 +1046,7 @@ This command causes a RET to be placed at the start of a routine.
 
 ### patient
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2355,7 +2355,7 @@ state. "asm" and "src" modes also print this.
 
 ### proc
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2392,7 +2392,7 @@ objwatch, mwatch, objmessagebrk, pobject.
 
 ### protect
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -2913,7 +2913,7 @@ Stop the debugger and exit.
 
 ### range
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -3160,7 +3160,7 @@ finish, backtrace.
 
 ### return
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -3343,7 +3343,7 @@ the current patient is used.
 
 ### scan
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -3617,7 +3617,7 @@ AX register when unassembling a message call.
 
 ----------
 
-###skip
+### skip
 
 **Usage:**  
 `skip [<number of instructions>]`
@@ -3718,7 +3718,7 @@ Defaults to "any".
 
 ### source
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -3775,7 +3775,7 @@ this again.
 
 ### src
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4196,7 +4196,7 @@ protect, source, file.
 
 ### string
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4246,7 +4246,7 @@ the PC.
 
 ### symbol
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4365,7 +4365,7 @@ gentree, impliedgrab.
 
 ### table
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4578,7 +4578,7 @@ freeze.
 
 ### thread
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4782,7 +4782,7 @@ List all the timers in GEOS.
 
 ### type
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 
@@ -4988,7 +4988,7 @@ addr-parse, assign, field.
 
 ### var
 
-This is a Tcl primitive. See "Tool Command Language," Chapter 5.
+This is a Tcl primitive. See [Tool Command Language](ttcl.md).
 
 ----------
 

--- a/TechDocs/Markdown/Tools/ttcl.md
+++ b/TechDocs/Markdown/Tools/ttcl.md
@@ -1,4 +1,4 @@
-## 5 Tool Command Language
+# 5 Tool Command Language
 
 Before using this chapter one should have a good understanding of how the 
 Swat commands function "Swat Introduction," Chapter 3, and of how the 
@@ -30,7 +30,7 @@ Descriptions and examples of coding conventions, techniques, and tricks.
 Steps to take in order to be able to use a newly written command to help 
 debug an application.
 
-### 5.1 Using This Chapter
+## 5.1 Using This Chapter
 
 This chapter provides the information needed to write a new Swat command 
 in Tcl. But, new commands need only be written in certain situations. Some 
@@ -49,7 +49,7 @@ should be written to examine that table in particular.
 The existing Swat commands should take care of the bulk of debugging, but 
 sometimes an extra command can help.
 
-### 5.2 Copyright Information
+## 5.2 Copyright Information
 
 The following sections of this chapter fall under the copyright below: 
 Background and Description, Syntax and Structure, and Commands.
@@ -62,7 +62,7 @@ that the above copyright notice appear in all copies. The University of
 California makes no representations about the suitability of this software for 
 any purpose. It is provided "as is" without express or implied warranty.
 
-### 5.3 Background and Description
+## 5.3 Background and Description
 
 The Tool Command Language is abbreviated as Tcl and is pronounced 
 "tickle". It was developed and written by Professor John Ousterhout at the 
@@ -82,7 +82,7 @@ the Tcl language, routines to implement the Tcl built-in
 commands, and procedures allowing an application to extend 
 Tcl with additional commands.
 
-### 5.4 Syntax and Structure
+## 5.4 Syntax and Structure
 
 Tcl supports only one type of data: *strings*. All commands, all arguments to 
 commands, all command results, and all variable values are strings. Where 
@@ -121,7 +121,7 @@ The structure and building of procedures in Tcl.
 + Variables  
 Variable declaration and description.
 
-#### 5.4.1 Basic Command Syntax
+### 5.4.1 Basic Command Syntax
 
 The Tcl language has syntactic similarities to both Unix and Lisp. However, 
 the interpretation of commands is different in Tcl than in either of those 
@@ -143,13 +143,13 @@ example, will treat its first argument as the name of a variable and its second
 argument as a string value to assign to that variable. For other commands, 
 arguments may be interpreted as integers, lists, file names, or Tcl commands.
 
-##### 5.4.1.1 Comments
+#### 5.4.1.1 Comments
 
 If the first non-blank character in a command is # (a number sign), then 
 everything from the # up through the next newline character is treated as 
 comment and discarded by the parser.
 
-##### 5.4.1.2 Argument Grouping
+#### 5.4.1.2 Argument Grouping
 
 Normally each argument field ends at the next white space (tabs or spaces), 
 but curly braces ("{" and "}") may be used to group arguments in different 
@@ -187,7 +187,7 @@ significant in a command field if the first character of the field is a left bra
 Otherwise neither left nor right braces in the field will be treated specially 
 (except as part of variable substitution).
 
-##### 5.4.1.3 Command Grouping
+#### 5.4.1.3 Command Grouping
 
 Normally, each command occupies one line (the command is terminated by a 
 newline character). Thus, the string:
@@ -237,7 +237,7 @@ If a field is enclosed in braces then the brackets and the characters between
 them are not interpreted specially; they are passed through to the argument 
 verbatim.
 
-##### 5.4.1.5 Variable Substitution
+#### 5.4.1.5 Variable Substitution
 
 The dollar sign ($) may be used as a special shorthand form for substituting 
 variables. If $ appears in an argument that is not enclosed in braces then 
@@ -269,7 +269,7 @@ argument verbatim.
 The dollar sign abbreviation is simply a shorthand form. **$a** is completely 
 equivalent to **[var a]**; it is provided as a convenience to reduce typing.
 
-##### 5.4.1.6 Backslash Substitution
+#### 5.4.1.6 Backslash Substitution
 
 Backslashes may be used to insert non-printing characters into command 
 fields and also to insert braces, brackets, and dollar signs into fields without 
@@ -330,7 +330,7 @@ structure; it only covers the most common cases. To produce particularly
 complicated arguments it will probably be easiest to use the format 
 command along with command substitution.
 
-#### 5.4.2 Expressions
+### 5.4.2 Expressions
 
 The second major interpretation applied to strings in Tcl is as *expressions*. 
 Several commands, such as **expr**, **for**, and **if**, treat some of their arguments 
@@ -408,7 +408,7 @@ desired result:
 
 `for {var i 1} {$i<=10} {var i [expr $i+1]} {body-}`
 
-#### 5.4.3 Lists
+### 5.4.3 Lists
 
 The third major way that strings are interpreted in Tcl is a *list*. A list is just 
 a string with a list-like structure consisting of fields separated by white 
@@ -439,7 +439,7 @@ The Tcl commands **concat**, **foreach**, **index**, **length**, **list**, and *
 you to build lists, extract elements from them, search them, and perform 
 other list-related functions.
 
-#### 5.4.4 Command Results
+### 5.4.4 Command Results
 
 Each command produces two results: a code and a string. The code indicates 
 whether the command completed successfully or not, and the string gives 
@@ -487,7 +487,7 @@ TCL_**RETURN** codes. The **catch** command allows Tcl programs to catch
 errors and handle them without aborting command interpretation any 
 further.
 
-#### 5.4.5 Procedures
+### 5.4.5 Procedures
 
 Tcl allows one to extend the command interface by defining procedures. A Tcl 
 procedure can be invoked just like any other Tcl command (it has a name and 
@@ -496,7 +496,7 @@ a piece of C code linked into the program; it is a string containing one or more
 other Tcl commands. See the **proc** command for information on how to define 
 procedures and what happens when they are invoked.
 
-#### 5.4.6 Variables
+### 5.4.6 Variables
 
 Tcl allows the definition of variables and the use of their values either 
 through $-style variable substitution, the var command, or a few other 
@@ -509,14 +509,14 @@ global command may be used to request that a name refer to a global
 variable for the duration of the current procedure (somewhat analogous to 
 **extern** in C).
 
-### 5.5 Commands
+## 5.5 Commands
 
 The Tcl library provides the following built-in commands, which will be 
 available to any application using Tcl. In addition to these built-in 
 commands, there may be additional commands defined in Swat, plus 
 commands defined as Tcl procedures.
 
-#### 5.5.1 Notation
+### 5.5.1 Notation
 
 The descriptions of the Tcl commands will follow the following notational 
 conventions:
@@ -548,7 +548,7 @@ indicates one or more repetitions of the construct may be used. For
 example, `unalias word*` can be the `unalias` command by itself, or it can 
 be followed by a list of words to be unaliased.
 
-#### 5.5.2 Built-in Commands
+### 5.5.2 Built-in Commands
 
 The built-in Tcl commands are as follows:
 
@@ -837,7 +837,7 @@ return, catch.
 
 ----------
 
-###eval
+### eval
 
 **Usage:**  
 `eval <body>`
@@ -1752,7 +1752,7 @@ given name, even if it has no value yet.
 **See Also:**  
 global.
 
-### 5.6 Coding
+## 5.6 Coding
 
 This section provides information about the features and commands of Tcl 
 that are important to know when using Swat, and the features and 
@@ -1767,7 +1767,7 @@ them.
 
 + Examples
 
-#### 5.6.1 Swat Data Structure Commands
+### 5.6.1 Swat Data Structure Commands
 
 `symbol, type, patient, handle, brk, cbrk, event, thread, 
 src, cache, table`
@@ -2952,7 +2952,7 @@ to display their fields (or members, as the case may be).
 **See Also:**  
 gc, symbol, symbol-types, value
 
-#### 5.6.2 Examples
+### 5.6.2 Examples
 
 This section will contain a few examples of Tcl code for Swat commands, 
 showing the use of some of included Tcl commands. A good way to view the 
@@ -3049,7 +3049,7 @@ fifth line, and the **range** command on the twenty-ninth line.
 
 ----------
 
-### 5.7 Using a New Command
+## 5.7 Using a New Command
 
 Once a new command is written, it needs to be loaded into Swat so that it can 
 be used. Depending on how the command is to be used, you may be interested 
@@ -3061,7 +3061,7 @@ in any of the following topics:
 
 + Explicit loading
 
-#### 5.7.1 Compilation
+### 5.7.1 Compilation
 
 It is possible to byte-compile a Tcl script. The **bc** Tcl command creates a .TLC 
 file containing compiled Tcl code-this code will run faster than normal Tcl 
@@ -3069,7 +3069,7 @@ code. When loading, Swat will load a .TLC file instead of a .TCL file where
 possible. Making changes to compiled Tcl functions involves changing the 
 source code and re-compiling.
 
-#### 5.7.2 Autoloading
+### 5.7.2 Autoloading
 
 If the development environment has been set up properly, there should 
 already exist the **/pcgeos/Tools/swat/lib** directory on the workstation. This 
@@ -3092,7 +3092,7 @@ the 1 indicates that the interpreter will not evaluate arguments passed to the
 command. (See "Swat Reference," Chapter 4, for more information on the 
 **autoload** command.)
 
-#### 5.7.3 Explicit Loading
+### 5.7.3 Explicit Loading
 
 Another way to load a command into Swat is to use the **load** command from 
 the Swat command line. This command is simply `load <path>/<filename>`. 

--- a/TechDocs/Markdown/Tools/ttools.md
+++ b/TechDocs/Markdown/Tools/ttools.md
@@ -1,11 +1,11 @@
-## 10 Using Tools
+# 10 Using Tools
 
 This chapter gives a reference of the tools included in this development kit. 
 This chapter is not intended to teach you how to use the tools; it provides a 
 reference only. To learn how to use most of the tools, see the Tutorial included 
 in the development kit and the First Steps chapter in the Concepts book.
 
-### 10.1 Tools Summary
+## 10.1 Tools Summary
 
 The tools provided in this kit are listed below. Each is described in full in the 
 following sections.
@@ -65,7 +65,7 @@ transferring it to any directory on the development machine.
 GEOS debugger. This program runs on the development machine, 
 monitoring GEOS programs running on the target machine.
 
-### 10.2 Typical Development Session
+## 10.2 Typical Development Session
 
 The Tutorial shows in detail how to write, compile, download, and debug an 
 application. As a quick guide, however, the following list recaps the steps in 
@@ -96,7 +96,7 @@ directions provided by the MAKEFILE.
 6. To test the geode, either run it on the target machine or run swat from 
 the development machine to debug it.
 
-### 10.3 File Types
+## 10.3 File Types
 
 You may be curious to know what sorts of files you'll be working with. If you 
 have to work with someone else's code, then being able to find your away 
@@ -265,7 +265,7 @@ After you have made your geode the first time (creating a makefile with
 
 + Geodes: .geo files.
 
-### 10.4 Esp
+## 10.4 Esp
 
 Esp (pronounced "esp") is the GEOS assembler. It creates object files from Esp 
 code - said code using a superset of MASM syntax. These object files may then 
@@ -330,7 +330,7 @@ dependencies.
 **-d** - Activate's Esp debugging mode. Useful only when trying to track down a 
 bug in Esp.
 
-### 10.5 Glue
+## 10.5 Glue
 
 Glue is the GEOS linker. It creates GEOS or DOS executables from object files. 
 (It can also create GEOS VM and font files, if you have the appropriate tools.) 
@@ -466,7 +466,7 @@ lock down or dereference the handle of the returned optr.
 
 **-z** - Output localization information.
 
-### 10.6 Goc
+## 10.6 Goc
 
 Goc is the GEOS C preprocessor, which will turn your .goc file into something 
 a regular C compiler can understand. It will traverse the .goc file, detect Goc 
@@ -528,7 +528,7 @@ what @default means).
 
 **-p** - For Geoworks use only.
 
-### 10.7 Grev
+## 10.7 Grev
 
 GEOS supports two version numbers for each geode. The first of these is the 
 release number, used to uniquely identify the release of the geode. The 
@@ -662,7 +662,7 @@ changes to file. The **-R** option works as stated above.
 **help**   
 Print out a detailed help.
  
-### 10.8 mkmf
+## 10.8 mkmf
 
 The mkmf tool exists to create a file named MAKEFILE. The **pmake** program 
 will use this file as a sort of script, using it to determine how to compile and 
@@ -696,7 +696,7 @@ intermediate step towards making the whole geode.  If you do not wish
 the files in a subdirectory to be incorporated in the program, create a file 
 in the directory called NO_MKMF. This file need have no contents.
 
-### 10.9 pccom
+## 10.9 pccom
 
 The pccom tool manages communication between the development and 
 target machines. It assumes that the machines are connected by a single 
@@ -707,7 +707,7 @@ Note that it is possible to use some features of pccom from within GEOS. For
 more information about this, see "PCCom Library," Chapter 22 of the 
 Concepts Book.
 
-#### 10.9.1 PCCOM Background
+### 10.9.1 PCCOM Background
 
 PCCOM is used in two primary situations. First, it is used by GEOS software 
 developers when transferring files or when debugging an application. In this 
@@ -720,7 +720,7 @@ Zoomer devices or other devices that require remote file manipulation. In this
 case, the host machine runs a program which copies escape character 
 sequences to the appropriate serial port, prompting PCCOM to act.
 
-#### 10.9.2 Running PCCOM on the Target
+### 10.9.2 Running PCCOM on the Target
 
 PCCOM is a DOS program that monitors the serial port and responds to 
 commands received on the line. All I/O is interrupt driven with XON/XOFF 
@@ -753,7 +753,7 @@ numbers of the interrupt(s) to be ignored, in hexadecimal.
 parameter is rarely required. The irq parameter is the number 
 of the IRQ level to be used.
 
-##### 10.9.2.1 Quitting PCCOM
+#### 10.9.2.1 Quitting PCCOM
 
 PCCOM may be quit either directly or remotely. To quit PCCOM directly, 
 simply hit the Enter key (or the q key) on the machine on which PCCOM is 
@@ -763,7 +763,7 @@ To quit PCCOM remotely, issue the quit escape sequence <Esc>EX through
 the serial line from the host machine. See below for a description of the 
 commands that can be issued remotely.
 
-##### 10.9.2.2 Remote PCCOM Commands
+#### 10.9.2.2 Remote PCCOM Commands
 
 PCCOM doesn't care what machine originates a remote command; its sole 
 purpose is to evaluate and execute commands received through the serial 
@@ -821,7 +821,7 @@ exclamation points in their names.
 
     Exit PCCOM      <Esc>EX             Exit PCCOM on the remote machine.
 
-##### 10.9.2.3 Sending and Receiving Files
+#### 10.9.2.3 Sending and Receiving Files
 
 If you are using the GEOS SDK, you will do most of your file sending and 
 receiving using the programs PCS, PCSEND, and PCGET. These programs 
@@ -990,7 +990,7 @@ Typing
 would download both HGCEC.GEO and LOGIBUSE.GEO to their proper 
 directories. A listing of all the supported tokens can be found in the SEND file.
 
-#### 10.9.3 File Transfer Protocol of PCCOM
+### 10.9.3 File Transfer Protocol of PCCOM
 
 If you need to create your own file transfer program or module, you can use 
 the basic PCCOM commands and a special transfer protocol to send or receive 
@@ -998,7 +998,7 @@ files over the serial link. This is useful, for example, if you have an existing
 Windows or DOS program to which you would like the to add the ability to 
 transfer files to or from the Zoomer (or another unit running PCCOM).
 
-##### 10.9.3.1 Sending a File to the Remote Machine
+#### 10.9.3.1 Sending a File to the Remote Machine
 
 Sending a file to the remote machine involves the steps below. A file may be 
 sent by any program that can access the serial port.
@@ -1102,7 +1102,7 @@ entire file.
 To make it absolutely clear that the file transfer has finished, send two 
 zero bytes.
 
-##### 10.9.3.2 Retrieving a File Remotely
+#### 10.9.3.2 Retrieving a File Remotely
 
 Retrieving a file from a machine running PCCOM is straightforward and uses 
 the same file transfer protocol shown above for sending a file. The sequence 
@@ -1162,7 +1162,7 @@ These make it clear that the file transfer has been completed.
 **10** - Send an ACK byte.  
 This acknowledges the end of the file transfer.
 
-##### 10.9.3.3 Calculating Checksum Values
+#### 10.9.3.3 Calculating Checksum Values
 
 The CRC word that accompanies each block of transferred data must be 
 calculated using the same code as PCCOM or you will probably have only 
@@ -1238,7 +1238,7 @@ BLOCK_QUOTE, or BLOCK_END characters in your calculations.
 
 
 
-### 10.10 pcget
+## 10.10 pcget
 
 Once you have pccom running on the target machine, you can invoke **pcget** 
 on the development machine to yank a file from the target machine to the 
@@ -1260,7 +1260,7 @@ flags, as you did when invoking the **pccom** tool. The /b flag sets the baud ra
 the IRQ level (e.g. "/I:3"). Note that these flags may be indicated with "-" 
 instead of "/").
 
-### 10.11 pcs
+## 10.11 pcs
 
 Once you have pccom running on the target machine, invoke **pcs** on the 
 development machine to send your geode's executable to the proper place on 
@@ -1350,7 +1350,7 @@ DRIVER\MOUSE\LOGIBUS\LOGIBUSE.GEO (or LOGIBUS.GEO).
     *\DOCUMENT\*                        *       DOCUMENT
     *\DOSAPPL\*                         *       .
 
-### 10.12 pcsend
+## 10.12 pcsend
 
 The **pcsend** tool sends files from the development machine to the target 
 machine (assuming that the target machine is running pccom). Normally you 
@@ -1373,7 +1373,7 @@ may use "-" instead of "/" when passing these flags.)
 
 `pcsend sendslow.com /b:2400`
 
-### 10.13 pmake
+## 10.13 pmake
 
 The **pmake** program is a make utility. This means that it takes a directory 
 of sources and a makefile which contains knowledge of how to turn these 
@@ -1416,7 +1416,7 @@ directory so that all applications may use it, then signal this to **pmake**:
 The **pmake** program does have command-line arguments, but these are used 
 only rarely; they are detailed below.
 
-#### 10.13.1 Copyright Notice and Acknowledgment
+### 10.13.1 Copyright Notice and Acknowledgment
 
 The **pmake** tool comes under the following copyright notice:
 
@@ -1434,7 +1434,7 @@ provided "as is" without express or implied warranty.
 The **pmake** program for the PC uses the SPAWNO routines by Ralf Brown to 
 minimize memory use while shelling to DOS and running other programs.
 
-#### 10.13.2 How to Customize pmake
+### 10.13.2 How to Customize pmake
 
 For most applications, executing **mkmf** will generate a perfect makefile. 
 However, you may be creating an unusual geode or have some makefile 
@@ -1517,7 +1517,7 @@ things you can do without learning too much about makefiles.
 
 ----------
 
-#### 10.13.3 Command Line Arguments
+### 10.13.3 Command Line Arguments
 
 The **pmake** program comes with a wide variety of flags to choose from. They 
 must be passed in the following order: flags (if any), variable assignments (if 
@@ -1602,7 +1602,7 @@ conditionals, which are described in section 10.13.5.2 below.
 **-W** - Suppresses **pmake**'s warnings. Note that tools which **pmake** invokes 
 (Goc, Glue, etc.) may still print out warnings of their own.
 
-#### 10.13.4 Contents of a Makefile
+### 10.13.4 Contents of a Makefile
 
 The **pmake** program takes as input a file that tells
 
@@ -1631,7 +1631,7 @@ Any line may be continued over multiple lines by ending it with a backslash
 following line are compressed into a single space before the input line is 
 examined by pmake.
 
-##### 10.13.4.1 Dependency Lines
+#### 10.13.4.1 Dependency Lines
 
 In any system, there are dependencies between the files that make up the 
 system. For instance, in a program made up of several C source files and one 
@@ -1746,7 +1746,7 @@ characters between a and z), or both. It matches any single character
 contained in the list. E.g. [A-Za-z] will match all letters, while 
 [0123456789] will match all numbers.
 
-##### 10.13.4.2 Shell Commands
+#### 10.13.4.2 Shell Commands
 
 At this point, you may be wondering how files are re-created. The re-creation 
 is accomplished by commands you place in the makefile. These commands 
@@ -1816,7 +1816,7 @@ ignored and **pmake** keeps going.
 If the system call should be made through the DOS COMMAND.COM, precede 
 the shell command with a backquote (`).
 
-##### 10.13.4.3 Variables
+#### 10.13.4.3 Variables
 
 The **pmake** program has the ability to save text in variables to be recalled 
 later at your convenience. Variables in **pmake** are used much like variables 
@@ -2016,13 +2016,13 @@ You might use the above sequence to set up an argument list in the CL
 environment variable if your compiler (invoked with CCOM) needed its 
 arguments in such a variable and was unable to take arguments in a file.
 
-##### 10.13.4.4 Comments
+#### 10.13.4.4 Comments
 
 Comments in a makefile start with a "#" character and extend to the end of 
 the line. They may appear anywhere you want them, except where they 
 might be misinterpreted as a shell command.
 
-##### 10.13.4.5 Transformation Rules
+#### 10.13.4.5 Transformation Rules
 
 As you know, a file's name consists of two parts: a base name, which gives 
 some hint as to the contents of the file, and a suffix, which usually indicates 
@@ -2222,7 +2222,7 @@ transformation, this is what **pmake** printed for the rest of the process:
     --- JIVE.EXE ---
     bcc -o JIVE.EXE JIVE.OBJ
 
-##### 10.13.4.6 Including Other Makefiles
+#### 10.13.4.6 Including Other Makefiles
 
 Just as for programs, it is often useful to extract certain parts of a makefile 
 into another file and just include it in other makefiles somehow. Many 
@@ -2272,14 +2272,14 @@ won't work; instead use the following:
     SYSTEM= command.mk
     #include <$(SYSTEM)>
 
-##### 10.13.4.7 Saving Commands
+#### 10.13.4.7 Saving Commands
 
 There may come a time when you will want to save certain commands to be 
 executed when everything else is done, by inserting an ellipsis "-" in the 
 Makefile. Commands saved in this manner are only executed if **pmake** 
 manages to re-create everything without an error.
 
-##### 10.13.4.8 Target Attributes
+#### 10.13.4.8 Target Attributes
 
 The **pmake** tool allows you to give attributes to targets by means of special 
 sources. Like everything else **pmake** uses, these sources begin with a period 
@@ -2346,7 +2346,7 @@ applied (as stored in the .ALLSRC variable for the target) as its
 system makefile) make use of these .USE rules to make developing easier 
 (they're in the default, system makefile directory).
 
-##### 10.13.4.9 Special Targets
+#### 10.13.4.9 Special Targets
 
 There are certain targets that have special meaning to **pmake**. When you 
 use one on a dependency line, it is the only target that may appear on the 
@@ -2439,7 +2439,7 @@ In addition to these targets, a line of the form
 
 applies the attribute to all the targets listed as sources .
 
-##### 10.13.4.10 Modifying Variable Expansion
+#### 10.13.4.10 Modifying Variable Expansion
 
 Variables need not always be expanded verbatim. The **pmake** program 
 defines several modifiers that may be applied to a variable's value before it is 
@@ -2550,7 +2550,7 @@ In addition, another style of substitution is also supported. This looks like:
 It must be the last modifier in the chain. The search is anchored at the end 
 of each word, so only suffixes or whole words may be replaced.
 
-#### 10.13.5 Advanced pmake Techniques
+### 10.13.5 Advanced pmake Techniques
 
 This section is devoted to those facilities in **pmake** that allow you to do a 
 great deal in a makefile with very little work, as well as do some things you 
@@ -2558,7 +2558,7 @@ couldn't do in make without a great deal of work (and perhaps the use of other
 programs). The problem with these features is that they must be handled 
 with care, or you will end up with a mess.
 
-##### 10.13.5.1 Search Paths
+#### 10.13.5.1 Search Paths
 
 The **pmake** tool supports the dispersal of files into multiple directories by 
 allowing you to specify places to look for sources with .PATH targets in the 
@@ -2612,7 +2612,7 @@ will not be noted when searching for implicit sources, nor will they be found
 when **pmake** attempts to discover when the file was last modified, unless the 
 file was created in the current directory. 
 
-##### 10.13.5.2 Conditional Statements
+#### 10.13.5.2 Conditional Statements
 
 Like a C compiler, **pmake** allows you to configure the makefile using 
 conditional statements. A conditional looks like this:
@@ -2703,7 +2703,7 @@ two functions to each term. They are as follows:
 There are also the "else if" forms: elif, elifdef, elifndef, elifmake, and 
 elifnmake.
 
-#### 10.13.6 The Way Things Work
+### 10.13.6 The Way Things Work
 
 When **pmake** reads the makefile, it parses sources and targets into nodes in 
 a graph. The graph is directed only in the sense that **pmake** knows which 
@@ -2749,7 +2749,7 @@ targets are left to be made), there is a cycle in the graph. The **pmake**
 program does a depth-first traversal of the graph to find all the targets that 
 weren't made and prints them out one by one.
 
-### 10.14 Swat Stub
+## 10.14 Swat Stub
 
 The swat stub runs on the target machine, passing information between a 
 running GEOS session and Swat on the host machine. It has one flag:

--- a/TechDocs/Markdown/Tools/twelcome.md
+++ b/TechDocs/Markdown/Tools/twelcome.md
@@ -1,4 +1,4 @@
-## 1 Welcome
+# 1 Welcome
 
 This manual provides full information about the GEOS 
 development tools. It also details your system 

--- a/TechDocs/Markdown/Tutorial/Data_Structures_and_UI.md
+++ b/TechDocs/Markdown/Tutorial/Data_Structures_and_UI.md
@@ -1,4 +1,4 @@
-## 5 Data Structures and UI
+# 5 Data Structures and UI
 
 In this chapter we add some UI gadgetry to the application. By creating some 
 objects and writing some procedural code, we will construct a cluster of 
@@ -8,7 +8,7 @@ We will explore the application's new code, both examining blocks of the
 source code to see what they do and going through a debugging session 
 during which we set some breakpoints and do some stepping through code.
 
-### 5.1 Editing the Application
+## 5.1 Editing the Application
 
 At the end of this chapter you will find a complete code listing for this stage 
 of the application. Pieces of code which have been added or changed since the 
@@ -25,7 +25,7 @@ before: if you still have Swat attached, then use the send Swat command;
 otherwise, make sure that the pccom tool is running on the target machine 
 and invoke pcs on the host machine.
 
-### 5.2 The Application so Far
+## 5.2 The Application so Far
 
 Our application has sprouted a scrolling list, three buttons, and a place to 
 input a numerical value. The buttons allow the user to add, remove, and 
@@ -76,7 +76,7 @@ resources we will work with each time. Since our application will
 eventually support multiple documents, we may never bother to do the 
 cleaning up necessary to make it multi-launchable.
 
-### 5.3 MCHRT.GP Change
+## 5.3 MCHRT.GP Change
 
 We changed one line of the MCHRT.GP file to let glue know that our 
 application is now single-launchable instead of multi-launchable.
@@ -88,7 +88,7 @@ type appl, process, single
 Our new addition, the "single" keyword, signals that the application is 
 single-launchable.
 
-### 5.4 MCHRT.GOC: Data & Structures
+## 5.4 MCHRT.GOC: Data & Structures
 
 Our additions to MCHRT.GOC fall into three basic categories. First, we will 
 declare global variables and set up prototypes for routines and messages. 
@@ -208,7 +208,7 @@ our local memory block, the block which will act as the "mini-heap". We will
 use the MemHandle to access the local memory block while that block is 
 loaded into memory. 
 
-### 5.5 MCHRT.GOC: New Objects
+## 5.5 MCHRT.GOC: New Objects
 
 ~~~
 @object GenPrimaryClass MCPrimary = {   
@@ -353,7 +353,7 @@ automatically.
 For more information about GenValue objects, see "GenValue," Chapter 8 of 
 the Object Reference Book.
 
-### 5.6 MCHRT.GOC: Procedural Code
+## 5.6 MCHRT.GOC: Procedural Code
 
 The last part of our additions is procedural code which we will use to manage 
 our data structures and coordinate updates between objects.
@@ -941,7 +941,7 @@ retHandle = @callsuper();
 return retHandle;
 ~~~
 
-### 5.7 Swat: Breakpoints and More
+## 5.7 Swat: Breakpoints and More
 
 Now that our application has some procedural code, we'll be able to use Swat 
 for some of the more traditional uses of a debugger: setting breakpoints and 

--- a/TechDocs/Markdown/Tutorial/Documents_and_Displays.md
+++ b/TechDocs/Markdown/Tutorial/Documents_and_Displays.md
@@ -1,4 +1,4 @@
-## 7 Documents and Displays
+# 7 Documents and Displays
 
 In this chapter, the application starts maintaining real document files and 
 allows the user to have more than one document open at a time. This turns 
@@ -8,14 +8,14 @@ document's file handle in a global variable, since there may now be several
 files open. We will take a more object-oriented approach, storing this sort of 
 information in instance data of objects representing documents.
 
-### 7.1 Making the Changes
+## 7.1 Making the Changes
 
 Make the changes to MCHRT.GP and MCHRT.GOC as indicated in Code 
 Display 5-1 and Code Display 5-2; as before, places where the code has 
 changed are indicated by vertical bars in the margin. After making the 
 changes to the source code, re-compile the executable with pmake. 
 
-### 7.2 The Application So Far
+## 7.2 The Application So Far
 
 Our chart application can now keep track of more than one document at a 
 time. It provides UI allowing the user to choose and select document names. 
@@ -63,7 +63,7 @@ objects; we could reconstruct them using the information stored in the
 linked list; we're doing things this way only to demonstrate how you 
 might save an object within a document file.
 
-### 7.3 MCHRT.GP: New Resources
+## 7.3 MCHRT.GP: New Resources
 
 Our glue parameters file has expanded to accommodate several new 
 resources and a new subclass.
@@ -105,7 +105,7 @@ export MCDocumentClass
 
 We must export our document class so that its symbols are recognized.
 
-### 7.4 MCHRT.GOC: New Structures
+## 7.4 MCHRT.GOC: New Structures
 
 The start of the application has changed quite a bit. You may notice that the 
 global variables are all missing. These were used by the process object to 
@@ -186,7 +186,7 @@ We're now saving the visible chart object's object block in the document file.
 We'll store its handle in the map block's header so that we'll be able to extract 
 it when opening the file.
 
-### 7.5 MCHRT.GOC: Application Objects
+## 7.5 MCHRT.GOC: Application Objects
 
 ~~~
 @object GenApplicationClass MCApp = {
@@ -242,7 +242,7 @@ menu bar should be floating and the
 HINT_DISPLAY_MENU_BAR_HIDDEN_ON_STARTUP hint says that the menu 
 bar should start out hidden on those systems that support hidden menu bars.
 
-### 7.6 Menus and Controllers
+## 7.6 Menus and Controllers
 
 In past stages of the application, we only had one menu (the File menu), 
 generated automatically. For this stage of the application, we create our own 
@@ -437,7 +437,7 @@ document object is now in charge of maintaining the data for each object, the
 gadgets which work with the data use the appropriate travel option to reach 
 the document.
 
-### 7.8 Document Group
+## 7.8 Document Group
 
 ~~~
 @start  DocGroup;
@@ -497,7 +497,7 @@ would change the document protocol. We could then write handlers in our
 document class for updating old documents, which would be recognized by 
 their low protocol numbers. 
 
-### 7.9 Altered Handlers
+## 7.9 Altered Handlers
 
 ~~~
 @method MCDocumentClass, MSG_MCD_SET_DATA_ITEM_MONIKER {
@@ -772,7 +772,7 @@ MSG_MCD_INSERT_DATA_ITEM. We won't explore each change; there are
 just more cases of using document instance data to refer to data structures 
 and constructing optrs to refer to objects.
 
-### 7.10 Maintaining the Document
+## 7.10 Maintaining the Document
 
 We have three message handlers to maintain our data structures within the 
 document file whenever the file is saved or opened.

--- a/TechDocs/Markdown/Tutorial/Introduction.md
+++ b/TechDocs/Markdown/Tutorial/Introduction.md
@@ -1,4 +1,4 @@
-## 1 Introduction
+# 1 Introduction
 
 This book will help you set up your development 
 stations, install your development kit software, and 

--- a/TechDocs/Markdown/Tutorial/Setting_Up.md
+++ b/TechDocs/Markdown/Tutorial/Setting_Up.md
@@ -1,10 +1,10 @@
-## 2 Setting Up
+# 2 Setting Up
 
 Setting up your system involves setting up your hardware and installing 
 software on it. This chapter explains how to do both and then provides a 
 sequence of steps and troubleshooting tips to test your setup.
 
-### 2.1 What You'll Need
+## 2.1 What You'll Need
 
 This development kit includes much of the software you will need to write 
 and debug GEOS applications. It does not, however, include a C compiler or 
@@ -49,7 +49,7 @@ Gender Changers and/or Adapters for Serial Cables
 Depending on the cables and connectors you have, you may 
 need one or more serial line gender changers or other adapters.
 
-#### 2.1.2 Software You'll Need
+### 2.1.2 Software You'll Need
 
 As stated above, this kit does not provide all the software you'll need. Both 
 the host and target machines must be loaded with some version of DOS, and 
@@ -63,7 +63,7 @@ You may also want to use a task-switching environment on the host machine
 to make switching between coding, compiling, and debugging easier and 
 quicker.
 
-### 2.2 Setting Up the Hardware
+## 2.2 Setting Up the Hardware
 
 First, set up your two PCs according to their included instructions (if any). 
 Keep in mind that you will be switching frequently between the two 
@@ -82,7 +82,7 @@ in Figure 1-1.
 *__Figure 1-1__ Workstation Setup
 The test and development PCs communicate via a null modem serial connection.*
 
-#### 2.3 Installing the Software
+## 2.3 Installing the Software
 
 Once you have finished setting up your machines and have connected the 
 serial cable, you must install the GEOS development kit. Place the SDK 
@@ -127,7 +127,7 @@ does not work, check that you are using the proper hardware configurations.
 If one or both of the two GEOS directories does not exist, try reinstalling the 
 target disks.
 
-### 2.4 Testing the Configuration
+## 2.4 Testing the Configuration
 
 Once you have finished installing all the software, your system should be 
 ready for you to begin programming. To check it, however, run through the 

--- a/TechDocs/Markdown/Tutorial/The_Plan.md
+++ b/TechDocs/Markdown/Tutorial/The_Plan.md
@@ -1,10 +1,10 @@
-## 3 The Plan
+# 3 The Plan
 
 The body of our tutorial consists of the step-by-step construction of an 
 application. The first step when you set out on any software development 
 project is to plan. Thus, we will start with a simple specification.
 
-### 3.1 My Chart Application
+## 3.1 My Chart Application
 
 **Precis:** Application accepts simple data entry and creates bar charts.
 
@@ -16,7 +16,7 @@ of GEOS programming.
 
 ![](Art/tutorial-mychart_papermock.png)
 
-### 3.2 Data Entry
+## 3.2 Data Entry
 
 Data will be displayed in a scrolling list. The user can select a position in the 
 list by clicking on the list. To manipulate the piece of data at that position, 
@@ -51,7 +51,7 @@ the New or Change buttons will be a GenValueClass object.
 GenValueClass is another object class for use with the Generic UI, 
 allowing the user to enter a value.
 
-### 3.3 Data Storage
+## 3.3 Data Storage
 
 Eventually, we would like the user to be able to work with sets of data as 
 "documents," and to allow multiple documents to be open at one time. To this 
@@ -72,7 +72,7 @@ can allocate and manipulate.
 document object to store our data list along, and the same file will store 
 the object we use to display the chart.
 
-### 3.4 Chart Display
+## 3.4 Chart Display
 
 The chart will be displayed in a simple rectangular area. The body of the 
 chart will be an object in charge of drawing the axes and title(s). Each bar of 

--- a/TechDocs/Markdown/Tutorial/The_Primary_Window.md
+++ b/TechDocs/Markdown/Tutorial/The_Primary_Window.md
@@ -1,4 +1,4 @@
-## 4 The Primary Window
+# 4 The Primary Window
 
 In this chapter, we will explore our first stage in constructing a charting 
 application. This first stage consists of a primary window, which we will use 
@@ -11,7 +11,7 @@ and later explore the program itself using the Swat debugger.
 
 ![](Art/tutorial-mychart_primary_window.png)
 
-### 4.1 README
+## 4.1 README
 
 You are about to start typing in the source code of a new program. Before we 
 tell you exactly what to do, we're going to spell out some miscellaneous 
@@ -30,7 +30,7 @@ sending files between the machines using the pccom tool, you might try
 either reducing your communication speed or consulting 
 "Troubleshooting Communications," Appendix A of this book.
 
-### 4.2 Creating the Application
+## 4.2 Creating the Application
 
 We set up our files in a subdirectory of \PCGEOS\APPL (we'll use 
 \PCGEOS\APPL\MCHRT) on the host machine. The files are MCHRT.GP 
@@ -152,7 +152,7 @@ icon.
 The window pictured on the first page of this chapter should appear on your 
 screen.
 
-### 4.3 The Application So Far
+## 4.3 The Application So Far
 
 Right now, application basically consists of a Primary Window. You might 
 think that the application looks rather plain, and it does. However, note the 
@@ -178,7 +178,7 @@ was before.
 
 ![](Art/tutorial-mychart_multi_lunchable.png)
 
-### 4.4 MCHRT.GP: Geode Parameters
+## 4.4 MCHRT.GP: Geode Parameters
 
 The geode parameters file tells the Glue linker about our application's 
 general organization. You can get complete information about all of the 
@@ -298,7 +298,7 @@ user will get valuable feedback that their actions are being acknowledged,
 even if our program isn't fast enough to do all of the underlying calculations 
 quickly.
 
-### 4.5 MCHRT.GOC: Source Code
+## 4.5 MCHRT.GOC: Source Code
 
 This file contains the source code for the application. Right now, there's 
 nothing that you would recognize as procedural code. All there is to this 
@@ -469,7 +469,7 @@ will do).
 We're done putting things into the INTERFACE resource for now. In fact, we're 
 done with the program. 
 
-### 4.6 Exploring With Swat
+## 4.6 Exploring With Swat
 
 Right now, the application doesn't have any procedural code. In fact, there 
 isn't very much code to the application at all. Chances are the program has 

--- a/TechDocs/Markdown/Tutorial/Troubleshooting_Communications.md
+++ b/TechDocs/Markdown/Tutorial/Troubleshooting_Communications.md
@@ -1,4 +1,4 @@
-## Troubleshooting Communications
+# Troubleshooting Communications
 
 The SDK install scripts work well for those programmers who know which 
 COM ports and IRQ levels their machines will use when communicating. 

--- a/TechDocs/Markdown/Tutorial/Views_and_Visual_Objects.md
+++ b/TechDocs/Markdown/Tutorial/Views_and_Visual_Objects.md
@@ -1,4 +1,4 @@
-## 6 Views and Visual Objects
+# 6 Views and Visual Objects
 
 In this chapter, we'll learn about some more common program activities, such 
 as drawing shapes and working with VM files. We'll see an example of the 
@@ -7,7 +7,7 @@ can make using Swat easier by creating a SWAT.RC script file.
 
 ![](Art/tutorial-mychart_visual_objects.png)
 
-### 6.1 Making the Changes
+## 6.1 Making the Changes
 
 Make the changes to MCHRT.GOC and MCHRT.GP as indicated in Code 
 Display 4-1 and Code Display 4-2. As before, these changes are marked by 
@@ -26,7 +26,7 @@ After making the changes to the files, remake the executable with pmake.
 Send the remade geode to the target machine using pcs or the send Swat 
 command.
 
-### 6.2 The Application So Far
+## 6.2 The Application So Far
 
 The application now draws a bar chart within a view window. It saves the list 
 of data within a file, and can retain that data after closing and re-opening the 
@@ -64,7 +64,7 @@ application's ability to save data, set up a list of data, exit to DOS, and
 then restart GEOS. To learn more about working with VM files, see 
 "Virtual Memory," Chapter 18 of the Concepts book.
 
-### 6.3 MCHRT.GP
+## 6.3 MCHRT.GP
 
 We've added a few new lines to the geode parameters file to accommodate the 
 addition of the object managing the bar chart.
@@ -92,7 +92,7 @@ line for the other class we've created for the application, MCProcessClass.
 The file's "class" line automatically signals that the class named on that line 
 should be exported. All other created classes must have an "export" line.
 
-### 6.4 MCHRT.GOC: Classes & Constants
+## 6.4 MCHRT.GOC: Classes & Constants
 
 There have been several changes made to the MCHRT.GOC file. Here we'll 
 take a look at the new code and examine the changes.
@@ -168,7 +168,7 @@ DataBlockHeader         *dataBlockHeader;                       /* Header info o
 
 We set up a global variable to store a pointer to the block header. 
 
-### 6.5 MCHRT.GOC: New Objects
+## 6.5 MCHRT.GOC: New Objects
 
 ~~~
 @object GenPrimaryClass MCPrimary = {
@@ -314,7 +314,7 @@ INTERFACE resource; this is quite legal. Generally it's more readable not to
 do so, and normally we'd keep the INTERFACE resource in one place, but we'll 
 leave things organized this way just to remind you that it's legal.
 
-### 6.6 MCProcessClass Code
+## 6.6 MCProcessClass Code
 
 ~~~
 @method MCListInsertDataItem, MCProcessClass, MSG_MCP_INSERT_DATA_ITEM {
@@ -517,7 +517,7 @@ since that's the only block in the file.
 As we did in the previous version of the program, we now close the data file 
 and call the superclass. 
 
-### 6.7 Graphics and Drawing
+## 6.7 Graphics and Drawing
 
 ~~~
 @method MCChartClass, MSG_VIS_DRAW {
@@ -609,7 +609,7 @@ the GrFillRect() routine which takes a GState and four coordinates. To find
 out about other things you can draw, see "Drawing Graphics," Chapter 24 of 
 the Concepts book.
 
-### 6.8 Maintaining the Chart Data
+## 6.8 Maintaining the Chart Data
 
 ~~~
 @method MCChartClass, MSG_MCC_INSERT_BAR {
@@ -698,7 +698,7 @@ waiting for the thread to handle all the previously-arrived messages.
 These message handlers work in much the same way as that for 
 MSG_MCC_INSERT_BAR.
 
-### 6.9 SWAT.RC: Automating Swat
+## 6.9 SWAT.RC: Automating Swat
 
 This file contains some Swat commands we learned about in the last chapter.
 

--- a/TechDocs/Markdown/index.md
+++ b/TechDocs/Markdown/index.md
@@ -1,7 +1,7 @@
 ---
 nav_order: 0
 ---
-## #FreeGEOS technical documentation
+# #FreeGEOS technical documentation
 
 #FreeGEOS comes with extensive technical documentation that describes tools, programming languages and API calls from the perspective of an SDK user. This documentation can be found in the `TechDocs` folder and is available in Markdown format. It is based on the GEOS SDK 2.0, which provides good coverage of the major architectural building blocks of the system, and includes the most comprehensive technical writing. It was originally published as a multi-volume library of physical books.
 


### PR DESCRIPTION
I noticed that the Markdown files do not always start with level 1 headings for the title, so I have updated all numbered headings so that the "###" level matches the chapter nesting level.

This should make the HTML docs look and work a bit more like what is intended by the documentation style.