### PR TITLE
Browser: fix handling of UTF-8 characters after CRLF or LFCR line break

### DIFF
--- a/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
+++ b/Library/Breadbox/Html4Par/htmlpars/htmlpars.goc
@@ -1346,6 +1346,10 @@ int LOCAL HTMLgetc(void)
 {
     int c = HTMLgetcLow();
 
+    /* "CR after LF" or "LF after CF": skip over "the other one" */
+    if( (c=='\n' && lc=='\r') || (c=='\r' && lc=='\n') )
+      c = HTMLgetcLow();
+
 #ifndef DO_DBCS
     if(G_decodeUtf8) {
       if(c!=EOF && c>0x7F) {
@@ -1388,10 +1392,6 @@ int LOCAL HTMLgetc(void)
       }
     }
 #endif
-
-    /* "CR after LF" or "LF after CF": skip over "the other one" */
-    if( (c=='\n' && lc=='\r') || (c=='\r' && lc=='\n') )
-      c = HTMLgetcLow();
 
     lc = c;                             /* remember last character read */
 


### PR DESCRIPTION
see this thread: https://www.geos-infobase.de/WBB_317/forum/index.php?thread/3177-webmagick-kleines-utf-8-problem/

When skipping the second character of the line break, the following character was previously not checked for the start of a UTF-8 multi-byte sequence.