### PR TITLE
Fixing wrong default folder icon if the folder icon is not in the token database

### DIFF
--- a/Appl/FileMgrs2/CommonDesktop/CFolder/cfolderDisplay.asm
+++ b/Appl/FileMgrs2/CommonDesktop/CFolder/cfolderDisplay.asm
@@ -995,6 +995,13 @@ FolderGetDefaultIcon	proc	near
 	;
 	mov	si, MANUFACTURER_ID_GEOWORKS
 
+    ;
+	; assume a directory
+    ;
+	movdw	bxax, cs:[defaultGEOSFolderIconChars]
+	cmp	es:[di].FR_fileType, GFT_DIRECTORY
+	je gotChars
+
 	;
 	; assume a default DOS document
 	;
@@ -1053,6 +1060,7 @@ if 1 ;_NEWDESK
 defaultDOSDataIconChars		dword	"nDOS"
 defaultGEOSDataIconChars	dword	"nDAT"
 defaultGEOSApplIconChars	dword	"nAPP"
+defaultGEOSFolderIconChars  dword   "nFDR"
 else
 defaultDOSDataIconChars		dword	"gDOS"
 defaultGEOSDataIconChars	dword	"gDAT"


### PR DESCRIPTION
See Issue #1058 

Now "filetype" is also checked against "directory," ensuring that folders are reliably recognized and the default folder icon is displayed if the icon is not available in the TokenDB.