### PR TITLE
Hidden title bar in File FInder and removed Breadbox copyright text

### DIFF
--- a/Appl/Breadbox/FFind/ffind.goc
+++ b/Appl/Breadbox/FFind/ffind.goc
@@ -170,8 +170,8 @@ Boolean Search(word level);
                   @FileFindStatus ;
 /* center everything */
         HINT_CENTER_CHILDREN_HORIZONTALLY;
-        HINT_SIZE_WINDOW_AS_DESIRED ;
-  //      HINT_PRIMARY_NO_FILE_MENU ;
+        HINT_SIZE_WINDOW_AS_DESIRED;
+        HINT_PRIMARY_NO_FILE_MENU; //hide the title bar, as it currently only has File -> Exit
         ATTR_GEN_HELP_CONTEXT = "TOC";
     }
 
@@ -497,13 +497,13 @@ Boolean Search(word level);
         GI_visMoniker = "Ready to search." ;
     }
     /*---------------------------------------------------------------------*/
-@ifdef BREADBOX_VERSION
+/*@ifdef BREADBOX_VERSION
     @object GenGlyphClass BreadboxLogo = {
         GI_visMoniker = @list { @BlueBreadbox, @BlackBreadbox } ;
     }
 @include "blackbb.goh"
 @include "bluebb.goh"
-@endif
+@endif*/
     /*---------------------------------------------------------------------*/
 @end Interface
 

--- a/Appl/Breadbox/FFind/ffind.gp
+++ b/Appl/Breadbox/FFind/ffind.gp
@@ -31,8 +31,6 @@ export FileFindVLTextClass
 
 platform geos201
 
-usernotes "Copyright 1994-2002  Breadbox Computer Company LLC  All Rights Reserved"
-
 #
 # END OF FILE:  FFIND.GP
 #


### PR DESCRIPTION
Also commented out ifdef macro for Breadbox branding.

Currently the menu bar in File Finder only has File -> Exit. It was hidden in NDO.