### PR TITLE
New clipboard transfer format for updated icon editor

### DIFF
--- a/CInclude/geoworks.h
+++ b/CInclude/geoworks.h
@@ -503,8 +503,9 @@ typedef enum /* word */ {
     CIF_BITMAP,
     CIF_SOUND_SYNTH,
     CIF_SOUND_SAMPLE,
-    CIF_ICON_LIST,
-    CIF_FAX_FILE_PAGE_WITH_INK
+    CIF_ICON_LIST,			/* list of icons, original icon editor */
+    CIF_FAX_FILE_PAGE_WITH_INK,
+    CIF_EXT_ICON_LIST			/* list of icons, updated icon editor */
 } ClipboardItemFormat;
 
 /*

--- a/Include/geoworks.def
+++ b/Include/geoworks.def
@@ -1892,13 +1892,17 @@ CIF_SOUND_SAMPLE	enum	ClipboardItemFormat
 	; Sampled sound description.
 
 CIF_ICON_LIST		enum	ClipboardItemFormat
-	; Internal icon editor format for transferring groups
+	; Internal original icon editor format for transferring groups
 	; of icons between icon files.
 
 CIF_FAX_FILE_PAGE_WITH_INK	enum	ClipboardItemFormat
 	; Internal faxview format.  It is a tree that points to a huge array
 	; containing a compressed fax page, and a db item holding the
 	; pages ink.
+
+CIF_EXT_ICON_LIST		enum	ClipboardItemFormat
+	; Internal updated icon editor format for transferring groups
+	; of icons between icon files.
 
 COMMENT @----------------------------------------------------------------------
 


### PR DESCRIPTION
This is necessary because the icons in the new icon editor contain significantly more information than those in the old icon editor.