### PR TITLE
Keyboard mapping issues

### DIFF
--- a/Driver/Keyboard/Canadian/Bilingual/kmapBilingualCanadian.def
+++ b/Driver/Keyboard/Canadian/Bilingual/kmapBilingualCanadian.def
@@ -836,7 +836,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Canadian/Bilingual/kmapBilingualCanadian.def
+++ b/Driver/Keyboard/Canadian/Bilingual/kmapBilingualCanadian.def
@@ -841,7 +841,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Canadian/Bilingual/kmapBilingualCanadian.def
+++ b/Driver/Keyboard/Canadian/Bilingual/kmapBilingualCanadian.def
@@ -496,19 +496,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Canadian/CSA-z243.200-91/kmapCanCSA.def
+++ b/Driver/Keyboard/Canadian/CSA-z243.200-91/kmapCanCSA.def
@@ -843,7 +843,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Canadian/CSA-z243.200-91/kmapCanCSA.def
+++ b/Driver/Keyboard/Canadian/CSA-z243.200-91/kmapCanCSA.def
@@ -838,7 +838,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Canadian/CSA-z243.200-91/kmapCanCSA.def
+++ b/Driver/Keyboard/Canadian/CSA-z243.200-91/kmapCanCSA.def
@@ -498,19 +498,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Canadian/FrenchExtended/kmapCanadianExt.def
+++ b/Driver/Keyboard/Canadian/FrenchExtended/kmapCanadianExt.def
@@ -849,8 +849,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT or
-    mask EVB_SHIFT_CTRL_ALT,
+    0,
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Canadian/FrenchExtended/kmapCanadianExt.def
+++ b/Driver/Keyboard/Canadian/FrenchExtended/kmapCanadianExt.def
@@ -509,19 +509,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Canadian/FrenchExtended/kmapCanadianExt.def
+++ b/Driver/Keyboard/Canadian/FrenchExtended/kmapCanadianExt.def
@@ -855,7 +855,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Danish/Extended/kmapDanishExt.def
+++ b/Driver/Keyboard/Danish/Extended/kmapDanishExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Danish/Extended/kmapDanishExt.def
+++ b/Driver/Keyboard/Danish/Extended/kmapDanishExt.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Danish/Extended/kmapDanishExt.def
+++ b/Driver/Keyboard/Danish/Extended/kmapDanishExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Danish/NonExtended/kmapDanish.def
+++ b/Driver/Keyboard/Danish/NonExtended/kmapDanish.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Danish/NonExtended/kmapDanish.def
+++ b/Driver/Keyboard/Danish/NonExtended/kmapDanish.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Danish/NonExtended/kmapDanish.def
+++ b/Driver/Keyboard/Danish/NonExtended/kmapDanish.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Dutch/Extended/kmapBelgianExt.def
+++ b/Driver/Keyboard/Dutch/Extended/kmapBelgianExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_L_AE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Dutch/Extended/kmapBelgianExt.def
+++ b/Driver/Keyboard/Dutch/Extended/kmapBelgianExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Dvorak/kmapDvorak.def
+++ b/Driver/Keyboard/Dvorak/kmapDvorak.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/French/Extended/kmapFrenchExt.def
+++ b/Driver/Keyboard/French/Extended/kmapFrenchExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/French/Extended/kmapFrenchExt.def
+++ b/Driver/Keyboard/French/Extended/kmapFrenchExt.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_BREVE> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/French/Extended/kmapFrenchExt.def
+++ b/Driver/Keyboard/French/Extended/kmapFrenchExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/French/NonExtended/kmapFrench.def
+++ b/Driver/Keyboard/French/NonExtended/kmapFrench.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_L_AE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/French/NonExtended/kmapFrench.def
+++ b/Driver/Keyboard/French/NonExtended/kmapFrench.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/French/SwissExtended/kmapSwissFrenchExt.def
+++ b/Driver/Keyboard/French/SwissExtended/kmapSwissFrenchExt.def
@@ -843,7 +843,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/French/SwissExtended/kmapSwissFrenchExt.def
+++ b/Driver/Keyboard/French/SwissExtended/kmapSwissFrenchExt.def
@@ -838,7 +838,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/French/SwissExtended/kmapSwissFrenchExt.def
+++ b/Driver/Keyboard/French/SwissExtended/kmapSwissFrenchExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/German/Extended/kmapGermanExt.def
+++ b/Driver/Keyboard/German/Extended/kmapGermanExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/German/Extended/kmapGermanExt.def
+++ b/Driver/Keyboard/German/Extended/kmapGermanExt.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/German/Extended/kmapGermanExt.def
+++ b/Driver/Keyboard/German/Extended/kmapGermanExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/German/NonExtended/kmapGerman.def
+++ b/Driver/Keyboard/German/NonExtended/kmapGerman.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_VERTICAL_BAR>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/German/NonExtended/kmapGerman.def
+++ b/Driver/Keyboard/German/NonExtended/kmapGerman.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/German/SwissExtended/kmapSwissGermanExt.def
+++ b/Driver/Keyboard/German/SwissExtended/kmapSwissGermanExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/German/SwissExtended/kmapSwissGermanExt.def
+++ b/Driver/Keyboard/German/SwissExtended/kmapSwissGermanExt.def
@@ -843,7 +843,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_PARAGRAPH>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/German/SwissNonExtended/kmapSwissGerman.def
+++ b/Driver/Keyboard/German/SwissNonExtended/kmapSwissGerman.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/German/SwissNonExtended/kmapSwissGerman.def
+++ b/Driver/Keyboard/German/SwissNonExtended/kmapSwissGerman.def
@@ -843,7 +843,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_PARAGRAPH>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Italian/Extended/kmapItalianExt.def
+++ b/Driver/Keyboard/Italian/Extended/kmapItalianExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_QUOTEDBLRIGHT>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Italian/Extended/kmapItalianExt.def
+++ b/Driver/Keyboard/Italian/Extended/kmapItalianExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Italian/NonExtended/kmapItalian.def
+++ b/Driver/Keyboard/Italian/NonExtended/kmapItalian.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_QUOTEDBLRIGHT>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Italian/NonExtended/kmapItalian.def
+++ b/Driver/Keyboard/Italian/NonExtended/kmapItalian.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Norwegian/Extended/kmapNorwegianExt.def
+++ b/Driver/Keyboard/Norwegian/Extended/kmapNorwegianExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Norwegian/Extended/kmapNorwegianExt.def
+++ b/Driver/Keyboard/Norwegian/Extended/kmapNorwegianExt.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Norwegian/Extended/kmapNorwegianExt.def
+++ b/Driver/Keyboard/Norwegian/Extended/kmapNorwegianExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Norwegian/NonExtended/kmapNorwegian.def
+++ b/Driver/Keyboard/Norwegian/NonExtended/kmapNorwegian.def
@@ -843,7 +843,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Norwegian/NonExtended/kmapNorwegian.def
+++ b/Driver/Keyboard/Norwegian/NonExtended/kmapNorwegian.def
@@ -838,7 +838,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Norwegian/NonExtended/kmapNorwegian.def
+++ b/Driver/Keyboard/Norwegian/NonExtended/kmapNorwegian.def
@@ -498,19 +498,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Portuguese/Extended/kmapPortugueseExt.def
+++ b/Driver/Keyboard/Portuguese/Extended/kmapPortugueseExt.def
@@ -843,7 +843,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Portuguese/Extended/kmapPortugueseExt.def
+++ b/Driver/Keyboard/Portuguese/Extended/kmapPortugueseExt.def
@@ -838,7 +838,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Portuguese/Extended/kmapPortugueseExt.def
+++ b/Driver/Keyboard/Portuguese/Extended/kmapPortugueseExt.def
@@ -498,19 +498,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Spanish/Extended/kmapSpanishExt.def
+++ b/Driver/Keyboard/Spanish/Extended/kmapSpanishExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Spanish/Extended/kmapSpanishExt.def
+++ b/Driver/Keyboard/Spanish/Extended/kmapSpanishExt.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Spanish/Extended/kmapSpanishExt.def
+++ b/Driver/Keyboard/Spanish/Extended/kmapSpanishExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Spanish/NonExtended/kmapSpanish.def
+++ b/Driver/Keyboard/Spanish/NonExtended/kmapSpanish.def
@@ -836,7 +836,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Spanish/NonExtended/kmapSpanish.def
+++ b/Driver/Keyboard/Spanish/NonExtended/kmapSpanish.def
@@ -841,7 +841,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Spanish/NonExtended/kmapSpanish.def
+++ b/Driver/Keyboard/Spanish/NonExtended/kmapSpanish.def
@@ -496,19 +496,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Swedish/Extended/kmapSwedishExt.def
+++ b/Driver/Keyboard/Swedish/Extended/kmapSwedishExt.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Swedish/Extended/kmapSwedishExt.def
+++ b/Driver/Keyboard/Swedish/Extended/kmapSwedishExt.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Swedish/Extended/kmapSwedishExt.def
+++ b/Driver/Keyboard/Swedish/Extended/kmapSwedishExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Swedish/NonExtended/kmapSwedish.def
+++ b/Driver/Keyboard/Swedish/NonExtended/kmapSwedish.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Swedish/NonExtended/kmapSwedish.def
+++ b/Driver/Keyboard/Swedish/NonExtended/kmapSwedish.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Swedish/NonExtended/kmapSwedish.def
+++ b/Driver/Keyboard/Swedish/NonExtended/kmapSwedish.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/Swedish/Typewriter/kmapSwedishTypewriter.def
+++ b/Driver/Keyboard/Swedish/Typewriter/kmapSwedishTypewriter.def
@@ -842,7 +842,7 @@ KbdExtendedDefTable	ExtendedDef <
     <>,
     <>,
     <>,
-    <C_BSW C_ACUTE>,
+    <C_BSW C_EURO_CHAR>,
     <C_BSW C_CEDILLA> 
 >,<				;EXT 0x14
     0,

--- a/Driver/Keyboard/Swedish/Typewriter/kmapSwedishTypewriter.def
+++ b/Driver/Keyboard/Swedish/Typewriter/kmapSwedishTypewriter.def
@@ -837,7 +837,7 @@ KbdExtendedDefTable	ExtendedDef <
     <C_BSW C_MACRON> 
 >,<				;EXT 0x13
     0,
-    mask EVB_CTRL_ALT, 
+    0, 
     <>,
     <>,
     <>,

--- a/Driver/Keyboard/Swedish/Typewriter/kmapSwedishTypewriter.def
+++ b/Driver/Keyboard/Swedish/Typewriter/kmapSwedishTypewriter.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/UK/Extended/kmapUKExt.def
+++ b/Driver/Keyboard/UK/Extended/kmapUKExt.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Driver/Keyboard/UK/NonExtended/kmapUK.def
+++ b/Driver/Keyboard/UK/NonExtended/kmapUK.def
@@ -497,19 +497,19 @@ KbdKeyDefTable	KeyDef	<
     <C_CTRL 0x0>,
     0x0 
 >,<				;SCAN CODE 0x5b
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_LWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
->,<				;SCAN CODE 0x5c
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+>,<				;SCAN CODE 0x5c 
+    KEY_SOLO,
+    <C_CTRL VC_RWIN>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5d
-    KEY_INVALID,
-    <C_CTRL VC_NULL>,
-    <C_CTRL 0x0>,
+    KEY_SOLO,
+    <C_CTRL VC_MENU>,
+    <C_CTRL CS_CONTROL>,
     0x0 
 >,<				;SCAN CODE 0x5e
     KEY_INVALID,

--- a/Include/char.def
+++ b/Include/char.def
@@ -351,6 +351,7 @@ C_SUM		= C_U_SIGMA
 C_PRODUCT	= C_U_PI
 C_RADICAL	= C_ROOT
 C_LOZENGE	= C_DIAMONDBULLET
+C_EURO_CHAR = C_CURRENCY       ;Note: "C_EURO_SIGN" is already used
 
 ;
 ; some former spelling errors:


### PR DESCRIPTION
This PR introduces a number of changes to the keyboard mappings:

- Adds the functionality to output the euro symbol when the AltGr + E (or Ctrl + Alt + E) key combination is pressed. This only applies to keyboards that have these key labels (see https://kbdlayout.info). See also Issue #1092

- Extending the functionality so that the Windows keys on the keyboard can be used in FreeGEOS. Until now, this was only integrated with the US keyboard driver. See Issue #1105

What I've touched:

|	Driver	|	Euro-Key	|	Win-Keys
|	-------------------	|	-------------------	|	-------------------
|	Belgian Ext	|	y	|	y
|	Bilingual Canadian	|	y	|	y
|	CAN/CSA/-Z243.200-91	|	y	|	y
|	Danish Ext	|	y	|	y
|	Danish	|	y	|	y
|	Dvorak	|	n	|	y
|	French Canadian	|	y	|	y
|	French Ext	|	y	|	y
|	French	|	y	|	y
|	French PS/1	|	n	|	y
|	German Ext	|	y	|	y
|	German	|	y	|	y
|	Italian Ext	|	y	|	y
|	Italian	|	y	|	y
|	Norwegian Ext	|	y	|	y
|	Norwegian	|	y	|	y
|	Portugese Ext	|	y	|	y
|	Spanish Ext	|	y	|	y
|	Spanish	|	y	|	y
|	Swedish Ext	|	y	|	y
|	Swedish	|	y	|	y
|	Swedish Typewriter	|	y	|	y
|	Swiss-French Ext	|	y	|	y
|	Swiss-German Ext	|	y	|	y
|	Swiss-German	|	y	|	y
|	Tandy 1000	|	n	|	n
|	Toshiba	|	n	|	n
|	U.S.	|	n	|	already avail.
|	UK Ext	|	n	|	y
|UK	|	n	|	y


